### PR TITLE
Replace syscall.Socketpair with net.Pipe

### DIFF
--- a/fsys.go
+++ b/fsys.go
@@ -4,11 +4,11 @@ package main
 import (
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"sort"
 	"strconv"
 	"sync"
-	"syscall"
 	"time"
 
 	"9fans.net/go/plan9"
@@ -17,7 +17,7 @@ import (
 // TODO(flux): Wrap fsys into a tidy object.
 
 var (
-	sfd *os.File
+	sfd net.Conn
 )
 
 const (
@@ -98,12 +98,7 @@ var (
 
 func fsysinit() {
 	initfcall()
-	pipe, err := syscall.Socketpair(syscall.AF_UNIX, syscall.SOCK_STREAM, 0)
-	if err != nil {
-		acmeerror("Failed to open pipe", nil)
-	}
-	reader := os.NewFile(uintptr(pipe[0]), "pipeend0")
-	writer := os.NewFile(uintptr(pipe[1]), "pipeend1")
+	reader, writer := net.Pipe()
 	if post9pservice(reader, "acme", mtpt) < 0 {
 		acmeerror("can't post service", nil)
 	}

--- a/util.go
+++ b/util.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 	"image"
-	"os"
+	"log"
 	"strings"
 	"unicode/utf8"
 )
@@ -35,8 +35,7 @@ func abs(x int) int {
 }
 
 func acmeerror(s string, err error) {
-	fmt.Fprintf(os.Stderr, "acme: %s: %v\n", s, err)
-	// panic(fmt.Sprintf(os.Stderr, "acme: %s: %v\n", s, err))
+	log.Panicf("acme: %s: %v\n", s, err)
 }
 
 var (


### PR DESCRIPTION
Also make acmeerror panic. This prevents a nil pointer dereference in
fsysproc() -- the code assumes acmeerror exits the program.

Helps #115