### PR TITLE
Fix column blackness

### DIFF
--- a/col.go
+++ b/col.go
@@ -425,26 +425,6 @@ func (c *Column) Grow(w *Window, but int) {
 				dnl -= l
 			}
 		}
-
-		// This is an egregious hack. It's an experiment for #52
-		// 0 lines is not being handled correctly elsewhere so try to
-		// find the largest and use it to force the 0s to 1s.
-		// 1. find index with max
-		maxindex := -1
-		maxval := 0
-		for i, nlv := range nl {
-			if nlv > maxval {
-				maxindex = i
-				maxval = nlv
-			}
-		}
-
-		for i := range nl {
-			if nl[i] == 0 {
-				nl[i]++
-				nl[maxindex]--
-			}
-		}
 	}
 Pack:
 	ny := make([]int, c.nw())
@@ -461,7 +441,7 @@ Pack:
 		if nl[j] != 0 {
 			r.Max.Y += 1 + nl[j]*v.body.fr.DefaultFontHeight()
 		}
-		r.Min.Y = v.Resize(r, c.safe, false)
+		r.Min.Y = v.Resize(r, false, false)
 		r.Max.Y += c.display.ScaleSize(Border)
 		c.display.ScreenImage.Draw(r, c.display.Black, nil, image.ZP)
 		y1 = r.Max.Y
@@ -488,7 +468,7 @@ Pack:
 		r.Max.Y = r.Min.Y + w.tagtop.Dy() + 1 + h + c.display.ScaleSize(Border)
 	}
 	// draw window
-	r.Max.Y = w.Resize(r, c.safe, true)
+	r.Max.Y = w.Resize(r, false, true)
 	if windex < c.nw()-1 {
 		r.Min.Y = r.Max.Y
 		r.Max.Y += c.display.ScaleSize(Border)
@@ -507,7 +487,7 @@ Pack:
 		if nl[j] != 0 {
 			r.Max.Y += 1 + nl[j]*v.body.fr.DefaultFontHeight()
 		}
-		y1 = v.Resize(r, c.safe, j == c.nw()-1)
+		y1 = v.Resize(r, false, j == c.nw()-1)
 		if j < c.nw()-1 { // no border on last window
 			r.Min.Y = y1
 			r.Max.Y += c.display.ScaleSize(Border)

--- a/wind.go
+++ b/wind.go
@@ -205,6 +205,7 @@ func (w *Window) moveToDel() {
 	}
 }
 
+// TagLines computes the number of lines in the tag that can fit in r.
 func (w *Window) TagLines(r image.Rectangle) int {
 	if !w.tagexpand && !w.showdel {
 		return 1
@@ -242,10 +243,20 @@ func (w *Window) TagLines(r image.Rectangle) int {
 	return n
 }
 
+// Resize the specified Window to rectangle r.
+// TODO(rjk): when collapsing the tag, this is called twice. Once would seem
+// sufficient.
+// TODO(rjk): This function does not appear to update the Window's rect correctly
+// in all cases.
 func (w *Window) Resize(r image.Rectangle, safe, keepextra bool) int {
+	// log.Printf("Window.Resize r=%v safe=%v keepextra=%v\n", r, safe, keepextra)
+	// defer log.Println("Window.Resize End\n")
+
+	// TODO(rjk): Do not leak global event state into this function.
 	mouseintag := mouse.Point.In(w.tag.all)
 	mouseinbody := mouse.Point.In(w.body.all)
 
+	// Tagtop is a rectangle corresponding to one line of tag.
 	w.tagtop = r
 	w.tagtop.Max.Y = r.Min.Y + fontget(tagfont, w.display).Height
 
@@ -308,6 +319,8 @@ func (w *Window) Resize(r image.Rectangle, safe, keepextra bool) int {
 		w.body.all.Min.Y = oy
 	}
 	w.maxlines = min(w.body.fr.GetFrameFillStatus().Nlines, max(w.maxlines, w.body.fr.GetFrameFillStatus().Maxlines))
+	// TODO(rjk): this value doesn't make sense when we've collapsed
+	// the tag if the rectangle update block is not executed.
 	return w.r.Max.Y
 }
 


### PR DESCRIPTION
Fix column blackness bug #52 in a way that correctly preserves tag
collapsing behaviour. Note that there appear to remain issues in the
implementation of Window.Resize that could do with additional
investigation.