### PR TITLE
Short term mitigation for column blackness #52

### DIFF
--- a/col.go
+++ b/col.go
@@ -104,14 +104,8 @@ func (c *Column) Add(w, clone *Window, y int) *Window {
 		v = c.w[c.nw()-1]
 		y = v.body.fr.Rect().Min.Y + v.body.fr.Rect().Dx()/2
 	}
+
 	// Which window will we land on?
-// 	var windex int
-// 	for windex = 0; windex < len(c.w); windex++ {
-// 		v = c.w[windex]
-// 		if y < v.r.Max.Y {
-// 			break
-// 		}
-// 	}
 	var windex int
 	windex, v = c.findWindowContainingY(y)
 

--- a/col.go
+++ b/col.go
@@ -439,7 +439,7 @@ func (c *Column) Grow(w *Window, but int) {
 			}
 		}
 
-		for i, _ := range nl {
+		for i := range nl {
 			if nl[i] == 0 {
 				nl[i]++
 				nl[maxindex]--

--- a/col.go
+++ b/col.go
@@ -115,13 +115,16 @@ func (c *Column) Add(w, clone *Window, y int) *Window {
 		if windex < c.nw() {
 			windex++
 		}
-		//
-		// if landing window (v) is too small, grow it first.
-		//
+
+		// if landing window (v) is too small, grow it first (landing window
+		// will be split to accomodate the newly added window.)
+		// minht is the height of the first line of the tag and the border thickness
+		// TODO(rjk): Make minht a method of the tag to simplify variable height fonts.
 		minht := v.tag.fr.DefaultFontHeight() + c.display.ScaleSize(Border) + 1
 		j := 0
-		ffs := v.body.fr.GetFrameFillStatus()
-		for !c.safe || ffs.Maxlines < 3 || v.body.all.Dy() <= minht {
+	//	ffs := v.body.fr.GetFrameFillStatus()
+		// TODO(rjk): Why don't we recompute the ffs? hypothesis: we need to remeasure?
+		for !c.safe ||  v.body.fr.GetFrameFillStatus().Maxlines < 3 || v.body.all.Dy() <= minht {
 			j++
 			if j > 10 {
 				buggered = true // Too many windows in column
@@ -130,10 +133,7 @@ func (c *Column) Add(w, clone *Window, y int) *Window {
 			c.Grow(v, 1)
 		}
 
-		//
 		// figure out where to split v to make room for w
-		//
-
 		// new window stops where next window begins
 		var ymax int
 		if windex < c.nw() {
@@ -161,7 +161,7 @@ func (c *Column) Add(w, clone *Window, y int) *Window {
 		}
 		r1 := r
 		y = min(y, ymax-(v.tag.fr.DefaultFontHeight()*v.taglines+v.body.fr.DefaultFontHeight()+c.display.ScaleSize(Border)+1))
-		ffs = v.body.fr.GetFrameFillStatus()
+		ffs := v.body.fr.GetFrameFillStatus()
 		r1.Max.Y = min(y, v.body.fr.Rect().Min.Y+ffs.Nlines*v.body.fr.DefaultFontHeight())
 		r1.Min.Y = v.Resize(r1, false, false)
 		r1.Max.Y = r1.Min.Y + c.display.ScaleSize(Border)

--- a/col.go
+++ b/col.go
@@ -122,8 +122,8 @@ func (c *Column) Add(w, clone *Window, y int) *Window {
 		// TODO(rjk): Make minht a method of the tag to simplify variable height fonts.
 		minht := v.tag.fr.DefaultFontHeight() + c.display.ScaleSize(Border) + 1
 		j := 0
-	//	ffs := v.body.fr.GetFrameFillStatus()
-		// TODO(rjk): Why don't we recompute the ffs? hypothesis: we need to remeasure?
+		// Code inspection suggests that the frame fill status may have altered
+		// after resizing.
 		for !c.safe ||  v.body.fr.GetFrameFillStatus().Maxlines < 3 || v.body.all.Dy() <= minht {
 			j++
 			if j > 10 {

--- a/col.go
+++ b/col.go
@@ -109,7 +109,7 @@ func (c *Column) Add(w, clone *Window, y int) *Window {
 	var windex int
 	windex, v = c.findWindowContainingY(y)
 
- 	// TODO(rjk): be polite. :-)
+	// TODO(rjk): be polite. :-)
 	buggered := false // historical variable name
 	if c.nw() > 0 {
 		if windex < c.nw() {
@@ -124,7 +124,7 @@ func (c *Column) Add(w, clone *Window, y int) *Window {
 		j := 0
 		// Code inspection suggests that the frame fill status may have altered
 		// after resizing.
-		for !c.safe ||  v.body.fr.GetFrameFillStatus().Maxlines < 3 || v.body.all.Dy() <= minht {
+		for !c.safe || v.body.fr.GetFrameFillStatus().Maxlines < 3 || v.body.all.Dy() <= minht {
 			j++
 			if j > 10 {
 				buggered = true // Too many windows in column
@@ -425,9 +425,9 @@ func (c *Column) Grow(w *Window, but int) {
 				dnl -= l
 			}
 		}
-		
+
 		// This is an egregious hack. It's an experiment for #52
-		// 0 lines is not being handled correctly elsewhere so try to 
+		// 0 lines is not being handled correctly elsewhere so try to
 		// find the largest and use it to force the 0s to 1s.
 		// 1. find index with max
 		maxindex := -1
@@ -441,8 +441,8 @@ func (c *Column) Grow(w *Window, but int) {
 
 		for i, _ := range nl {
 			if nl[i] == 0 {
-				nl[i] ++
-				nl[maxindex] --
+				nl[i]++
+				nl[maxindex]--
 			}
 		}
 	}


### PR DESCRIPTION
The column blackness bug #52 is caused when `Window` objects are sized to 0 body lines (with an implied collapsing of the tag to 1 line of text.) Preventing sizing to 0 body lines prevents column blackness. So helps #52 but more work remains.