### PR TITLE
Simplify Text cache

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -616,7 +616,7 @@ func putall(et, _, _ *Text, _, _ bool, arg string) {
 				continue
 			}
 			a := string(w.body.file.name)
-			if w.body.file.mod || w.body.ncache > 0 {
+			if w.body.file.mod || len(w.body.cache) > 0 {
 				if _, err := os.Stat(a); err != nil {
 					warning(nil, "no auto-Put of %s: %v\n", a, err)
 				} else {

--- a/wind.go
+++ b/wind.go
@@ -169,7 +169,7 @@ func (w *Window) Init(clone *Window, r image.Rectangle, dis *draw.Display) {
 
 func (w *Window) DrawButton() {
 	b := button
-	if !w.isdir && !w.isscratch && (w.body.file.mod || w.body.ncache > 0) {
+	if !w.isdir && !w.isscratch && (w.body.file.mod || len(w.body.cache) > 0) {
 		b = modbutton
 	}
 	var br image.Rectangle
@@ -478,7 +478,7 @@ func (w *Window) SetTag1() {
 	//	Lpipe := (" |")
 
 	/* there are races that get us here with stuff in the tag cache, so we take extra care to sync it */
-	if w.tag.ncache != 0 || w.tag.file.mod {
+	if len(w.tag.cache) != 0 || w.tag.file.mod {
 		w.Commit(&w.tag) /* check file name; also guarantees we can modify tag contents */
 	}
 
@@ -491,13 +491,13 @@ func (w *Window) SetTag1() {
 	sb.WriteString(w.body.file.name)
 	sb.WriteString(Ldelsnarf)
 	if w.filemenu {
-		if w.body.needundo || len(w.body.file.delta) > 0 || w.body.ncache != 0 {
+		if w.body.needundo || len(w.body.file.delta) > 0 || len(w.body.cache) != 0 {
 			sb.WriteString(Lundo)
 		}
 		if len(w.body.file.epsilon) > 0 {
 			sb.WriteString(Lredo)
 		}
-		dirty := w.body.file.name != "" && (w.body.ncache != 0 || w.body.file.seq != w.putseq)
+		dirty := w.body.file.name != "" && (len(w.body.cache) != 0 || w.body.file.seq != w.putseq)
 		if !w.isdir && dirty {
 			sb.WriteString(Lput)
 		}
@@ -538,7 +538,7 @@ func (w *Window) SetTag1() {
 		}
 	}
 	w.tag.file.mod = false
-	n := w.tag.Nc() + (w.tag.ncache)
+	n := w.tag.Nc() + len(w.tag.cache)
 	if w.tag.q0 > n {
 		w.tag.q0 = n
 	}


### PR DESCRIPTION
Remove redundant fields ncache and ncachealloc since they are just len
and cap of the slice.