### PR TITLE
Fix editout locking in file server and Edit command

### DIFF
--- a/dat.go
+++ b/dat.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"runtime/debug"
 	"strings"
-	"sync"
 	"unicode/utf8"
 
 	"9fans.net/go/draw"
@@ -137,7 +136,7 @@ var (
 	cedit      chan int
 	cwarn      chan uint
 
-	editoutlk *sync.Mutex
+	editoutlk = make(chan bool, 1)
 
 	WinID = 0
 )

--- a/fsys_test.go
+++ b/fsys_test.go
@@ -344,6 +344,17 @@ func TestFSys(t *testing.T) {
 			t.Errorf("Failed to write dumpdir %q: %v\n", dumpdir, err)
 		}
 	})
+	t.Run("WriteEditout", func(t *testing.T) {
+		fid, err := fsys.Open("/editout", plan9.OWRITE)
+		if err != nil {
+			t.Fatalf("failed to open /editout: %v", err)
+		}
+		defer fid.Close()
+		_, err = fid.Write([]byte("hello\n"))
+		if err == nil || err.Error() != Eperm.Error() {
+			t.Fatalf("write to editout returned %v; expected %v", err, Eperm)
+		}
+	})
 }
 
 func TestFSysAddr(t *testing.T) {

--- a/wind.go
+++ b/wind.go
@@ -58,7 +58,7 @@ type Window struct {
 	tagexpand   bool
 	taglines    int
 	tagtop      image.Rectangle
-	editoutlk   *sync.Mutex
+	editoutlk   chan bool
 }
 
 func NewWindow() *Window {
@@ -102,6 +102,7 @@ func (w *Window) initHeadless(clone *Window) *Window {
 	if clone != nil {
 		w.autoindent = clone.autoindent
 	}
+	w.editoutlk = make(chan bool, 1)
 	return w
 }
 


### PR DESCRIPTION
- This gets `Edit |cmd` and `Edit <cmd` working
- The Mutex wasn't even allocated because it was declared as a pointer