### PR TITLE
Make fsys log test more lenient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ _testmain.go
 *.exe
 *.test
 *.prof
+edwood

--- a/acme.go
+++ b/acme.go
@@ -92,7 +92,7 @@ func main() {
 	var display *draw.Display
 	display, err = draw.Init(nil, *varfontflag, "edwood", *winsize)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("can't open display: %v\n", err)
 	}
 	if err := display.Attach(draw.Refnone); err != nil {
 		panic("failed to attach to window")

--- a/fsys_test.go
+++ b/fsys_test.go
@@ -21,7 +21,9 @@ func startAcme(t *testing.T) (*exec.Cmd, *client.Fsys) {
 
 	acmd := exec.Command("./edwood")
 	acmd.Stdout = os.Stdout
-	acmd.Start()
+	if err := acmd.Start(); err != nil {
+		t.Fatalf("failed to execute ./edwood: %v", err)
+	}
 
 	var fsys *client.Fsys
 	var err error
@@ -176,6 +178,9 @@ Occasion
 	tfs.Write("/new/body", text)
 
 	op := <-reportchan
+	for strings.Index(op, "focus") != -1 {
+		op = <-reportchan
+	}
 	if strings.Index(op, "new") == -1 {
 		t.Fatalf("Didn't get report of window creation.")
 	}


### PR DESCRIPTION
"focus" can show up before "new" in the log,
for the same window id
