### PR TITLE
Fix some golint warnings

### DIFF
--- a/acme.go
+++ b/acme.go
@@ -43,7 +43,7 @@ var loadfileflag = flag.String("l", "", "Load file name")
 var mtptflag = flag.String("m", "", "Mountpoint")
 var swapscrollbuttonsflag = flag.Bool("r", false, "Swap scroll buttons")
 var winsize = flag.String("W", "1024x768", "Window Size (WidthxHeight)")
-var ncol int = 2
+var ncol = 2
 
 var mainpid int
 
@@ -202,7 +202,7 @@ func readfile(c *Column, filename string) {
 	xfidlog(w, "new")
 }
 
-var fontCache map[string]*draw.Font = make(map[string]*draw.Font)
+var fontCache = make(map[string]*draw.Font)
 
 func fontget(name string, display *draw.Display) *draw.Font {
 	var font *draw.Font

--- a/dat.go
+++ b/dat.go
@@ -47,7 +47,6 @@ const (
 	NRange = 10 // TODO(flux): No reason for this static limit anymore; should we remove?
 	//	Infinity  = 0x7FFFFFFF
 
-	//	STACK = 65536
 	EVENTSIZE = 256
 	BUFSIZE   = MaxBlock + plan9.IOHDRSZ
 	RBUFSIZE  = BUFSIZE / utf8.UTFMax
@@ -117,7 +116,7 @@ var (
 	tagcolors         [frame.NumColours]*draw.Image
 	textcolors        [frame.NumColours]*draw.Image
 	wdir              string
-	editing           int = Inactive
+	editing           = Inactive
 	messagesize       int
 	globalautoindent  bool
 	dodollarsigns     bool
@@ -140,7 +139,7 @@ var (
 
 	editoutlk *sync.Mutex
 
-	WinId int = 0
+	WinID = 0
 )
 
 type Range struct {

--- a/disk_test.go
+++ b/disk_test.go
@@ -96,24 +96,24 @@ func TestReadWriteBig(t *testing.T) {
 	}
 	bigstring := b.String()
 
-	original_large_blk := disk.NewBlock(uint(4 * 100))
-	new_large_blk := writereadtestcore(t, "big write-read test", bigstring, original_large_blk, disk)
+	originalLargeBlk := disk.NewBlock(uint(4 * 100))
+	newLargeBlk := writereadtestcore(t, "big write-read test", bigstring, originalLargeBlk, disk)
 
-	if original_large_blk != new_large_blk {
-		t.Errorf("without resizing, new_large_blk should equal original_large_blk")
+	if originalLargeBlk != newLargeBlk {
+		t.Errorf("without resizing, newLargeBlk should equal originalLargeBlk")
 	}
 
 	// Resize it with a little string.
-	new_small_blk := writereadtestcore(t, "small size-changing write-read test", "c日本d", new_large_blk, disk)
-	if new_small_blk == original_large_blk {
-		t.Errorf("with resizing, new_small_blk should not equal original_large_blk")
+	newSmallBlk := writereadtestcore(t, "small size-changing write-read test", "c日本d", newLargeBlk, disk)
+	if newSmallBlk == originalLargeBlk {
+		t.Errorf("with resizing, newSmallBlk should not equal originalLargeBlk")
 	}
 
-	if original_large_blk != disk.free[2] {
-		t.Errorf("with resizing, original_large_blk should be in the free-bucket for re-use")
+	if originalLargeBlk != disk.free[2] {
+		t.Errorf("with resizing, originalLargeBlk should be in the free-bucket for re-use")
 	}
-	if original_large_blk.next != nil {
-		t.Errorf("Release failed to make original_large_blk.next point to nothing")
+	if originalLargeBlk.next != nil {
+		t.Errorf("Release failed to make originalLargeBlk.next point to nothing")
 	}
 
 	// Resize with a big string, make sure that we reuse the block
@@ -123,12 +123,12 @@ func TestReadWriteBig(t *testing.T) {
 	}
 	bigstring = b.String()
 
-	different_large_blk := writereadtestcore(t, "small to large size-changing write-read test", bigstring, new_small_blk, disk)
-	if new_small_blk == different_large_blk {
-		t.Errorf("with resizing, from small to large, different_large_blk should not equal new_small_blk")
+	differentLargeBlk := writereadtestcore(t, "small to large size-changing write-read test", bigstring, newSmallBlk, disk)
+	if newSmallBlk == differentLargeBlk {
+		t.Errorf("with resizing, from small to large, differentLargeBlk should not equal newSmallBlk")
 	}
-	if different_large_blk != original_large_blk {
-		t.Errorf("with resizing to a previously-used large block, should have reused original_large_blk")
+	if differentLargeBlk != originalLargeBlk {
+		t.Errorf("with resizing to a previously-used large block, should have reused originalLargeBlk")
 	}
 	if disk.free[2] != nil {
 		t.Errorf("reusing block from bucket should have removed the block")

--- a/ecmd.go
+++ b/ecmd.go
@@ -40,7 +40,7 @@ func mkaddr(f *File) (a Address) {
 	return a
 }
 
-var none Address = Address{Range{0, 0}, nil}
+var none = Address{Range{0, 0}, nil}
 
 func cmdexec(t *Text, cp *Cmd) bool {
 	w := (*Window)(nil)

--- a/elog.go
+++ b/elog.go
@@ -58,10 +58,10 @@ func (e *Elog) Term() {
 	(*e).warned = false
 }
 
-func (e *ElogOperation) reset() {
-	e.t = Null
-	e.nd = 0
-	e.r = e.r[0:0]
+func (eo *ElogOperation) reset() {
+	eo.t = Null
+	eo.nd = 0
+	eo.r = eo.r[0:0]
 }
 
 func elogclose(f *File) {}

--- a/exec.go
+++ b/exec.go
@@ -85,9 +85,8 @@ func printarg(argt *Text, q0 int, q1 int) string {
 	}
 	if q0 == q1 {
 		return fmt.Sprintf("%s:#%d", argt.file.name, q0)
-	} else {
-		return fmt.Sprintf("%s:#%d,#%d", argt.file.name, q0, q1)
 	}
+	return fmt.Sprintf("%s:#%d,#%d", argt.file.name, q0, q1)
 }
 
 func getarg(argt *Text, doaddr bool, dofile bool) (string, string) {

--- a/file.go
+++ b/file.go
@@ -73,8 +73,8 @@ func (h *FileHash) Set(b []byte) {
 	copy(h[:], b)
 }
 
-func (h0 FileHash) Eq(h1 FileHash) bool {
-	return bytes.Compare(h0[:], h1[:]) == 0
+func (h FileHash) Eq(h1 FileHash) bool {
+	return bytes.Compare(h[:], h1[:]) == 0
 }
 
 func calcFileHash(b []byte) FileHash {

--- a/frame/box.go
+++ b/frame/box.go
@@ -65,7 +65,7 @@ func runeindex(p []byte, n int) int {
 	offs := 0
 	for i := 0; i < n; i++ {
 		if p[offs] < 0x80 {
-			offs += 1
+			offs++
 		} else {
 			_, size := utf8.DecodeRune(p[offs:])
 			offs += size
@@ -166,7 +166,7 @@ func (f *frameimpl) validateboxmodel(format string, args ...interface{}) {
 	total := 0
 	for _, b := range f.box {
 		if b.Nrune < 0 {
-			total += 1
+			total++
 		} else {
 			total += b.Nrune
 		}

--- a/frame/box_test.go
+++ b/frame/box_test.go
@@ -17,8 +17,8 @@ func (bx SimpleBoxModelTest) Try() interface{} {
 	return struct{}{}
 }
 
-func (tv SimpleBoxModelTest) Verify(t *testing.T, prefix string, result interface{}) {
-	testcore(t, prefix, tv.name, tv.frame, tv.nbox, tv.afterboxes)
+func (bx SimpleBoxModelTest) Verify(t *testing.T, prefix string, result interface{}) {
+	testcore(t, prefix, bx.name, bx.frame, bx.nbox, bx.afterboxes)
 }
 
 func TestRunIndex(t *testing.T) {
@@ -366,11 +366,11 @@ func (bx FindBoxModelTest) Try() interface{} {
 	return bx.stim(bx.frame)
 }
 
-func (tv FindBoxModelTest) Verify(t *testing.T, prefix string, result interface{}) {
+func (bx FindBoxModelTest) Verify(t *testing.T, prefix string, result interface{}) {
 	r := result.(int)
-	testcore(t, prefix, tv.name, tv.frame, tv.nbox, tv.afterboxes)
-	if got, want := r, tv.foundbox; got != want {
-		t.Errorf("%s-%s: running stim got %d but want %d\n", prefix, tv.name, got, want)
+	testcore(t, prefix, bx.name, bx.frame, bx.nbox, bx.afterboxes)
+	if got, want := r, bx.foundbox; got != want {
+		t.Errorf("%s-%s: running stim got %d but want %d\n", prefix, bx.name, got, want)
 	}
 }
 

--- a/frame/insert_test.go
+++ b/frame/insert_test.go
@@ -28,18 +28,18 @@ func (bx InsertTest) Try() interface{} {
 	return InsertTestResult{a, b, c}
 }
 
-func (tv InsertTest) Verify(t *testing.T, prefix string, result interface{}) {
+func (bx InsertTest) Verify(t *testing.T, prefix string, result interface{}) {
 	r := result.(InsertTestResult)
 
-	if got, want := r.ppt, tv.ppt; got != want {
-		t.Errorf("%s-%s: running stim ppt got %d but want %d\n", prefix, tv.name, got, want)
+	if got, want := r.ppt, bx.ppt; got != want {
+		t.Errorf("%s-%s: running stim ppt got %d but want %d\n", prefix, bx.name, got, want)
 	}
-	if got, want := r.resultpt, tv.resultpt; got != want {
-		t.Errorf("%s-%s: running stim resultpt got %d but want %d\n", prefix, tv.name, got, want)
+	if got, want := r.resultpt, bx.resultpt; got != want {
+		t.Errorf("%s-%s: running stim resultpt got %d but want %d\n", prefix, bx.name, got, want)
 	}
 	// We use the global frame here to make sure that bxscan works as desired.
 	// I note in passing that encapsulation here could be improved.
-	testcore(t, prefix, tv.name, r.frame, tv.nbox, tv.afterboxes)
+	testcore(t, prefix, bx.name, r.frame, bx.nbox, bx.afterboxes)
 }
 
 func mkRu(s string) []rune {

--- a/frame/util.go
+++ b/frame/util.go
@@ -19,9 +19,8 @@ func (f *frameimpl) canfit(pt image.Point, b *frbox) (int, bool) {
 	if b.Nrune < 0 {
 		if int(b.Minwid) <= left {
 			return 1, true
-		} else {
-			return 0, false
 		}
+		return 0, false
 	}
 
 	if left >= b.Wid {
@@ -152,9 +151,8 @@ func nbyte(f *frbox) int {
 func nrune(b *frbox) int {
 	if b.Nrune < 0 {
 		return 1
-	} else {
-		return b.Nrune
 	}
+	return b.Nrune
 }
 
 func Rpt(min, max image.Point) image.Rectangle {

--- a/frame/util_test.go
+++ b/frame/util_test.go
@@ -28,17 +28,17 @@ func (bx BoxModelTest) Try() interface{} {
 	}
 }
 
-func (tv BoxModelTest) Verify(t *testing.T, prefix string, result interface{}) {
+func (bx BoxModelTest) Verify(t *testing.T, prefix string, result interface{}) {
 	r := result.(BoxModelTestResult)
 
-	if got, want := r.result, tv.result; got != want {
-		t.Errorf("%s-%s: running stim got %d but want %d\n", prefix, tv.name, got, want)
+	if got, want := r.result, bx.result; got != want {
+		t.Errorf("%s-%s: running stim got %d but want %d\n", prefix, bx.name, got, want)
 	}
-	if got, want := r.boolresult, tv.boolresult; got != want {
-		t.Errorf("%s-%s: running stim bool got %v but want %v\n", prefix, tv.name, got, want)
+	if got, want := r.boolresult, bx.boolresult; got != want {
+		t.Errorf("%s-%s: running stim bool got %v but want %v\n", prefix, bx.name, got, want)
 	}
 
-	testcore(t, prefix, tv.name, tv.frame, tv.nbox, tv.afterboxes)
+	testcore(t, prefix, bx.name, bx.frame, bx.nbox, bx.afterboxes)
 }
 
 func TestCanfit(t *testing.T) {

--- a/fsys.go
+++ b/fsys.go
@@ -25,11 +25,11 @@ const (
 	DEBUG = 0
 )
 
-var fids map[uint32]*Fid = make(map[uint32]*Fid)
+var fids = make(map[uint32]*Fid)
 
 type fsfunc func(*Xfid, *Fid) *Xfid
 
-var fcall []fsfunc = make([]fsfunc, plan9.Tmax)
+var fcall = make([]fsfunc, plan9.Tmax)
 
 func initfcall() {
 	fcall[plan9.Tflush] = fsysflush
@@ -53,7 +53,7 @@ var (
 	Enotdir = errors.New("not a directory")
 )
 
-var dirtab []*DirTab = []*DirTab{
+var dirtab = []*DirTab{
 	{".", plan9.QTDIR, Qdir, 0500 | plan9.DMDIR},
 	{"acme", plan9.QTDIR, Qacme, 0500 | plan9.DMDIR},
 	{"cons", plan9.QTFILE, Qcons, 0600},
@@ -67,7 +67,7 @@ var dirtab []*DirTab = []*DirTab{
 	//	{ nil, }
 }
 
-var dirtabw []*DirTab = []*DirTab{
+var dirtabw = []*DirTab{
 	{".", plan9.QTDIR, Qdir, 0500 | plan9.DMDIR},
 	{"addr", plan9.QTFILE, QWaddr, 0600},
 	{"body", plan9.QTAPPEND, QWbody, 0600 | plan9.DMAPPEND},
@@ -92,7 +92,7 @@ type Mnt struct {
 var mnt Mnt
 
 var (
-	username string = "Wile E. Coyote"
+	username = "Wile E. Coyote"
 	closing  int
 )
 
@@ -191,7 +191,7 @@ func fsysdelid(idm *MntDir) {
 		prev = m
 	}
 
-	cerr <- fmt.Errorf("fsysdelid: can't find id %d\n", idm.id)
+	cerr <- fmt.Errorf("fsysdelid: can't find id %d", idm.id)
 }
 
 // Called only in exec.c:/^run(), from a different FD group

--- a/fsys_test.go
+++ b/fsys_test.go
@@ -139,9 +139,8 @@ func startAcme(t *testing.T) *Acme {
 			if i >= 9 {
 				t.Fatalf("Failed to mount acme: %v", err)
 				return nil
-			} else {
-				time.Sleep(time.Second)
 			}
+			time.Sleep(time.Second)
 		} else {
 			break
 		}

--- a/look.go
+++ b/look.go
@@ -43,7 +43,7 @@ func plumbthread() {
 		plumbeditfidbr := bufio.NewReader(plumbeditfid)
 		// Relay messages.
 		for {
-			var m *plumb.Message = &plumb.Message{}
+			var m = &plumb.Message{}
 			err := m.Recv(plumbeditfidbr)
 			if err != nil {
 				break
@@ -585,9 +585,8 @@ func expandfile(t *Text, q0 int, q1 int, e *Expand) (success bool) {
 			_, _, e.a1 = address(true, nil, Range{-1, -1}, Range{0, 0}, e.a0, amax,
 				func(q int) rune { return t.ReadC(q) }, false)
 			return true
-		} else {
-			r = t.DirName(string([]rune(r)[:nname]))
 		}
+		r = t.DirName(string([]rune(r)[:nname]))
 	}
 	e.bname = r
 	// if it's already a window name, it's a file
@@ -622,9 +621,8 @@ func expand(t *Text, q0 int, q1 int) (Expand, bool) {
 	e.agetc = func(q int) rune {
 		if q < t.Nc() {
 			return t.ReadC(q)
-		} else {
-			return 0
 		}
+		return 0
 	}
 
 	// if in selection, choose selection

--- a/row_test.go
+++ b/row_test.go
@@ -13,11 +13,11 @@ type loadfontstest struct {
 	val   string
 }
 
-const short_file = `/Users/rjkroege/tools/gopkg/src/github.com/rjkroege/edwood
+const shortFile = `/Users/rjkroege/tools/gopkg/src/github.com/rjkroege/edwood
 /mnt/font/GoRegular/13a/font
 `
 
-const full_file = `/Users/rjkroege/tools/gopkg/src/github.com/rjkroege/edwood
+const fullFile = `/Users/rjkroege/tools/gopkg/src/github.com/rjkroege/edwood
 /mnt/font/GoRegular/13a/font
 /mnt/font/Iosevka/12a/font
 `
@@ -47,7 +47,7 @@ func TestLoadFonts(t *testing.T) {
 	if err != nil {
 		t.Fatal("TestLoadFonts short_file can't create file:", err)
 	}
-	if _, err := f.WriteString(short_file); err != nil {
+	if _, err := f.WriteString(shortFile); err != nil {
 		t.Fatal("TestLoadFonts short_file can't write file:", err)
 	}
 	f.Close()
@@ -60,7 +60,7 @@ func TestLoadFonts(t *testing.T) {
 	if err != nil {
 		t.Fatal("TestLoadFonts full_file can't create file:", err)
 	}
-	if _, err := f.WriteString(full_file); err != nil {
+	if _, err := f.WriteString(fullFile); err != nil {
 		t.Fatal("TestLoadFonts full_file can't write file:", err)
 	}
 	f.Close()

--- a/text.go
+++ b/text.go
@@ -269,18 +269,18 @@ func (t *Text) Load(q0 int, filename string, setqid bool) (nread int, err error)
 	}
 	if ismtpt(filename) {
 		warning(nil, "will not open self mount point %s\n", filename)
-		return 0, fmt.Errorf("will not open self mount point %s\n", filename)
+		return 0, fmt.Errorf("will not open self mount point %s", filename)
 	}
 	fd, err := os.Open(filename)
 	if err != nil {
 		warning(nil, "can't open %s: %v\n", filename, err)
-		return 0, fmt.Errorf("can't open %s: %v\n", filename, err)
+		return 0, fmt.Errorf("can't open %s: %v", filename, err)
 	}
 	defer fd.Close()
 	d, err := fd.Stat()
 	if err != nil {
 		warning(nil, "can't fstat %s: %v\n", filename, err)
-		return 0, fmt.Errorf("can't fstat %s: %v\n", filename, err)
+		return 0, fmt.Errorf("can't fstat %s: %v", filename, err)
 	}
 
 	q1 := (0)
@@ -289,7 +289,7 @@ func (t *Text) Load(q0 int, filename string, setqid bool) (nread int, err error)
 		/* this is checked in get() but it's possible the file changed underfoot */
 		if len(t.file.text) > 1 {
 			warning(nil, "%s is a directory; can't read with multiple windows on it\n", filename)
-			return 0, fmt.Errorf("%s is a directory; can't read with multiple windows on it\n", filename)
+			return 0, fmt.Errorf("%s is a directory; can't read with multiple windows on it", filename)
 		}
 		t.w.isdir = true
 		t.w.filemenu = false
@@ -301,7 +301,7 @@ func (t *Text) Load(q0 int, filename string, setqid bool) (nread int, err error)
 		dirNames, err := fd.Readdirnames(0)
 		if err != nil {
 			warning(nil, "failed to Readdirnames: %s\n", filename)
-			return 0, fmt.Errorf("failed to Readdirnames: %s\n", filename)
+			return 0, fmt.Errorf("failed to Readdirnames: %s", filename)
 		}
 		for i, dn := range dirNames {
 			s, err := os.Stat(filepath.Join(fd.Name(), dn))
@@ -430,9 +430,8 @@ func (t *Text) BsInsert(q0 int, r []rune, tofile bool) (q, nrp int) {
 			t.Insert(q0, tp[:n], tofile)
 			nrp = n
 			return q0, nrp
-		} else {
-			bp++
 		}
+		bp++
 	}
 	t.Insert(q0, r, tofile)
 	nrp = n
@@ -756,12 +755,12 @@ func (t *Text) Type(r rune) {
 		return
 	}
 
-	case_Down := func() {
+	caseDown := func() {
 		q0 = t.org + t.fr.Charofpt(image.Pt(t.fr.Rect().Min.X, t.fr.Rect().Min.Y+n*t.fr.DefaultFontHeight()))
 		t.SetOrigin(q0, true)
 		return
 	}
-	case_Up := func() {
+	caseUp := func() {
 		q0 = t.Backnl(t.org, n)
 		t.SetOrigin(q0, true)
 		return
@@ -798,7 +797,7 @@ func (t *Text) Type(r rune) {
 			return
 		}
 		n = t.fr.GetFrameFillStatus().Maxlines / 3
-		case_Down()
+		caseDown()
 		return
 	case Kscrollonedown:
 		if t.what == Tag {
@@ -809,11 +808,11 @@ func (t *Text) Type(r rune) {
 		if n <= 0 {
 			n = 1
 		}
-		case_Down()
+		caseDown()
 		return
 	case draw.KeyPageDown:
 		n = 2 * t.fr.GetFrameFillStatus().Maxlines / 3
-		case_Down()
+		caseDown()
 		return
 	case draw.KeyUp:
 		if t.what == Tag {
@@ -821,7 +820,7 @@ func (t *Text) Type(r rune) {
 			return
 		}
 		n = t.fr.GetFrameFillStatus().Maxlines / 3
-		case_Up()
+		caseUp()
 		return
 	case Kscrolloneup:
 		if t.what == Tag {
@@ -829,11 +828,11 @@ func (t *Text) Type(r rune) {
 			return
 		}
 		n = mousescrollsize(t.fr.GetFrameFillStatus().Maxlines)
-		case_Up()
+		caseUp()
 		return
 	case draw.KeyPageUp:
 		n = 2 * t.fr.GetFrameFillStatus().Maxlines / 3
-		case_Up()
+		caseUp()
 		return
 	case draw.KeyHome:
 		t.TypeCommit()

--- a/texter.go
+++ b/texter.go
@@ -17,7 +17,7 @@ type Texter interface {
 	View(q0, q1 int) []byte // Return a "read only" slice
 }
 
-// TestText implements Texter around a buffer
+// TextBuffer implements Texter around a buffer.
 type TextBuffer struct {
 	q0, q1 int
 	buf    []rune

--- a/wind.go
+++ b/wind.go
@@ -74,8 +74,8 @@ func (w *Window) initHeadless(clone *Window) *Window {
 	w.tagexpand = true
 	w.body.w = w
 	w.incl = []string{}
-	WinId++
-	w.id = WinId
+	WinID++
+	w.id = WinID
 	w.ref.Inc()
 	if globalincref {
 		w.ref.Inc()
@@ -145,7 +145,7 @@ func (w *Window) Init(clone *Window, r image.Rectangle, dis *draw.Display) {
 	}
 	w.body.Init(r1, rf, textcolors, w.display)
 	w.body.what = Body
-	r1.Min.Y -= 1
+	r1.Min.Y--
 	r1.Max.Y = r1.Min.Y + 1
 	if w.display != nil {
 		w.display.ScreenImage.Draw(r1, tagcolors[frame.ColBord], nil, image.ZP)


### PR DESCRIPTION
These are the simple ones. There are more.

Common lints include:
* Not making use of type inference
* Underscore in identifier name
* Receiver name is not consistent
* Simplify `if` statements where the `else` part can be removed
* Use `foo++` instead of `foo += 1`; similarly for `foo--`
* Errors should not have a newline at the end