### PR TITLE
Eliminate more null characters

### DIFF
--- a/acme.go
+++ b/acme.go
@@ -731,8 +731,9 @@ func acmeputsnarf() {
 }
 
 func acmegetsnarf() {
-	r := make([]byte, MAXSNARF)
-	n, _, _ := row.display.ReadSnarf(r)
+	b := make([]byte, MAXSNARF)
+	n, _, _ := row.display.ReadSnarf(b)
+	r, _, _ := cvttorunes(b, n)
 	snarfbuf.Reset()
-	snarfbuf.Insert(0, []rune(string(r[:n])))
+	snarfbuf.Insert(0, r)
 }

--- a/buf.go
+++ b/buf.go
@@ -3,7 +3,6 @@ package main
 import (
 	"io/ioutil"
 	"os"
-	"strings"
 	"unicode/utf8"
 )
 
@@ -35,12 +34,9 @@ func (b *Buffer) Load(q0 int, fd *os.File) (n int, h FileHash, hasNulls bool, er
 	if err != nil {
 		warning(nil, "read error in Buffer.Load")
 	}
-	s := string(d)
-	s = strings.Replace(s, "\000", "", -1)
-	hasNulls = len(s) != len(d)
-	runes := []rune(s)
+	runes, _, hasNulls := cvttorunes(d, len(d))
 	(*b).Insert(q0, runes)
-	return (len(runes)), calcFileHash(d), hasNulls, err
+	return len(runes), calcFileHash(d), hasNulls, err
 }
 
 func (b *Buffer) Read(q0 int, r []rune) (int, error) {

--- a/look.go
+++ b/look.go
@@ -250,8 +250,11 @@ func plumbshow(m *plumb.Message) {
 		name = fmt.Sprintf("%s/%s", m.Dir, name)
 	}
 	name = filepath.Clean(name)
+	r, _, _ := cvttorunes([]byte(name), len(name)) // remove nulls
+	name = string(r)
 	w.SetName(name)
-	w.body.Insert(0, []rune(string(m.Data)), true)
+	r, _, _ = cvttorunes(m.Data, len(m.Data))
+	w.body.Insert(0, r, true)
 	w.body.file.mod = false
 	w.dirty = false
 	w.SetTag()
@@ -347,7 +350,9 @@ func isfilec(r rune) bool {
 
 // Runestr wrapper for cleanname
 func cleanrname(rs []rune) []rune {
-	return []rune(filepath.Clean(string(rs)))
+	s := filepath.Clean(string(rs))
+	r, _, _ := cvttorunes([]byte(s), len(s))
+	return r
 }
 
 /*


### PR DESCRIPTION
These are all the calls to cvttorunes in acme that are relevant in
edwood. It doesn't include indirect calls from helper function
bytetorune, which doesn't exist in Edwood.

Fixes #54 and similar issues.