### PR TITLE
run rsc.io/grind on edwood

### DIFF
--- a/addr.go
+++ b/addr.go
@@ -26,7 +26,7 @@ func isregexc(r rune) bool {
 	if r == 0 {
 		return false
 	}
-	if isalnum(rune(r)) {
+	if isalnum(r) {
 		return true
 	}
 	if utfrune([]rune("^+-.*?#,;[]()$"), r) != -1 {

--- a/col.go
+++ b/col.go
@@ -71,7 +71,6 @@ func (c *Column) AddFile(f *File) *Window {
 func (c *Column) Add(w, clone *Window, y int) *Window {
 	// Figure out new window placement
 	var v *Window
-	var ymax int
 
 	r := c.r
 	r.Min.Y = c.tag.fr.Rect().Max.Y + c.display.ScaleSize(Border)
@@ -112,6 +111,7 @@ func (c *Column) Add(w, clone *Window, y int) *Window {
 		 */
 
 		// new window stops where next window begins
+		var ymax int
 		if windex < c.nw() {
 			ymax = c.w[windex].r.Min.Y - c.display.ScaleSize(Border)
 		} else {
@@ -311,7 +311,6 @@ func (c *Column) Sort() {
 
 func (c *Column) Grow(w *Window, but int) {
 	//var nl, ny *int
-	var v *Window
 
 	var windex int
 
@@ -339,7 +338,7 @@ func (c *Column) Grow(w *Window, but int) {
 	cr.Min.Y = c.w[0].r.Min.Y
 	if but == 3 { // Switch to full size window
 		if windex != 0 {
-			v = c.w[0]
+			v := (*Window)(c.w[0])
 			c.w[0] = w
 			c.w[windex] = v
 		}
@@ -401,6 +400,7 @@ func (c *Column) Grow(w *Window, but int) {
 Pack:
 	// pack everyone above
 	y1 := cr.Min.Y
+	var v *Window
 	for j := 0; j < windex; j++ {
 		v = c.w[j]
 		r := v.r
@@ -468,7 +468,6 @@ Pack:
 }
 
 func (c *Column) DragWin(w *Window, but int) {
-
 	var (
 		r      image.Rectangle
 		i, b   int

--- a/col.go
+++ b/col.go
@@ -338,7 +338,7 @@ func (c *Column) Grow(w *Window, but int) {
 	cr.Min.Y = c.w[0].r.Min.Y
 	if but == 3 { // Switch to full size window
 		if windex != 0 {
-			v := (*Window)(c.w[0])
+			v := c.w[0]
 			c.w[0] = w
 			c.w[windex] = v
 		}

--- a/dat.go
+++ b/dat.go
@@ -257,7 +257,7 @@ func WIN(q plan9.Qid) int {
 }
 
 func FILE(q plan9.Qid) uint64 {
-	return uint64(q.Path & 0xff)
+	return q.Path & 0xff
 }
 
 func QID(id int, q uint64) uint64 {

--- a/ecmd.go
+++ b/ecmd.go
@@ -111,9 +111,7 @@ func cmdexec(t *Text, cp *Cmd) bool {
 }
 
 func edittext(w *Window, q int, r []rune) error {
-	var f *File
-
-	f = w.body.file
+	f := (*File)(w.body.file)
 	switch editing {
 	case Inactive:
 		return fmt.Errorf("permission denied")
@@ -507,7 +505,6 @@ func w_cmd(t *Text, cp *Cmd) bool {
 }
 
 func x_cmd(t *Text, cp *Cmd) bool {
-
 	if cp.re != "" {
 		looper(t.file, cp, cp.cmdc == 'x')
 	} else {
@@ -592,7 +589,6 @@ func pipe_cmd(t *Text, cp *Cmd) bool {
 }
 
 func nlcount(t *Text, q0, q1 int) (nl, pnr int) {
-
 	buf := make([]rune, RBUFSIZE)
 	i := 0
 	nl = 0
@@ -709,15 +705,14 @@ func eq_cmd(t *Text, cp *Cmd) bool {
 
 func nl_cmd(t *Text, cp *Cmd) bool {
 	f := t.file
-	var a Address
 	if cp.addr == nil {
 		// First put it on newline boundaries
-		a = mkaddr(f)
+		a := Address(mkaddr(f))
 		addr = lineaddr(0, a, -1)
 		a = lineaddr(0, a, 1)
 		addr.r.q1 = a.r.q1
 		if addr.r.q0 == t.q0 && addr.r.q1 == t.q1 {
-			a = mkaddr(f)
+			a := Address(mkaddr(f))
 			addr = lineaddr(1, a, 1)
 		}
 	}

--- a/ecmd.go
+++ b/ecmd.go
@@ -33,8 +33,8 @@ func resetxec() {
 }
 
 func mkaddr(f *File) (a Address) {
-	a.r.q0 = int(f.curtext.q0)
-	a.r.q1 = int(f.curtext.q1)
+	a.r.q0 = f.curtext.q0
+	a.r.q1 = f.curtext.q1
 	a.f = f
 	return a
 }
@@ -48,7 +48,7 @@ func cmdexec(t *Text, cp *Cmd) bool {
 	}
 
 	if w == nil && (cp.addr == nil || cp.addr.typ != '"' &&
-		Buffer([]rune("bBnqUXY!")).Index([]rune{rune(cp.cmdc)}) == -1 && // Commands that don't need a window
+		Buffer([]rune("bBnqUXY!")).Index([]rune{cp.cmdc}) == -1 && // Commands that don't need a window
 		!(cp.cmdc == 'D' && len(cp.text) > 0)) {
 		editerror("no current window")
 	}
@@ -93,7 +93,7 @@ func cmdexec(t *Text, cp *Cmd) bool {
 			dot = cmdaddress(cp.addr, dot, 0)
 		}
 		for cp = cp.cmd; cp != nil; cp = cp.next {
-			if dot.r.q1 > int(t.file.b.Nc()) {
+			if dot.r.q1 > t.file.b.Nc() {
 				editerror("dot extends past end of buffer during { command")
 			}
 			t.q0 = dot.r.q0
@@ -111,7 +111,7 @@ func cmdexec(t *Text, cp *Cmd) bool {
 }
 
 func edittext(w *Window, q int, r []rune) error {
-	f := (*File)(w.body.file)
+	f := w.body.file
 	switch editing {
 	case Inactive:
 		return fmt.Errorf("permission denied")
@@ -539,7 +539,7 @@ func runpipe(t *Text, cmd rune, cr []rune, state int) {
 			t.file.elog.Delete(t.q0, t.q1)
 		}
 	}
-	s = append([]rune{rune(cmd)}, r...)
+	s = append([]rune{cmd}, r...)
 
 	dir = ""
 	if t != nil {
@@ -707,12 +707,12 @@ func nl_cmd(t *Text, cp *Cmd) bool {
 	f := t.file
 	if cp.addr == nil {
 		// First put it on newline boundaries
-		a := Address(mkaddr(f))
+		a := mkaddr(f)
 		addr = lineaddr(0, a, -1)
 		a = lineaddr(0, a, 1)
 		addr.r.q1 = a.r.q1
 		if addr.r.q0 == t.q0 && addr.r.q1 == t.q1 {
-			a := Address(mkaddr(f))
+			a := mkaddr(f)
 			addr = lineaddr(1, a, 1)
 		}
 	}

--- a/edit.go
+++ b/edit.go
@@ -220,7 +220,7 @@ func editcmd(ct *Text, r []rune) {
 		lastpat = ""
 	}
 	go editthread()
-	err := error(<-editerrc)
+	err := <-editerrc
 	editing = Inactive
 	if err != nil {
 		warning(nil, "Edit: %s\n", err)
@@ -259,7 +259,7 @@ func getnum(signok int) int {
 		sign = -1
 		getch()
 	}
-	c := rune(nextc())
+	c := nextc()
 	if c < '0' || '9' < c { /* no number defaults to 1 */
 		return sign
 	}
@@ -306,7 +306,7 @@ func okdelim(c rune) {
 
 func atnl() {
 	cmdskipbl()
-	c := rune(getch())
+	c := getch()
 	if c != '\n' {
 		debug.PrintStack()
 		editerror("newline expected (saw %c)", c)
@@ -428,7 +428,7 @@ func parsecmd(nest int) *Cmd {
 	if cmdskipbl() == -1 {
 		return nil
 	}
-	c := rune(getch())
+	c := getch()
 	if c == -1 {
 		return nil
 	}
@@ -437,25 +437,25 @@ func parsecmd(nest int) *Cmd {
 		getch() /* the 'd' */
 		cmd.cmdc = 'c' | 0x100
 	}
-	i := int(cmdlookup(cmd.cmdc))
+	i := cmdlookup(cmd.cmdc)
 	if i >= 0 {
 		if cmd.cmdc == '\n' {
 			goto Return /* let nl_cmd work it all out */
 		}
-		ct := (*Cmdtab)(&cmdtab[i])
+		ct := &cmdtab[i]
 		if ct.defaddr == aNo && cmd.addr != nil {
 			editerror("command takes no address")
 		}
 		if ct.count != 0 {
-			cmd.num = int(getnum(ct.count))
+			cmd.num = getnum(ct.count)
 		}
 		if ct.regexp != 0 {
 			/* x without pattern . .*\n, indicated by cmd.re==0 */
 			/* X without pattern is all files */
-			c := rune(nextc())
+			c := nextc()
 			if ct.cmdc != 'x' && ct.cmdc != 'X' || (c != ' ' && c != '\t' && c != '\n') {
 				cmdskipbl()
-				c := rune(getch())
+				c := getch()
 				if c == '\n' || c < 0 {
 					editerror("no address")
 				}
@@ -605,7 +605,7 @@ func simpleaddr() *Addr {
 		fallthrough
 	case '"':
 		addr.typ = getch()
-		addr.re = getregexp(rune(addr.typ))
+		addr.re = getregexp(addr.typ)
 	case '.':
 		fallthrough
 	case '$':
@@ -671,7 +671,7 @@ func compoundaddr() *Addr {
 	}
 	getch()
 	addr.next = compoundaddr()
-	next := (*Addr)(addr.next)
+	next := addr.next
 	if next != nil && (next.typ == ',' || next.typ == ';') && next.left == nil {
 		editerror("bad address syntax")
 	}

--- a/edit.go
+++ b/edit.go
@@ -193,8 +193,6 @@ func editerror(format string, args ...interface{}) {
 }
 
 func editcmd(ct *Text, r []rune) {
-	var err error
-
 	if len(r) == 0 {
 		return
 	}
@@ -222,7 +220,7 @@ func editcmd(ct *Text, r []rune) {
 		lastpat = ""
 	}
 	go editthread()
-	err = <-editerrc
+	err := error(<-editerrc)
 	editing = Inactive
 	if err != nil {
 		warning(nil, "Edit: %s\n", err)
@@ -255,17 +253,13 @@ func ungetch() {
 }
 
 func getnum(signok int) int {
-	var n int
-	var sign int
-	var c rune
-
-	n = 0
-	sign = 1
+	n := int(0)
+	sign := int(1)
 	if signok > 1 && nextc() == '-' {
 		sign = -1
 		getch()
 	}
-	c = nextc()
+	c := rune(nextc())
 	if c < '0' || '9' < c { /* no number defaults to 1 */
 		return sign
 	}
@@ -311,9 +305,8 @@ func okdelim(c rune) {
 }
 
 func atnl() {
-	var c rune
 	cmdskipbl()
-	c = getch()
+	c := rune(getch())
 	if c != '\n' {
 		debug.PrintStack()
 		editerror("newline expected (saw %c)", c)
@@ -428,9 +421,6 @@ func cmdlookup(c rune) int {
 }
 
 func parsecmd(nest int) *Cmd {
-	var i int
-	var c rune
-	var ct *Cmdtab
 	var cp, ncp *Cmd
 	var cmd Cmd
 
@@ -438,7 +428,7 @@ func parsecmd(nest int) *Cmd {
 	if cmdskipbl() == -1 {
 		return nil
 	}
-	c = getch()
+	c := rune(getch())
 	if c == -1 {
 		return nil
 	}
@@ -447,12 +437,12 @@ func parsecmd(nest int) *Cmd {
 		getch() /* the 'd' */
 		cmd.cmdc = 'c' | 0x100
 	}
-	i = cmdlookup(cmd.cmdc)
+	i := int(cmdlookup(cmd.cmdc))
 	if i >= 0 {
 		if cmd.cmdc == '\n' {
 			goto Return /* let nl_cmd work it all out */
 		}
-		ct = &cmdtab[i]
+		ct := (*Cmdtab)(&cmdtab[i])
 		if ct.defaddr == aNo && cmd.addr != nil {
 			editerror("command takes no address")
 		}
@@ -462,10 +452,10 @@ func parsecmd(nest int) *Cmd {
 		if ct.regexp != 0 {
 			/* x without pattern . .*\n, indicated by cmd.re==0 */
 			/* X without pattern is all files */
-			c = nextc()
+			c := rune(nextc())
 			if ct.cmdc != 'x' && ct.cmdc != 'X' || (c != ' ' && c != '\t' && c != '\n') {
 				cmdskipbl()
-				c = getch()
+				c := rune(getch())
 				if c == '\n' || c < 0 {
 					editerror("no address")
 				}
@@ -545,12 +535,10 @@ Return:
 }
 
 func getregexp(delim rune) string {
-	var buf string
-	var i int
 	var c rune
 
-	buf = ""
-	for i = 0; ; i++ {
+	buf := string("")
+	for i := int(0); ; i++ {
 		c = getch()
 		if c == '\\' {
 			if nextc() == delim {
@@ -675,7 +663,6 @@ func simpleaddr() *Addr {
 
 func compoundaddr() *Addr {
 	var addr Addr
-	var next *Addr
 
 	addr.left = simpleaddr()
 	addr.typ = cmdskipbl()
@@ -684,7 +671,7 @@ func compoundaddr() *Addr {
 	}
 	getch()
 	addr.next = compoundaddr()
-	next = addr.next
+	next := (*Addr)(addr.next)
 	if next != nil && (next.typ == ',' || next.typ == ';') && next.left == nil {
 		editerror("bad address syntax")
 	}

--- a/exec.go
+++ b/exec.go
@@ -237,7 +237,6 @@ func execute(t *Text, aq0 int, aq1 int, external bool, argt *Text) {
 }
 
 func edit(et *Text, _ *Text, argt *Text, _, _ bool, arg string) {
-
 	if et == nil {
 		return
 	}
@@ -335,7 +334,6 @@ func cut(et *Text, t *Text, _ *Text, dosnarf bool, docut bool, _ string) {
 }
 
 func newcol(et *Text, _ *Text, _ *Text, _, _ bool, _ string) {
-
 	c := et.row.Add(nil, -1)
 	if c != nil {
 		w := c.Add(nil, nil, -1)
@@ -439,7 +437,6 @@ func getname(t *Text, argt *Text, arg string, isput bool) string {
 }
 
 func get(et *Text, t *Text, argt *Text, flag1 bool, _ bool, arg string) {
-
 	if flag1 {
 		if et == nil || et.w == nil {
 			return
@@ -508,7 +505,6 @@ func checkhash(name string, f *File, d os.FileInfo) {
 		f.qidpath = d.Name()
 		f.mtime = d.ModTime()
 	}
-
 }
 
 // TODO(flux): dev and qidpath?
@@ -644,7 +640,6 @@ func seqof(w *Window, isundo bool) int {
 }
 
 func undo(et *Text, _ *Text, _ *Text, flag1, _ bool, _ string) {
-
 	if et == nil || et.w == nil {
 		return
 	}
@@ -729,7 +724,6 @@ func look(et *Text, t *Text, argt *Text, _, _ bool, arg string) {
 }
 
 func tab(et *Text, _ *Text, argt *Text, _, _ bool, arg string) {
-
 	if et == nil || et.w == nil {
 		return
 	}
@@ -1172,12 +1166,11 @@ func indentval(s string) int {
 }
 
 func indent(et *Text, _ *Text, argt *Text, _, _ bool, arg string) {
-	var autoindent int
 	w := (*Window)(nil)
 	if et != nil && et.w != nil {
 		w = et.w
 	}
-	autoindent = IError
+	autoindent := int(IError)
 	r, _ := getarg(argt, false, true)
 	if len(r) > 0 {
 		autoindent = indentval(r)

--- a/exec.go
+++ b/exec.go
@@ -459,7 +459,7 @@ func get(et *Text, t *Text, argt *Text, flag1 bool, _ bool, arg string) {
 			return
 		}
 	}
-	r := string(name)
+	r := name
 	for _, u := range t.file.text {
 		u.Reset()
 		u.w.DirFree()
@@ -611,7 +611,7 @@ func putall(et, _, _ *Text, _, _ bool, arg string) {
 			if w.nopen[QWevent] > 0 {
 				continue
 			}
-			a := string(w.body.file.name)
+			a := w.body.file.name
 			if w.body.file.mod || len(w.body.cache) > 0 {
 				if _, err := os.Stat(a); err != nil {
 					warning(nil, "no auto-Put of %s: %v\n", a, err)
@@ -731,15 +731,15 @@ func tab(et *Text, _ *Text, argt *Text, _, _ bool, arg string) {
 	r, _ := getarg(argt, false, true)
 	tab := int64(0)
 	if r != "" {
-		p := string(r)
+		p := r
 		if '0' <= p[0] && p[0] <= '9' {
 			tab, _ = strconv.ParseInt(p, 10, 16)
 		}
 	} else {
-		arg = wsre.ReplaceAllString(string(arg), " ")
+		arg = wsre.ReplaceAllString(arg, " ")
 		args := strings.Split(arg, " ")
 		arg = args[0]
-		p := string(arg)
+		p := arg
 		if '0' <= p[0] && p[0] <= '9' {
 			tab, _ = strconv.ParseInt(p, 10, 16)
 		}
@@ -763,7 +763,7 @@ func fontx(et *Text, t *Text, argt *Text, _, _ bool, arg string) {
 	// Parse parameter.  It might be in arg, or argt, or both
 	r, _ := getarg(argt, false, true)
 	r = r + " " + arg
-	r = wsre.ReplaceAllString(string(r), " ")
+	r = wsre.ReplaceAllString(r, " ")
 	words := strings.Split(arg, " ")
 
 	for _, wrd := range words {
@@ -955,7 +955,7 @@ func runproc(win *Window, s string, rdir string, newns bool, argaddr string, arg
 		}
 		dir = ""
 		if rdir != "" {
-			dir = string(rdir)
+			dir = rdir
 		}
 		shell = acmeshell
 		if shell == "" {
@@ -1003,7 +1003,7 @@ func runproc(win *Window, s string, rdir string, newns bool, argaddr string, arg
 		if win != nil {
 			// Access possibly mutable Window state inside a lock.
 			win.lk.Lock()
-			filename = string(win.body.file.name)
+			filename = win.body.file.name
 			winid = win.id
 			incl = append([]string{}, win.incl...)
 			win.lk.Unlock()
@@ -1101,7 +1101,7 @@ func runproc(win *Window, s string, rdir string, newns bool, argaddr string, arg
 		}
 	}
 
-	t = wsre.ReplaceAllString(string(t), " ")
+	t = wsre.ReplaceAllString(t, " ")
 	t = strings.TrimLeft(t, " ")
 	c.av = strings.Split(t, " ")
 	if arg != "" {
@@ -1110,7 +1110,7 @@ func runproc(win *Window, s string, rdir string, newns bool, argaddr string, arg
 
 	dir = ""
 	if rdir != "" {
-		dir = string(rdir)
+		dir = rdir
 	}
 	cmd := exec.Command(c.av[0], c.av[1:]...)
 	cmd.Dir = dir
@@ -1193,7 +1193,7 @@ func dump(et *Text, _ *Text, argt *Text, isdump bool, _ bool, arg string) {
 		name = arg
 	} else {
 		r, _ := getarg(argt, false, true)
-		name = string(r)
+		name = r
 	}
 
 	if isdump {

--- a/frame/delete.go
+++ b/frame/delete.go
@@ -14,7 +14,6 @@ func (f *frameimpl) Delete(p0, p1 int) int {
 func (f *frameimpl) deleteimpl(p0, p1 int) int {
 	f.validateboxmodel("Frame.Delete Start p0=%d p1=%d", p0, p1)
 	defer f.validateboxmodel("Frame.Delete Start p0=%d p1=%d", p0, p1)
-	var r image.Rectangle
 
 	if p1 > f.nchars {
 		p1 = f.nchars - 1
@@ -50,6 +49,7 @@ func (f *frameimpl) deleteimpl(p0, p1 int) int {
 	 *  - f->p0 and f->p1 are not adjusted until after all deletion is done
 	 */
 	// f.Logboxes("before loop pt0 %v pt1 %v n0 %d n1 %d", pt0, pt1, n0, n1)
+	var r image.Rectangle
 	for pt1.X != pt0.X && n1 < len(f.box) {
 		// f.Logboxes("top of loop pt0 %v pt1 %v n0 %d n1 %d, r %v", pt0, pt1, n0, n1)
 		b := f.box[n1]

--- a/frame/draw.go
+++ b/frame/draw.go
@@ -104,13 +104,13 @@ func (f *frameimpl) Drawsel0(pt image.Point, p0, p1 int, back *draw.Image, text 
 	p := 0
 	trim := false
 	x := 0
-	var w int
 
 	if p0 > p1 {
 		panic("Drawsel0: p0 and p1 must be ordered")
 	}
 
 	nb := 0
+	var w int
 	for ; nb < len(f.box) && p < p1; nb++ {
 		b := f.box[nb]
 		nr := nrune(b)

--- a/frame/insert.go
+++ b/frame/insert.go
@@ -140,8 +140,6 @@ func (f *frameimpl) insertimpl(r []rune, p0 int) bool {
 		return f.lastlinefull
 	}
 
-	var rect image.Rectangle
-
 	col := f.cols[ColBack]
 	tcol := f.cols[ColText]
 
@@ -224,6 +222,7 @@ func (f *frameimpl) insertimpl(r []rune, p0 int) bool {
 		f.nchars -= f.strlen(n0)
 		f.delbox(n0, len(f.box)-1)
 	}
+	var rect image.Rectangle
 	if n0 == len(f.box) {
 		div := f.defaultfontheight
 		f.nlines = (pt1.Y - f.rect.Min.Y) / div

--- a/frame/ptofchar.go
+++ b/frame/ptofchar.go
@@ -63,7 +63,6 @@ func (f *frameimpl) Charofpt(pt image.Point) int {
 func (f *frameimpl) charofptimpl(pt image.Point) int {
 	var w, bn int
 	var p int
-	var r rune
 
 	pt = f.grid(pt)
 	qt := f.rect.Min
@@ -78,6 +77,7 @@ func (f *frameimpl) charofptimpl(pt image.Point) int {
 		p += nrune(b)
 	}
 
+	var r rune
 	for _, b := range f.box[bn:] {
 		if qt.X > pt.X {
 			break

--- a/frame/tick.go
+++ b/frame/tick.go
@@ -9,8 +9,6 @@ import (
 // InitTick sets up the TickImage (e.g. cursor)
 // TODO(rjk): doesn't appear to need to be exposed publically.
 func (f *frameimpl) InitTick() {
-
-	var err error
 	if f.cols[ColBack] == nil || f.display == nil {
 		return
 	}
@@ -25,6 +23,7 @@ func (f *frameimpl) InitTick() {
 
 	height := ft.DefaultHeight()
 
+	var err error
 	f.tickimage, err = f.display.AllocImage(image.Rect(0, 0, f.tickscale*frtickw, height), b.Pix, false, draw.Transparent)
 	if err != nil {
 		return

--- a/fsys.go
+++ b/fsys.go
@@ -151,13 +151,10 @@ func fsysproc() {
 }
 
 func fsysaddid(dir string, incl []string) *MntDir {
-	var m *MntDir
-	var id int
-
 	mnt.lk.Lock()
 	mnt.id++
-	id = mnt.id
-	m = &MntDir{}
+	id := int(mnt.id)
+	m := (*MntDir)(&MntDir{})
 	m.id = int64(id)
 	m.dir = dir
 	m.ref = 1 // one for Command, one will be incremented in attach
@@ -254,8 +251,8 @@ func fsysflush(x *Xfid, f *Fid) *Xfid {
 }
 
 func fsysattach(x *Xfid, f *Fid) *Xfid {
-	var t plan9.Fcall
 	if x.fcall.Uname != username {
+		var t plan9.Fcall
 		return respond(x, &t, Eperm)
 	}
 	f.busy = true
@@ -266,11 +263,12 @@ func fsysattach(x *Xfid, f *Fid) *Xfid {
 	f.dir = dirtab[0] // '.'
 	f.nrpart = 0
 	f.w = nil
+	var t plan9.Fcall
 	t.Qid = f.qid
 	f.mntdir = nil
 	var id int64
-	var err error
 	if x.fcall.Aname != "" {
+		var err error
 		id, err = strconv.ParseInt(x.fcall.Aname, 10, 32)
 		if err != nil {
 			acmeerror(fmt.Sprintf("fsysattach: bad Aname %s", x.fcall.Aname), err)
@@ -469,7 +467,6 @@ func fsyswalk(x *Xfid, f *Fid) *Xfid {
 }
 
 func fsysopen(x *Xfid, f *Fid) *Xfid {
-	var t plan9.Fcall
 	var m uint
 	// can't truncate anything, so just disregard
 	x.fcall.Mode &= ^(uint8(plan9.OTRUNC | plan9.OCEXEC))
@@ -494,6 +491,7 @@ func fsysopen(x *Xfid, f *Fid) *Xfid {
 	return nil
 
 Deny:
+	var t plan9.Fcall
 	return respond(x, &t, Eperm)
 }
 
@@ -591,7 +589,6 @@ func fsyswrite(x *Xfid, f *Fid) *Xfid {
 }
 
 func fsysclunk(x *Xfid, f *Fid) *Xfid {
-
 	fsysdelid(f.mntdir)
 	x.c <- xfidclose
 	return nil
@@ -613,7 +610,6 @@ func fsysstat(x *Xfid, f *Fid) *Xfid {
 }
 
 func fsyswstat(x *Xfid, f *Fid) *Xfid {
-
 	var t plan9.Fcall
 
 	return respond(x, &t, Eperm)
@@ -630,7 +626,6 @@ func newfid(fid uint32) *Fid {
 }
 
 func getclock() int64 {
-
 	return time.Now().Unix()
 }
 

--- a/fsys.go
+++ b/fsys.go
@@ -153,8 +153,8 @@ func fsysproc() {
 func fsysaddid(dir string, incl []string) *MntDir {
 	mnt.lk.Lock()
 	mnt.id++
-	id := int(mnt.id)
-	m := (*MntDir)(&MntDir{})
+	id := mnt.id
+	m := &MntDir{}
 	m.id = int64(id)
 	m.dir = dir
 	m.ref = 1 // one for Command, one will be incremented in attach
@@ -257,7 +257,7 @@ func fsysattach(x *Xfid, f *Fid) *Xfid {
 	}
 	f.busy = true
 	f.open = false
-	f.qid.Path = uint64(Qdir)
+	f.qid.Path = Qdir
 	f.qid.Type = plan9.QTDIR
 	f.qid.Vers = 0
 	f.dir = dirtab[0] // '.'
@@ -347,7 +347,7 @@ func fsyswalk(x *Xfid, f *Fid) *Xfid {
 
 			if wname == ".." {
 				typ = plan9.QTDIR
-				path = uint64(Qdir)
+				path = Qdir
 				id = 0
 				if w != nil {
 					w.Close()
@@ -355,7 +355,7 @@ func fsyswalk(x *Xfid, f *Fid) *Xfid {
 				}
 				q.Type = typ
 				q.Vers = 0
-				q.Path = uint64(QID(id, path))
+				q.Path = QID(id, path)
 				t.Wqid = append(t.Wqid, q)
 				continue
 			}
@@ -379,7 +379,7 @@ func fsyswalk(x *Xfid, f *Fid) *Xfid {
 				break
 			}
 			w.ref.Inc() // we'll drop reference at end if there's an error
-			path = uint64(Qdir)
+			path = Qdir
 			typ = plan9.QTDIR
 			row.lk.Unlock()
 			dir = dirtabw[0] // '.'
@@ -389,7 +389,7 @@ func fsyswalk(x *Xfid, f *Fid) *Xfid {
 			}
 			q.Type = typ
 			q.Vers = 0
-			q.Path = uint64(QID(id, path))
+			q.Path = QID(id, path)
 			t.Wqid = append(t.Wqid, q)
 			continue
 
@@ -402,7 +402,7 @@ func fsyswalk(x *Xfid, f *Fid) *Xfid {
 				w = <-cnewwindow  // receive new window
 				w.ref.Inc()
 				typ = plan9.QTDIR
-				path = uint64(QID(w.id, Qdir))
+				path = QID(w.id, Qdir)
 				id = w.id
 				dir = dirtabw[0]
 				q.Type = typ

--- a/logf.go
+++ b/logf.go
@@ -135,7 +135,7 @@ func xfidlog(w *Window, op string) {
 		}
 	}
 	f := w.body.file
-	name := string(f.name)
+	name := f.name
 	eventlog.ev = append(eventlog.ev, fmt.Sprintf("%d %s %s\n", w.id, op, name))
 	if eventlog.r.L == nil {
 		eventlog.r.L = &eventlog.lk

--- a/look.go
+++ b/look.go
@@ -211,7 +211,6 @@ func look3(t *Text, q0 int, q1 int, external bool) {
 
 func plumblook(m *plumb.Message) {
 	var e Expand
-	var addr string
 
 	if len(m.Data) >= BUFSIZE {
 		warning(nil, "insanely long file name (%d bytes) in plumb message (%.32s...)\n", len(m.Data), m.Data)
@@ -228,7 +227,7 @@ func plumblook(m *plumb.Message) {
 	e.jump = true
 	e.a0 = 0
 	e.a1 = 0
-	addr = findattr(m.Attr, "addr")
+	addr := string(findattr(m.Attr, "addr"))
 	if addr != "" {
 		e.ar = []rune(addr)
 		e.a1 = len(e.ar)
@@ -478,10 +477,9 @@ Rescue:
 }
 
 func expandfile(t *Text, q0 int, q1 int, e *Expand) (success bool) {
-	var colon int
 	amax := q1
 	if q1 == q0 {
-		colon = -1
+		colon := int(-1)
 		for q1 < t.file.b.Nc() {
 			c := t.ReadC(q1)
 			if isfilec(c) {
@@ -784,7 +782,6 @@ func openfile(t *Text, e *Expand) *Window {
 }
 
 func newx(et *Text, t *Text, argt *Text, flag1 bool, flag2 bool, arg string) {
-
 	a, _ := getarg(argt, false, true)
 	if a != "" {
 		newx(et, t, nil, flag1, flag2, a)

--- a/look.go
+++ b/look.go
@@ -227,7 +227,7 @@ func plumblook(m *plumb.Message) {
 	e.jump = true
 	e.a0 = 0
 	e.a1 = 0
-	addr := string(findattr(m.Attr, "addr"))
+	addr := findattr(m.Attr, "addr")
 	if addr != "" {
 		e.ar = []rune(addr)
 		e.a1 = len(e.ar)
@@ -456,7 +456,7 @@ func dirname(t *Text, r []rune) []rune {
 	for m := (0); m < nt; m++ {
 		c = b[m]
 		if c == '/' {
-			slash = int(m)
+			slash = m
 		}
 		if c == ' ' || c == '\t' {
 			break
@@ -789,7 +789,7 @@ func newx(et *Text, t *Text, argt *Text, flag1 bool, flag2 bool, arg string) {
 			return
 		}
 	}
-	s := wsre.ReplaceAllString(string(arg), " ")
+	s := wsre.ReplaceAllString(arg, " ")
 	filenames := strings.Split(s, " ")
 	if len(filenames) == 1 && filenames[0] == "" && et.col != nil {
 		w := et.col.Add(nil, nil, -1)
@@ -804,7 +804,7 @@ func newx(et *Text, t *Text, argt *Text, flag1 bool, flag2 bool, arg string) {
 		fmt.Printf("rs = %#v\n", rs)
 		e := Expand{}
 		e.name = rs
-		e.bname = string(rs)
+		e.bname = rs
 		e.jump = true
 		fmt.Printf("e = %#v\n", e)
 		openfile(et, &e)

--- a/text.go
+++ b/text.go
@@ -345,7 +345,7 @@ func (t *Text) Load(q0 int, filename string, setqid bool) (nread int, err error)
 		t.org += n
 	} else {
 		if q0 <= t.org+(t.fr.GetFrameFillStatus().Nchars) { // Text is within the window, put it there.
-			t.fr.Insert(t.file.b[q0:q0+n], int(q0-t.org))
+			t.fr.Insert(t.file.b[q0:q0+n], q0-t.org)
 		}
 	}
 	// For each clone, redraw
@@ -477,7 +477,7 @@ func (t *Text) Insert(q0 int, r []rune, tofile bool) {
 		t.org += n
 	} else {
 		if t.fr != nil && q0 <= t.org+(t.fr.GetFrameFillStatus().Nchars) {
-			t.fr.Insert(r[:n], int(q0-t.org))
+			t.fr.Insert(r[:n], q0-t.org)
 		}
 	}
 	if t.w != nil {
@@ -1140,7 +1140,7 @@ func (t *Text) Select() {
 	selectq = t.org + (t.fr.Charofpt(mouse.Point))
 	//	fmt.Printf("Text.Select: mouse.Msec %v, clickmsec %v\n", mouse.Msec, clickmsec)
 	//	fmt.Printf("clicktext==t %v, (q0==q1 && selectq==q0): %v", clicktext == t, q0 == q1 && selectq == q0)
-	if (clicktext == t && mouse.Msec-uint32(clickmsec) < 500) && (q0 == q1 && selectq == q0) {
+	if (clicktext == t && mouse.Msec-clickmsec < 500) && (q0 == q1 && selectq == q0) {
 		q0, q1 = t.DoubleClick(q0, q1)
 		fmt.Printf("Text.Select: DoubleClick returned %d, %d\n", q0, q1)
 		t.SetSelect(q0, q1)
@@ -1180,7 +1180,7 @@ func (t *Text) Select() {
 		}
 	}
 	if q0 == q1 {
-		if q0 == t.q0 && clicktext == t && mouse.Msec-uint32(clickmsec) < 500 {
+		if q0 == t.q0 && clicktext == t && mouse.Msec-clickmsec < 500 {
 			q0, q1 = t.DoubleClick(q0, q1)
 			clicktext = nil
 		} else {
@@ -1567,7 +1567,7 @@ func (t *Text) BackNL(p, n int) int {
 	if n == 0 && p > 0 && t.ReadC(p-1) != '\n' {
 		n = 1
 	}
-	i := int(n)
+	i := n
 	for i > 0 && p > 0 {
 		i--
 		p-- /* it's at a newline now; back over it */

--- a/text.go
+++ b/text.go
@@ -283,7 +283,6 @@ func (t *Text) Load(q0 int, filename string, setqid bool) (nread int, err error)
 		return 0, fmt.Errorf("can't fstat %s: %v\n", filename, err)
 	}
 
-	var count int
 	q1 := (0)
 	hasNulls := false
 	if d.IsDir() {
@@ -327,6 +326,7 @@ func (t *Text) Load(q0 int, filename string, setqid bool) (nread int, err error)
 	} else {
 		t.w.isdir = false
 		t.w.filemenu = true
+		var count int
 		count, hasNulls, err = t.file.Load(q0, fd, setqid && q0 == 0)
 		if err != nil {
 			warning(nil, "Error reading file %s: %v", filename, err)
@@ -363,7 +363,6 @@ func (t *Text) Load(q0 int, filename string, setqid bool) (nread int, err error)
 		warning(nil, "%s: NUL bytes elided\n", filename)
 	}
 	return q1 - q0, nil
-
 }
 
 func (t *Text) Backnl(p int, n int) int {
@@ -1067,7 +1066,6 @@ func (t *Text) Type(r rune) {
 		t.w.Commit(t)
 	}
 	t.iq1 = t.q0
-
 }
 
 func (t *Text) Commit(tofile bool) {
@@ -1095,12 +1093,12 @@ func getP1(fr frame.Frame) int {
 }
 
 func (t *Text) FrameScroll(fr frame.SelectScrollUpdater, dl int) {
-	var q0 int
 	if dl == 0 {
 		// TODO(rjk): Make this mechanism better? It seems unfortunate.
 		ScrSleep(100)
 		return
 	}
+	var q0 int
 	if dl < 0 {
 		q0 = t.Backnl(t.org, (-dl))
 	} else {
@@ -1565,13 +1563,11 @@ func (t *Text) ClickHTMLMatch(inq0 int) (q0, q1 int, r bool) {
 }
 
 func (t *Text) BackNL(p, n int) int {
-	var i int
-
 	/* look for start of this line if n==0 */
 	if n == 0 && p > 0 && t.ReadC(p-1) != '\n' {
 		n = 1
 	}
-	i = n
+	i := int(n)
 	for i > 0 && p > 0 {
 		i--
 		p-- /* it's at a newline now; back over it */
@@ -1666,5 +1662,4 @@ func (t *Text) DirName(name string) string {
 	}
 	spl = filepath.Clean(spl + string(filepath.Separator) + name)
 	return spl
-
 }

--- a/wind.go
+++ b/wind.go
@@ -215,7 +215,7 @@ func (w *Window) TagLines(r image.Rectangle) int {
 
 	if !w.tagexpand {
 		/* use just as many lines as needed to show the Del */
-		n := int(w.delRunePos())
+		n := w.delRunePos()
 		if n < 0 {
 			return 1
 		}
@@ -229,7 +229,7 @@ func (w *Window) TagLines(r image.Rectangle) int {
 	}
 
 	/* if tag ends with \n, include empty line at end for typing */
-	n := int(w.tag.fr.GetFrameFillStatus().Nlines)
+	n := w.tag.fr.GetFrameFillStatus().Nlines
 	if w.tag.file.b.Nc() > 0 {
 		c := w.tag.file.b.ReadC(w.tag.file.b.Nc() - 1)
 		if c == '\n' {

--- a/wind.go
+++ b/wind.go
@@ -108,10 +108,8 @@ func (w *Window) initHeadless(clone *Window) *Window {
 }
 
 func (w *Window) Init(clone *Window, r image.Rectangle, dis *draw.Display) {
-
 	//	var r1, br image.Rectangle
 	//	var f *File
-	var rf string
 	//	var rp []rune
 	//	var nc int
 
@@ -139,6 +137,7 @@ func (w *Window) Init(clone *Window, r image.Rectangle, dis *draw.Display) {
 		r1.Max.Y = r1.Min.Y
 	}
 
+	var rf string
 	if clone != nil {
 		rf = clone.body.font
 	} else {
@@ -207,7 +206,6 @@ func (w *Window) moveToDel() {
 }
 
 func (w *Window) TagLines(r image.Rectangle) int {
-	var n int
 	if !w.tagexpand && !w.showdel {
 		return 1
 	}
@@ -217,7 +215,7 @@ func (w *Window) TagLines(r image.Rectangle) int {
 
 	if !w.tagexpand {
 		/* use just as many lines as needed to show the Del */
-		n = w.delRunePos()
+		n := int(w.delRunePos())
 		if n < 0 {
 			return 1
 		}
@@ -231,7 +229,7 @@ func (w *Window) TagLines(r image.Rectangle) int {
 	}
 
 	/* if tag ends with \n, include empty line at end for typing */
-	n = w.tag.fr.GetFrameFillStatus().Nlines
+	n := int(w.tag.fr.GetFrameFillStatus().Nlines)
 	if w.tag.file.b.Nc() > 0 {
 		c := w.tag.file.b.ReadC(w.tag.file.b.Nc() - 1)
 		if c == '\n' {
@@ -594,11 +592,9 @@ func isDir(r string) (bool, error) {
 	}
 
 	return false, nil
-
 }
 
 func (w *Window) AddIncl(r string) {
-
 	// Tries to open absolute paths, and if fails, tries
 	// to use dirname instead.
 	d, err := isDir(r)
@@ -616,7 +612,6 @@ func (w *Window) AddIncl(r string) {
 	}
 	w.incl = append(w.incl, r)
 	return
-
 }
 
 func (w *Window) Clean(conservative bool) bool {

--- a/xfid.go
+++ b/xfid.go
@@ -31,11 +31,11 @@ func clampaddr(w *Window) {
 	if w.addr.q1 < 0 {
 		w.addr.q1 = 0
 	}
-	if w.addr.q0 > int(w.body.Nc()) {
-		w.addr.q0 = int(w.body.Nc())
+	if w.addr.q0 > w.body.Nc() {
+		w.addr.q0 = w.body.Nc()
 	}
-	if w.addr.q1 > int(w.body.Nc()) {
-		w.addr.q1 = int(w.body.Nc())
+	if w.addr.q1 > w.body.Nc() {
+		w.addr.q1 = w.body.Nc()
 	}
 }
 
@@ -169,7 +169,7 @@ func xfidopen(x *Xfid) {
 			seq++
 			t.file.Mark()
 			cut(t, t, nil, false, true, "")
-			w.wrselrange = Range{int(t.q1), int(t.q1)}
+			w.wrselrange = Range{t.q1, t.q1}
 			w.nomark = true
 		case QWeditout:
 			if editing == Inactive {
@@ -184,7 +184,7 @@ func xfidopen(x *Xfid) {
 			//		respond(x, &fc, Einuse);
 			//		return;
 			//	}
-			w.wrselrange = Range{int(t.q1), int(t.q1)}
+			w.wrselrange = Range{t.q1, t.q1}
 			break
 		}
 		w.Unlock()
@@ -358,7 +358,7 @@ func xfidread(x *Xfid) {
 
 	case QWdata:
 		// BUG: what should happen if q1 > q0?
-		if w.addr.q0 > int(w.body.Nc()) {
+		if w.addr.q0 > w.body.Nc() {
 			respond(x, &fc, Eaddr)
 			break
 		}
@@ -367,7 +367,7 @@ func xfidread(x *Xfid) {
 
 	case QWxdata:
 		// BUG: what should happen if q1 > q0?
-		if w.addr.q0 > int(w.body.Nc()) {
+		if w.addr.q0 > w.body.Nc() {
 			respond(x, &fc, Eaddr)
 			break
 		}
@@ -560,7 +560,7 @@ func xfidwrite(x *Xfid) {
 		a = w.addr
 		t = &w.body
 		w.Commit(t)
-		if a.q0 > int(t.Nc()) || a.q1 > int(t.Nc()) {
+		if a.q0 > t.Nc() || a.q1 > t.Nc() {
 			respond(x, &fc, Eaddr)
 			break
 		}


### PR DESCRIPTION
This change is *most* automated. grind was used to perform some
cleanup on go's compiler when it was first migrated from C. Most
notably, it moves variable declaration closer to use.

After applying grind, I used uncovert to remove some unnecessary type casts.