### PR TITLE
Fix crash when double clicking end of HTML text

### DIFF
--- a/text.go
+++ b/text.go
@@ -1446,8 +1446,10 @@ func (t *Text) ClickMatch(cl, cr rune, dir int, inq int) (q int, r bool) {
 	return inq, cl == '\n' && nest == 1
 }
 
+// ishtmlstart checks whether the text starting at location q an html tag.
+// Returned stat is 1 for <a>, -1 for </a>, 0 for no tag or <a />.
+// Returned q1 is the location after the tag.
 func (t *Text) ishtmlstart(q int) (q1 int, stat int) {
-	Untested()
 	if q+2 > t.file.b.Nc() {
 		return 0, 0
 	}
@@ -1467,17 +1469,19 @@ func (t *Text) ishtmlstart(q int) (q1 int, stat int) {
 		c = t.ReadC(q)
 		q++
 	}
-	if c1 == '/' {
+	if c1 == '/' { // closing tag
 		return q, -1
 	}
-	if c2 == '/' || c2 == '!' {
+	if c2 == '/' || c2 == '!' { // open + close tag or comment
 		return 0, 0
 	}
 	return q, 1
 }
 
+// ishtmlend checks whether the text ending at location q an html tag.
+// Returned stat is 1 for <a>, -1 for </a>, 0 for no tag or <a />.
+// Returned q0 is the start of the tag.
 func (t *Text) ishtmlend(q int) (q1 int, stat int) {
-	Untested()
 	if q < 2 {
 		return 0, 0
 	}
@@ -1497,24 +1501,23 @@ func (t *Text) ishtmlend(q int) (q1 int, stat int) {
 		q--
 		c = t.ReadC(q)
 	}
-	if c1 == '/' {
+	if c1 == '/' { // closing tag
 		return q, -1
 	}
-	if c2 == '/' || c2 == '!' {
+	if c2 == '/' || c2 == '!' { // open + close tag or comment
 		return 0, 0
 	}
 	return q, 1
 }
 
 func (t *Text) ClickHTMLMatch(inq0 int) (q0, q1 int, r bool) {
-	depth := 0
-	q := inq0
 	q0 = inq0
+	q1 = inq0
 
 	// after opening tag?  scan forward for closing tag
-	_, stat := t.ishtmlend(inq0)
-	if stat == 1 {
-		depth = 1
+	if _, stat := t.ishtmlend(q0); stat == 1 {
+		depth := 1
+		q := q1
 		for q < t.file.b.Nc() {
 			nq, n := t.ishtmlstart(q)
 			if n != 0 {
@@ -1530,9 +1533,9 @@ func (t *Text) ClickHTMLMatch(inq0 int) (q0, q1 int, r bool) {
 	}
 
 	// before closing tag?  scan backward for opening tag
-	_, stat = t.ishtmlstart(q)
-	if stat == -1 {
-		depth = -1
+	if _, stat := t.ishtmlstart(q1); stat == -1 {
+		depth := -1
+		q := q0
 		for q > 0 {
 			nq, n := t.ishtmlend(q)
 			if n != 0 {

--- a/text_test.go
+++ b/text_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestClickHTMLMatch(t *testing.T) {
+	tt := []struct {
+		s      string
+		inq0   int
+		q0, q1 int
+		ok     bool
+	}{
+		{"hello world", 0, 0, 0, false},
+		{"<b>hello world", 3, 0, 0, false},
+		{"<b>hello world</b>", 4, 0, 0, false},
+		{"<b>hello world</b>", 13, 0, 0, false},
+		{"<b>hello world</b>", 3, 3, 14, true},
+		{"<b>hello world</b>", 14, 3, 14, true},
+		{"<title>hello 世界</title>", 7, 7, 15, true},
+		{"<p>hello <br /><b>world</b>!</p>", 3, 3, 28, true},
+	}
+
+	for i, tc := range tt {
+		t.Run(fmt.Sprintf("test-%02d", i), func(t *testing.T) {
+			r := []rune(tc.s)
+			text := &Text{
+				file: &File{
+					b: Buffer(r),
+				},
+			}
+			q0, q1, ok := text.ClickHTMLMatch(tc.inq0)
+			switch {
+			case ok != tc.ok:
+				t.Errorf("ClickHTMLMatch of %q at position %v returned %v; expected %v\n",
+					tc.s, tc.inq0, ok, tc.ok)
+
+			case q0 > q1 || q0 < 0 || q1 >= len(r):
+				t.Errorf("ClickHTMLMatch of %q at position %v is %v:%v; expected %v:%v\n",
+					tc.s, tc.inq0, q0, q1, tc.q0, tc.q1)
+
+			case q0 != tc.q0 || q1 != tc.q1:
+				t.Errorf("ClickHTMLMatch of %q at position %v is %q; expected %q\n",
+					tc.s, tc.inq0, r[q0:q1], r[tc.q0:tc.q1])
+			}
+		})
+	}
+}


### PR DESCRIPTION
Double clicking on the rune before the ending tag was returning bad selection:
```
Text.Select: DoubleClick returned 276, 0
panic: acme: textsetselect p0=262 p1=0 q0=276 q1=0 t.org=14 nchars=730

goroutine 66 [running, locked to thread]:
main.(*Text).SetSelect(0xc0002c0128, 0x114, 0x0)
		/home/fhs/go/src/github.com/rjkroege/edwood/text.go:1320 +0x396
main.(*Text).Select(0xc0002c0128)
		/home/fhs/go/src/github.com/rjkroege/edwood/text.go:1134 +0x7db
main.MovedMouse(0x351, 0x216, 0x1, 0x2220bd4b)
		/home/fhs/go/src/github.com/rjkroege/edwood/acme.go:421 +0x47d
main.mousethread(0xc0000cc0c0)
		/home/fhs/go/src/github.com/rjkroege/edwood/acme.go:300 +0x2bb
created by main.main
		/home/fhs/go/src/github.com/rjkroege/edwood/acme.go:172 +0x968
```