### PR TITLE
Remove calls to syscall.CloseOnExec

### DIFF
--- a/fsys.go
+++ b/fsys.go
@@ -102,8 +102,6 @@ func fsysinit() {
 	if err != nil {
 		acmeerror("Failed to open pipe", nil)
 	}
-	syscall.CloseOnExec(pipe[0])
-	syscall.CloseOnExec(pipe[1])
 	reader := os.NewFile(uintptr(pipe[0]), "pipeend0")
 	writer := os.NewFile(uintptr(pipe[1]), "pipeend1")
 	if post9pservice(reader, "acme", mtpt) < 0 {

--- a/xfid.go
+++ b/xfid.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"syscall"
 	"unicode/utf8"
 
 	"9fans.net/go/draw"
@@ -136,7 +135,7 @@ func xfidopen(x *Xfid) {
 				return
 			}
 			var err error
-			// TODO(flux): Move the TempFile and CloseOnExec and Remove
+			// TODO(flux): Move the TempFile and Remove
 			// into a tempfile() call
 			w.rdselfd, err = ioutil.TempFile("", "acme")
 			if err != nil {
@@ -144,7 +143,6 @@ func xfidopen(x *Xfid) {
 				respond(x, &fc, fmt.Errorf("can't create temp file"))
 				return
 			}
-			syscall.CloseOnExec(int(w.rdselfd.Fd()))
 			os.Remove(w.rdselfd.Name()) // tempfile ORCLOSE
 			w.nopen[q]++
 			q0 = t.q0


### PR DESCRIPTION
It's not portable, and you generally don't have to worry about the
close-on-exec flag -- Go will take care of it. See comment at the top of
https://golang.org/src/syscall/exec_unix.go for more details.