### PR TITLE
Update Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,18 @@
 sudo: false
 language: go
+go_import_path: github.com/rjkroege/edwood
 
 go:
-  - 1.10.3
+  - "1.10.x"
+  - "1.11.x"
 
 install:
   - # Do nothing. This is needed to prevent default install action "go get -t -v ./..." from happening here (we want it to happen inside script step).
 
 env:
-  - acmeshell=sh
+  global:
+    - acmeshell=sh
+    - GO111MODULE=on
 
 script:
   - go get -t -v ./...


### PR DESCRIPTION
- Test module build in Go 1.11
- Set import path so that forks (e.g. github.com/fhs/edwood) can build
  in travis with internal package `internal/regexp`. This is only needed
  for Go 1.10. The import path is specified in go.mod file for Go 1.11.