### PR TITLE
Simplify some code (found by staticcheck)

### DIFF
--- a/addr.go
+++ b/addr.go
@@ -1,5 +1,7 @@
 package main
 
+import "strings"
+
 const (
 	None = iota
 	Fore = '+'
@@ -13,10 +15,7 @@ const (
 
 // Return if r is valid character in an address
 func isaddrc(r rune) bool {
-	if utfrune([]rune("0123456789+-/$.#,;?"), r) != -1 {
-		return true
-	}
-	return false
+	return strings.ContainsRune("0123456789+-/$.#,;?", r)
 }
 
 // quite hard: could be almost anything but white space, but we are a little conservative,

--- a/elog.go
+++ b/elog.go
@@ -87,7 +87,7 @@ func (e *Elog) secondlast() *ElogOperation {
 
 func (eo *ElogOperation) setr(r []rune) {
 	if eo.r == nil || cap(eo.r) < len(r) {
-		eo.r = make([]rune, len(r), len(r))
+		eo.r = make([]rune, len(r))
 	} else {
 		eo.r = eo.r[0:len(r)]
 	}

--- a/exec.go
+++ b/exec.go
@@ -416,7 +416,7 @@ func getname(t *Text, argt *Text, arg string, isput bool) string {
 			// if are doing a Put, want to synthesize name even for non-existent file
 			// best guess is that file name doesn't contain a slash
 			promote = true
-			if strings.Index(r, "/") != -1 {
+			if strings.ContainsRune(r, '/') {
 				t = argt
 				arg = r
 			}

--- a/exec_test.go
+++ b/exec_test.go
@@ -10,11 +10,8 @@ func acmeTestingMain() {
 	cwait = make(chan *os.ProcessState)
 	cerr = make(chan error)
 	go func() {
-		for {
-			select {
-			case <-cerr:
-				// Do nothing with command output.
-			}
+		for range cerr {
+			// Do nothing with command output.
 		}
 	}()
 }

--- a/file.go
+++ b/file.go
@@ -93,7 +93,7 @@ func (h *FileHash) Set(b []byte) {
 }
 
 func (h FileHash) Eq(h1 FileHash) bool {
-	return bytes.Compare(h[:], h1[:]) == 0
+	return bytes.Equal(h[:], h1[:])
 }
 
 func calcFileHash(b []byte) FileHash {

--- a/fsys_test.go
+++ b/fsys_test.go
@@ -410,10 +410,10 @@ Occasion
 	tfs.Write("/new/body", text)
 
 	op := <-reportchan
-	for strings.Index(op, "focus") != -1 {
+	for strings.Contains(op, "focus") {
 		op = <-reportchan
 	}
-	if strings.Index(op, "new") == -1 {
+	if !strings.Contains(op, "new") {
 		t.Fatalf("Didn't get report of window creation.")
 	}
 

--- a/look.go
+++ b/look.go
@@ -82,7 +82,7 @@ func look3(t *Text, q0 int, q1 int, external bool) {
 	e, expanded = expand(t, q0, q1)
 	if !external && t.w != nil && t.w.nopen[QWevent] > 0 {
 		// send alphanumeric expansion to external client
-		if expanded == false {
+		if !expanded {
 			return
 		}
 		f = 0
@@ -182,7 +182,7 @@ func look3(t *Text, q0 int, q1 int, external bool) {
 		}
 	}
 	// interpret alphanumeric string ourselves
-	if expanded == false {
+	if !expanded {
 		return
 	}
 	if e.name != "" || e.at != nil {
@@ -755,11 +755,11 @@ func openfile(t *Text, e *Expand) *Window {
 			eval = false
 			warning(nil, "addresses out of order\n")
 		}
-		if eval == false {
+		if !eval {
 			e.jump = false // don't jump if invalid address
 		}
 	}
-	if eval == false {
+	if !eval {
 		r.q0 = t.q0
 		r.q1 = t.q1
 	}

--- a/row.go
+++ b/row.go
@@ -416,7 +416,7 @@ func (r *Row) Dump(file string) {
 					0, 0,
 					100.0*float64(w.r.Min.Y-c.r.Min.Y)/float64(c.r.Dy()),
 					fontname)
-			} else if w.body.file.Dirty() == false && access(t.file.name) || w.isdir {
+			} else if !w.body.file.Dirty() && access(t.file.name) || w.isdir {
 				dumped = false
 				t.file.dumpid = w.id
 				fmt.Fprintf(b, "f%11d %11d %11d %11d %11.7f %s\n", i, w.id,

--- a/util.go
+++ b/util.go
@@ -200,10 +200,7 @@ func errorwinforwin(w *Window) *Window {
 	if dir == "." { // sigh
 		dir = ""
 	}
-	incl = []string{}
-	for _, in := range w.incl {
-		incl = append(incl, in)
-	}
+	incl = append(incl, w.incl...)
 	owner = w.owner
 	w.Unlock()
 	for {

--- a/wind.go
+++ b/wind.go
@@ -611,14 +611,14 @@ func (w *Window) AddIncl(r string) {
 	// Tries to open absolute paths, and if fails, tries
 	// to use dirname instead.
 	d, err := isDir(r)
-	if d == false {
+	if !d {
 		if filepath.IsAbs(r) {
 			warning(nil, "%s: Not a directory: %v", r, err)
 			return
 		}
 		r = string(dirname(&w.body, []rune(r)))
 		d, err := isDir(r)
-		if d == false {
+		if !d {
 			warning(nil, "%s: Not a directory: %v", r, err)
 			return
 		}

--- a/xfid.go
+++ b/xfid.go
@@ -41,17 +41,12 @@ func clampaddr(w *Window) {
 func xfidctl(x *Xfid, d *draw.Display) {
 	// log.Println("xfidctl", x)
 	// defer log.Println("done xfidctl")
-	for {
-		select {
-		case f := <-x.c:
-			f(x)
-			if d != nil {
-				d.Flush()
-			} // d here is for testability.
-			cxfidfree <- x
-			//		case <-exit:
-			//			return
-		}
+	for f := range x.c {
+		f(x)
+		if d != nil {
+			d.Flush()
+		} // d here is for testability.
+		cxfidfree <- x
 	}
 }
 
@@ -216,7 +211,7 @@ func xfidclose(x *Xfid) {
 	w = x.f.w
 	x.f.busy = false
 	x.f.w = nil
-	if x.f.open == false {
+	if !x.f.open {
 		if w != nil {
 			w.Close()
 		}
@@ -463,7 +458,7 @@ func xfidwrite(x *Xfid) {
 			if qid == QWtag {
 				t.Insert(q0, r, true)
 			} else {
-				if w.nomark == false {
+				if !w.nomark {
 					seq++
 					t.file.Mark()
 				}
@@ -553,7 +548,7 @@ func xfidwrite(x *Xfid) {
 			break
 		}
 		r, _, _ := cvttorunes(x.fcall.Data, int(x.fcall.Count))
-		if w.nomark == false {
+		if !w.nomark {
 			seq++
 			t.file.Mark()
 		}


### PR DESCRIPTION
```
$ staticcheck -checks 'S1*'
addr.go:16:2: should use 'return <expr>' instead of 'if <expr> { return <bool> }; return <bool>' (S1008)
elog.go:90:23: should use make([]rune, len(r)) instead (S1019)
exec.go:419:7: should use strings.Contains(r, "/") instead (S1003)
exec_test.go:13:3: should use for range instead of for { select {} } (S1000)
file.go:96:9: should use bytes.Equal(h[:], h1[:]) instead (S1004)
fsys_test.go:413:6: should use strings.Contains(op, "focus") instead (S1003)
fsys_test.go:416:5: should use !strings.Contains(op, "new") instead (S1003)
look.go:85:6: should omit comparison to bool constant, can be simplified to !expanded (S1002)
look.go:185:5: should omit comparison to bool constant, can be simplified to !expanded (S1002)
look.go:758:6: should omit comparison to bool constant, can be simplified to !eval (S1002)
look.go:762:5: should omit comparison to bool constant, can be simplified to !eval (S1002)
row.go:419:14: should omit comparison to bool constant, can be simplified to !w.body.file.Dirty() (S1002)
util.go:204:2: should replace loop with incl = append(incl, w.incl...) (S1011)
wind.go:614:5: should omit comparison to bool constant, can be simplified to !d (S1002)
wind.go:621:6: should omit comparison to bool constant, can be simplified to !d (S1002)
xfid.go:44:2: should use for range instead of for { select {} } (S1000)
xfid.go:219:5: should omit comparison to bool constant, can be simplified to !x.f.open (S1002)
xfid.go:466:8: should omit comparison to bool constant, can be simplified to !w.nomark (S1002)
xfid.go:556:6: should omit comparison to bool constant, can be simplified to !w.nomark (S1002)
```