### PR TITLE
Fix crash when executing empty command

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -972,7 +972,7 @@ func runproc(win *Window, s string, rdir string, newns bool, argaddr string, arg
 	c.name = name
 	// t is the full path, trimmed of left whitespace.
 	pipechar = 0
-	if t[0] == '<' || t[0] == '|' || t[0] == '>' {
+	if len(t) > 0 && (t[0] == '<' || t[0] == '|' || t[0] == '>') {
 		pipechar = int(t[0])
 		t = t[1:]
 	}


### PR DESCRIPTION
To reproduce, select spaces and middle click on it.

```
$ edwood
Untested: main.run(0x0, 0xc42026af34, 0x3, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, ...): .../exec.go:674 +0x34
panic: runtime error: index out of range

goroutine 50 [running]:
main.runproc(0x0, 0xc42026af34, 0x3, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, ...)
	.../exec.go:975 +0x11f2
created by main.run
	.../exec.go:686 +0x148
```