### PR TITLE
Fix crash when listing filenames with non-ascii characters

### DIFF
--- a/dat.go
+++ b/dat.go
@@ -201,12 +201,6 @@ type Xfid struct {
 
 type RangeSet []Range
 
-type Dirlist struct {
-	r   []rune
-	nr  int
-	wid int
-}
-
 type Expand struct {
 	q0    int
 	q1    int

--- a/text.go
+++ b/text.go
@@ -233,9 +233,9 @@ func (t *Text) Columnate(names []string, widths []int) {
 	q1 = 0
 	for i := 0; i < nrow; i++ {
 		for j := i; j < len(names); j += nrow {
-			dl := names[j]
-			t.file.Insert(q1, []rune(dl))
-			q1 += (len(dl))
+			dl := bytetorune([]byte(names[j]))
+			t.file.Insert(q1, dl)
+			q1 += len(dl)
 			if j+nrow >= len(names) {
 				break
 			}

--- a/util.go
+++ b/util.go
@@ -62,6 +62,11 @@ func restoremouse(w *Window) bool {
 	return false
 }
 
+func bytetorune(s []byte) []rune {
+	r, _, _ := cvttorunes(s, len(s))
+	return r
+}
+
 // TODO(flux) The "correct" answer here is return unicode.IsNumber(c) || unicode.IsLetter(c)
 func isalnum(c rune) bool {
 	/*


### PR DESCRIPTION
Also remove unused Dirlist struct (we use 2 slices instead of []Dirlist).

Fixes #113