### PR TITLE
Remove replicated window putseq

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -591,7 +591,7 @@ func putfile(f *File, q0 int, q1 int, name string) {
 			w.dirty = false
 			f.unread = false
 		}
-		
+
 		f.SnapshotSeq()
 		for _, u := range f.text {
 			u.w.dirty = w.dirty

--- a/exec.go
+++ b/exec.go
@@ -591,8 +591,9 @@ func putfile(f *File, q0 int, q1 int, name string) {
 			w.dirty = false
 			f.unread = false
 		}
+		
+		f.SnapshotSeq()
 		for _, u := range f.text {
-			u.w.putseq = f.seq
 			u.w.dirty = w.dirty
 		}
 	}

--- a/file.go
+++ b/file.go
@@ -26,6 +26,7 @@ type File struct {
 	unread    bool
 	editclean bool
 	seq       int
+	putseq int		// seq on last put
 	mod       bool
 
 	// Observer pattern: many Text instances can share a File.
@@ -54,6 +55,16 @@ func (f *File) Load(q0 int, fd *os.File, sethash bool) (n int, hasNulls bool, er
 		f.hash = h
 	}
 	return n, hasNulls, err
+}
+
+// SnapshotSeq saves the current seq to putseq. Call this on Put actions.
+func (f *File) SnapshotSeq() {
+	f.putseq = f.seq
+}
+
+// SeqDiffer returns true if the current seq differs from a previously snapshot.
+func (f *File) SeqDiffer() bool {
+	return f.seq != f.putseq
 }
 
 func HashFile(filename string) (h FileHash, err error) {

--- a/file.go
+++ b/file.go
@@ -26,7 +26,7 @@ type File struct {
 	unread    bool
 	editclean bool
 	seq       int
-	putseq int		// seq on last put
+	putseq    int // seq on last put
 	mod       bool
 
 	// Observer pattern: many Text instances can share a File.

--- a/wind.go
+++ b/wind.go
@@ -44,7 +44,6 @@ type Window struct {
 	maxlines    int
 	dirnames    []string
 	widths      []int
-	putseq      int
 	incl        []string
 	reffont     *draw.Font
 	ctrllock    *sync.Mutex
@@ -398,7 +397,7 @@ func (w *Window) Undo(isundo bool) {
 	f := body.file
 	for _, text := range f.text {
 		v := text.w
-		v.dirty = (f.seq != v.putseq)
+		v.dirty = f.SeqDiffer()
 		if v != w {
 			v.body.q0 = (getP0(v.body.fr)) + v.body.org
 			v.body.q1 = (getP1(v.body.fr)) + v.body.org
@@ -508,7 +507,7 @@ func (w *Window) SetTag1() {
 		if len(w.body.file.epsilon) > 0 {
 			sb.WriteString(Lredo)
 		}
-		dirty := w.body.file.name != "" && (len(w.body.cache) != 0 || w.body.file.seq != w.putseq)
+		dirty := w.body.file.name != "" && (len(w.body.cache) != 0 || w.body.file.SeqDiffer())
 		if !w.isdir && dirty {
 			sb.WriteString(Lput)
 		}


### PR DESCRIPTION
The `putseq` is a per-file concept but replicated in every window. Move
`putseq` into `File`