### PR TITLE
Make signal handling portable

### DIFF
--- a/fsys.go
+++ b/fsys.go
@@ -114,7 +114,7 @@ func fsysproc() {
 	for {
 		fc, err := plan9.ReadFcall(sfd)
 		if err != nil || fc == nil {
-			acmeerror("fsysproc: ", err)
+			acmeerror("fsysproc", err)
 		}
 		if x == nil {
 			cxfidalloc <- nil

--- a/signal_plan9.go
+++ b/signal_plan9.go
@@ -1,0 +1,18 @@
+// +build plan9
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+var ignoreSignals = []os.Signal{
+	syscall.Note("sys: write on closed pipe"),
+}
+
+var hangupSignals = []os.Signal{
+	syscall.SIGINT,
+	syscall.SIGTERM,
+	syscall.SIGHUP,
+}

--- a/signal_unix.go
+++ b/signal_unix.go
@@ -1,0 +1,21 @@
+// +build darwin dragonfly freebsd linux netbsd openbsd solaris
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+var ignoreSignals = []os.Signal{
+	syscall.SIGPIPE,
+	syscall.SIGTTIN,
+	syscall.SIGTTOU,
+	syscall.SIGTSTP,
+}
+
+var hangupSignals = []os.Signal{
+	syscall.SIGINT,
+	syscall.SIGTERM,
+	syscall.SIGHUP,
+}

--- a/signal_windows.go
+++ b/signal_windows.go
@@ -1,0 +1,18 @@
+// +build windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+var ignoreSignals = []os.Signal{
+	syscall.SIGPIPE,
+}
+
+var hangupSignals = []os.Signal{
+	syscall.SIGINT,
+	syscall.SIGTERM,
+	syscall.SIGHUP,
+}


### PR DESCRIPTION
Plan9port and Plan 9 acme handles these signal:

```
char *oknotes[] ={
	"delete",
	"hangup",	// SIGHUP
	"kill",		// SIGTERM
	"exit",
	nil
};
```

I'm not sure what generates the "delete" and "exit" signals, but SIGTERM
was missing from Edwood's list, so I've added that. SIGQUIT is useful
for debugging a Go program (typing ctrl-\ will print stack trace of all
running goroutines), so I removed that. SIGSTOP cannot be handled, so
that was also removed.

Edwood was ignoring all other signals, which seems wrong. I made it so
it'll only ignore what plan9port acme was ignoring:

```
char *ignotes[] = {
	"sys: write on closed pipe",	// SIGPIPE
	"sys: ttin",	// SIGTTIN
	"sys: ttou",	// SIGTTOU
	"sys: tstp",	// SIGTSTP
	nil
};
```

Helps #115
Helps #116