### PR TITLE
Handle unicode correctly on writes to cons

### DIFF
--- a/util.go
+++ b/util.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"image"
 	"os"
+	"unicode/utf8"
 )
 
 func min(a, b int) int {
@@ -106,6 +107,31 @@ func utfrune(s []rune, r rune) int {
 		}
 	}
 	return -1
+}
+
+func cvttorunes(p []byte, n int) (r []rune, nb int, nulls bool) {
+	// Always guaranteed that n bytes may be interpreted
+	// without worrying about partial runes.  This may mean
+	// reading up to UTFmax-1 more bytes than n; the caller
+	// knows this.  If n is a firm limit, the caller should
+	// set p[n] = 0.
+	for nb < n {
+		var w int
+		var ru rune
+		if p[nb] < utf8.RuneSelf {
+			w = 1
+			ru = rune(p[nb])
+		} else {
+			ru, w = utf8.DecodeRune(p[nb:])
+		}
+		if ru != 0 {
+			r = append(r, ru)
+		} else {
+			nulls = true
+		}
+		nb += w
+	}
+	return
 }
 
 func errorwin1(dir string, incl []string) *Window {

--- a/xfid_test.go
+++ b/xfid_test.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"bytes"
+	"fmt"
+	"reflect"
 	"testing"
 
 	"9fans.net/go/draw"
+	"9fans.net/go/plan9"
 )
 
 func TestXfidAlloc(t *testing.T) {
@@ -20,4 +24,42 @@ func TestXfidAlloc(t *testing.T) {
 		t.Errorf("Failed to get an Xfid")
 	}
 	cxfidfree <- x
+}
+
+func TestFullrunewrite(t *testing.T) {
+	testCases := []struct {
+		in        []byte
+		out       []rune
+		pin, pout []byte
+	}{
+		{[]byte("hello world"), []rune("hello world"), nil, nil},
+		{[]byte("Hello, 世界"), []rune("Hello, 世界"), nil, nil},
+		{[]byte("hello \x00\x00world"), []rune("hello world"), nil, nil},
+		{[]byte("abc\xe4\xb8xyz"), []rune("abc\uFFFD\uFFFDxyz"), nil, nil},        // invalid rune
+		{[]byte("abcxyz\xe4\xb8"), []rune("abcxyz"), nil, []byte{'\xe4', '\xb8'}}, // ends with partial rune
+		{[]byte("\x96hello"), []rune("世hello"), []byte{'\xe4', '\xb8'}, nil},      // begins with partial rune
+	}
+	for _, tc := range testCases {
+		x := Xfid{
+			f: &Fid{
+				nrpart: len(tc.pin),
+			},
+			fcall: plan9.Fcall{
+				Data:  tc.in,
+				Count: uint32(len(tc.in)),
+			},
+		}
+		copy(x.f.rpart[:], tc.pin)
+
+		r := fullrunewrite(&x)
+		if !reflect.DeepEqual(r, tc.out) {
+			for i, b := range tc.in {
+				fmt.Printf("%v %x %d\n", i, b, b)
+			}
+			t.Errorf("Fullrunewrite(%q, %q) full runes are %q; expected %q\n", tc.pin, tc.in, r, tc.out)
+		}
+		if x.f.nrpart != len(tc.pout) || !bytes.Equal(x.f.rpart[:x.f.nrpart], tc.pout[:]) {
+			t.Errorf("Fullrunewrite(%q, %q) partial runes are %q; expected %q\n", tc.pin, tc.in, x.f.rpart[:x.f.nrpart], tc.pout)
+		}
+	}
 }


### PR DESCRIPTION
Edwood was putting null characters in the window when writing non-ascii
characters to cons file.

The code is now aligned with plan9port acme.