### PR TITLE
Add Go module support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/rjkroege/edwood
+
+require 9fans.net/go v0.0.0-20180626134441-6000580a6378

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+9fans.net/go v0.0.0-20180626134441-6000580a6378 h1:8jIVxy2RXNT+qswzqmriGYc/lRQsuhpGMkc2LiCLwLo=
+9fans.net/go v0.0.0-20180626134441-6000580a6378/go.mod h1:diCsxrliIURU9xsYtjCp5AbpQKqdhKmf0ujWDUSkfoY=


### PR DESCRIPTION
The next Go release (go1.11) will have experimental support for modules.

Update #35