### PR TITLE
Remove redundant breaks and returns

### DIFF
--- a/acme.go
+++ b/acme.go
@@ -299,7 +299,7 @@ func mousethread(display *draw.Display) {
 		case mousectl.Mouse = <-mousectl.C:
 			MovedMouse(mousectl.Mouse)
 		case <-cwarn:
-			break
+			// Do nothing
 		case pm := <-cplumb:
 			if pm.Type == "text" {
 				act := findattr(pm.Attr, "action")
@@ -441,7 +441,6 @@ func MovedMouse(m draw.Mouse) {
 		}
 		return
 	}
-	return
 }
 
 func keyboardthread(display *draw.Display) {
@@ -630,7 +629,6 @@ func xfidallocthread(d *draw.Display) {
 		case x := <-cxfidfree:
 			x.next = xfree
 			xfree = x
-			break
 		}
 	}
 

--- a/addr.go
+++ b/addr.go
@@ -96,7 +96,6 @@ func number(showerr bool, t Texter, r Range, line int, dir int, size int) (Range
 		if line > 0 {
 			goto Rescue
 		}
-		break
 	case Fore:
 		if q1 > 0 {
 			for q1 < t.Nc() && t.ReadC(q1-1) != '\n' {
@@ -119,7 +118,6 @@ func number(showerr bool, t Texter, r Range, line int, dir int, size int) (Range
 		if line > 0 {
 			goto Rescue
 		}
-		break
 	case Back:
 		if q0 < t.Nc() {
 			for q0 > 0 && t.ReadC(q0-1) != '\n' {
@@ -246,7 +244,6 @@ func address(showerr bool, t Texter, lim Range, ar Range, q0 int, q1 int, getc f
 				r, evalp = number(showerr, t, r, 1, int(prevc), Line) // do previous one
 			}
 			dir = int(c)
-			break
 		case c == '.':
 			fallthrough
 		case c == '$':
@@ -265,7 +262,6 @@ func address(showerr bool, t Texter, lim Range, ar Range, q0 int, q1 int, getc f
 			} else {
 				dir = None
 			}
-			break
 		case c == '#':
 			if q == q1 {
 				return r, evalp, q - 1
@@ -302,7 +298,6 @@ func address(showerr bool, t Texter, lim Range, ar Range, q0 int, q1 int, getc f
 			}
 			dir = None
 			size = Line
-			break
 		case c == '?':
 			dir = Back
 			fallthrough
@@ -322,7 +317,6 @@ func address(showerr bool, t Texter, lim Range, ar Range, q0 int, q1 int, getc f
 					}
 					c = getc(q)
 					q++
-					break
 				case '/':
 					goto out
 				}
@@ -334,7 +328,6 @@ func address(showerr bool, t Texter, lim Range, ar Range, q0 int, q1 int, getc f
 			}
 			dir = None
 			size = Line
-			break
 		}
 	}
 	if evalp && dir != None {

--- a/ecmd.go
+++ b/ecmd.go
@@ -101,7 +101,6 @@ func cmdexec(t *Text, cp *Cmd) bool {
 			t.q1 = dot.r.q1
 			cmdexec(t, cp)
 		}
-		break
 	default:
 		if i < 0 {
 			editerror("unknown command %c in cmdexec", cp.cmdc)
@@ -627,7 +626,6 @@ func eq_cmd(t *Text, cp *Cmd) bool {
 	switch len(cp.text) {
 	case 0:
 		mode = PosnLine
-		break
 	case 1:
 		if cp.text[0] == '#' {
 			mode = PosnChars
@@ -997,7 +995,6 @@ func cmdaddress(ap *Addr, a Address, sign int) Address {
 			if ap.next == nil || ap.next.typ == '+' || ap.next.typ == '-' {
 				a = lineaddr(1, a, sign)
 			}
-			break
 		default:
 			acmeerror("cmdaddress", nil)
 			return a

--- a/edit.go
+++ b/edit.go
@@ -647,7 +647,6 @@ func simpleaddr() *Addr {
 				nap.next = addr.next
 				addr.next = nap
 			}
-			break
 		case '+':
 			fallthrough
 		case '-':

--- a/exec.go
+++ b/exec.go
@@ -587,7 +587,6 @@ func putfile(f *File, q0 int, q1 int, name string) {
 	}
 
 	w.SetTag()
-	return
 }
 
 func put(et *Text, _0 *Text, argt *Text, _1 bool, _2 bool, arg string) {

--- a/file.go
+++ b/file.go
@@ -318,7 +318,6 @@ func (f *File) Undo(isundo bool) (q0p, q1p int) {
 			} else {
 				f.name = string(u.buf)
 			}
-			break
 		}
 		(*delta) = (*delta)[0 : len(*delta)-1]
 	}

--- a/text.go
+++ b/text.go
@@ -738,7 +738,6 @@ func (t *Text) Type(r rune) {
 			t.w.tagexpand = true
 			t.w.Resize(t.w.r, false, true)
 		}
-		return
 	}
 
 	Tagup := func() {
@@ -748,18 +747,15 @@ func (t *Text) Type(r rune) {
 			t.w.taglines = 1
 			t.w.Resize(t.w.r, false, true)
 		}
-		return
 	}
 
 	caseDown := func() {
 		q0 = t.org + t.fr.Charofpt(image.Pt(t.fr.Rect().Min.X, t.fr.Rect().Min.Y+n*t.fr.DefaultFontHeight()))
 		t.SetOrigin(q0, true)
-		return
 	}
 	caseUp := func() {
 		q0 = t.Backnl(t.org, n)
 		t.SetOrigin(q0, true)
-		return
 	}
 
 	switch r {
@@ -929,7 +925,7 @@ func (t *Text) Type(r rune) {
 			return
 		}
 		nr = len(rp) // runestrlen(rp);
-		break        // fall through to normal insertion case
+		// break into normal insertion case
 	case 0x1B:
 		if t.eq0 != ^0 {
 			if t.eq0 <= t.q0 {

--- a/wind.go
+++ b/wind.go
@@ -624,7 +624,6 @@ func (w *Window) AddIncl(r string) {
 		}
 	}
 	w.incl = append(w.incl, r)
-	return
 }
 
 // Clean returns true iff w can be treated as unmodified.

--- a/xfid.go
+++ b/xfid.go
@@ -183,7 +183,6 @@ func xfidopen(x *Xfid) {
 				return
 			}
 			w.wrselrange = Range{t.q1, t.q1}
-			break
 		}
 		w.Unlock()
 	} else {
@@ -235,7 +234,6 @@ func xfidclose(x *Xfid) {
 				w.ctlfid = MaxFid
 				w.ctrllock.Unlock()
 			}
-			break
 		case QWdata:
 			fallthrough
 		case QWxdata:
@@ -258,20 +256,16 @@ func xfidclose(x *Xfid) {
 					w.dumpdir = ""
 				}
 			}
-			break
 		case QWrdsel:
 			w.rdselfd.Close()
 			w.rdselfd = nil
-			break
 		case QWwrsel:
 			w.nomark = false
 			t = &w.body
 			t.Show(min((w.wrselrange.q0), t.Nc()), min((w.wrselrange.q1), t.Nc()), true)
 			t.ScrDraw(t.fr.GetFrameFillStatus().Nchars)
-			break
 		case QWeditout:
 			<-w.editoutlk
-			break
 		}
 		w.Close()
 		w.Unlock()
@@ -279,7 +273,6 @@ func xfidclose(x *Xfid) {
 		switch q {
 		case Qeditout:
 			<-editoutlk
-			break
 		}
 	}
 	respond(x, &fc, nil)
@@ -309,7 +302,6 @@ func xfidread(x *Xfid) {
 			return
 		default:
 			warning(nil, "unknown qid %d\n", q)
-			break
 		}
 		respond(x, &fc, nil)
 		return
@@ -521,7 +513,6 @@ func xfidwrite(x *Xfid) {
 		w.addr = a
 		fc.Count = x.fcall.Count
 		respond(x, &fc, nil)
-		break
 
 	case Qeditout:
 		fallthrough
@@ -538,7 +529,6 @@ func xfidwrite(x *Xfid) {
 		}
 		fc.Count = x.fcall.Count
 		respond(x, &fc, nil)
-		break
 
 	case QWerrors:
 		w = errorwinforwin(w)
@@ -553,7 +543,6 @@ func xfidwrite(x *Xfid) {
 
 	case QWctl:
 		xfidctlwrite(x, w)
-		break
 
 	case QWdata:
 		a = w.addr


### PR DESCRIPTION
* These were found by [staticcheck](https://staticcheck.io):
```
$ staticcheck -checks S1023,SA4011
acme.go:302:4: ineffective break statement. Did you mean to break out of the outer loop? (SA4011)
acme.go:444:2: redundant return statement (S1023)
acme.go:633:4: ineffective break statement. Did you mean to break out of the outer loop? (SA4011)
addr.go:99:3: redundant break statement (S1023)
addr.go:122:3: redundant break statement (S1023)
addr.go:249:4: ineffective break statement. Did you mean to break out of the outer loop? (SA4011)
addr.go:249:4: redundant break statement (S1023)
addr.go:268:4: ineffective break statement. Did you mean to break out of the outer loop? (SA4011)
addr.go:268:4: redundant break statement (S1023)
addr.go:305:4: ineffective break statement. Did you mean to break out of the outer loop? (SA4011)
addr.go:305:4: redundant break statement (S1023)
addr.go:325:6: ineffective break statement. Did you mean to break out of the outer loop? (SA4011)
addr.go:325:6: redundant break statement (S1023)
addr.go:337:4: ineffective break statement. Did you mean to break out of the outer loop? (SA4011)
addr.go:337:4: redundant break statement (S1023)
ecmd.go:104:3: redundant break statement (S1023)
ecmd.go:630:3: redundant break statement (S1023)
ecmd.go:1000:4: ineffective break statement. Did you mean to break out of the outer loop? (SA4011)
ecmd.go:1000:4: redundant break statement (S1023)
edit.go:650:4: redundant break statement (S1023)
exec.go:590:2: redundant return statement (S1023)
file.go:321:4: ineffective break statement. Did you mean to break out of the outer loop? (SA4011)
file.go:321:4: redundant break statement (S1023)
text.go:741:3: redundant return statement (S1023)
text.go:751:3: redundant return statement (S1023)
text.go:757:3: redundant return statement (S1023)
text.go:762:3: redundant return statement (S1023)
text.go:932:3: redundant break statement (S1023)
wind.go:627:2: redundant return statement (S1023)
xfid.go:186:4: redundant break statement (S1023)
xfid.go:238:4: redundant break statement (S1023)
xfid.go:261:4: redundant break statement (S1023)
xfid.go:265:4: redundant break statement (S1023)
xfid.go:271:4: redundant break statement (S1023)
xfid.go:274:4: redundant break statement (S1023)
xfid.go:282:4: redundant break statement (S1023)
xfid.go:312:4: redundant break statement (S1023)
xfid.go:524:3: redundant break statement (S1023)
xfid.go:541:3: redundant break statement (S1023)
xfid.go:556:3: redundant break statement (S1023)
```