### PR TITLE
Add trailing space to default row/col tag

### DIFF
--- a/col.go
+++ b/col.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	Lheader = []rune("New Cut Paste Snarf Sort Zerox Delcol")
+	Lheader = []rune("New Cut Paste Snarf Sort Zerox Delcol ")
 )
 
 type Column struct {

--- a/row.go
+++ b/row.go
@@ -46,7 +46,7 @@ func (row *Row) Init(r image.Rectangle, dis *draw.Display) *Row {
 	r1.Min.Y = r1.Max.Y
 	r1.Max.Y += row.display.ScaleSize(Border)
 	row.display.ScreenImage.Draw(r1, row.display.Black, nil, image.ZP)
-	t.Insert(0, []rune("Newcol Kill Putall Dump Exit"), true)
+	t.Insert(0, []rune("Newcol Kill Putall Dump Exit "), true)
 	t.SetSelect(t.file.b.Nc(), t.file.b.Nc())
 	return row
 }


### PR DESCRIPTION
This is now consistent with p9p acme.