### PR TITLE
Fix some staticcheck warnings (including bugs)

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -432,7 +432,7 @@ func getname(t *Text, argt *Text, arg string, isput bool) string {
 	return r
 }
 
-func get(et *Text, t *Text, argt *Text, flag1 bool, _ bool, arg string) {
+func get(et *Text, _ *Text, argt *Text, flag1 bool, _ bool, arg string) {
 	if flag1 {
 		if et == nil || et.w == nil {
 			return
@@ -442,7 +442,7 @@ func get(et *Text, t *Text, argt *Text, flag1 bool, _ bool, arg string) {
 		return
 	}
 	w := et.w
-	t = &w.body
+	t := &w.body
 	name := getname(t, argt, arg, false)
 	if name == "" {
 		warning(nil, "no file name\n")
@@ -692,11 +692,11 @@ func run(win *Window, s string, rdir string, newns bool, argaddr string, xarg st
 	go runwaittask(c, cpid)
 }
 
-func sendx(et *Text, t *Text, _ *Text, _, _ bool, _ string) {
+func sendx(et *Text, _ *Text, _ *Text, _, _ bool, _ string) {
 	if et.w == nil {
 		return
 	}
-	t = &et.w.body
+	t := &et.w.body
 	if t.q0 != t.q1 {
 		cut(t, t, nil, true, false, "")
 	}
@@ -710,9 +710,9 @@ func sendx(et *Text, t *Text, _ *Text, _, _ bool, _ string) {
 	t.Show(t.q1, t.q1, true)
 }
 
-func look(et *Text, t *Text, argt *Text, _, _ bool, arg string) {
+func look(et *Text, _ *Text, argt *Text, _, _ bool, arg string) {
 	if et != nil && et.w != nil {
-		t = &et.w.body
+		t := &et.w.body
 		if len(arg) > 0 {
 			search(t, []rune(arg))
 			return
@@ -759,17 +759,15 @@ func tab(et *Text, _ *Text, argt *Text, _, _ bool, arg string) {
 	}
 }
 
-func fontx(et *Text, t *Text, argt *Text, _, _ bool, arg string) {
+func fontx(et *Text, _ *Text, argt *Text, _, _ bool, arg string) {
 	if et == nil || et.w == nil {
 		return
 	}
-	t = &et.w.body
+	t := &et.w.body
 	file := ""
 	// Parse parameter.  It might be in arg, or argt, or both
 	r, _ := getarg(argt, false, true)
-	r = r + " " + arg
-	r = wsre.ReplaceAllString(r, " ")
-	words := strings.Split(arg, " ")
+	words := strings.Fields(r + " " + arg)
 
 	for _, wrd := range words {
 		switch wrd {

--- a/fsys.go
+++ b/fsys.go
@@ -352,8 +352,9 @@ func fsyswalk(x *Xfid, f *Fid) *Xfid {
 				continue
 			}
 			// is it a numeric name?
-			_, err := strconv.ParseInt(wname, 10, 32)
+			_, err = strconv.ParseInt(wname, 10, 32)
 			if err != nil {
+				err = nil
 				goto Regular
 			}
 			// yes: it's a directory

--- a/fsys_test.go
+++ b/fsys_test.go
@@ -172,7 +172,7 @@ func TestFSys(t *testing.T) {
 		t.SkipNow()                   // Only used for debugging?
 		fid, err := fsys.Open("/", 0) // Readonly
 		if err != nil {
-			t.Errorf("Failed to open/: %v", err)
+			t.Fatalf("Failed to open/: %v", err)
 		}
 
 		dirs, err := fid.Dirread()
@@ -186,7 +186,7 @@ func TestFSys(t *testing.T) {
 
 		fid, err = fsys.Open("/1", plan9.OREAD)
 		if err != nil {
-			t.Errorf("Failed to walk to /1: %v", err)
+			t.Fatalf("Failed to walk to /1: %v", err)
 		}
 		dirs, err = fid.Dirread()
 		if err != nil {
@@ -199,7 +199,7 @@ func TestFSys(t *testing.T) {
 	t.Run("Basic", func(t *testing.T) {
 		fid, err := fsys.Open("/new/body", plan9.OWRITE)
 		if err != nil {
-			t.Errorf("Failed to open/: %v", err)
+			t.Fatalf("Failed to open/: %v", err)
 		}
 		text := []byte("This is a test\nof the emergency typing system\n")
 		fid.Write(text)
@@ -207,7 +207,7 @@ func TestFSys(t *testing.T) {
 
 		fid, err = fsys.Open("/2/body", plan9.OREAD)
 		if err != nil {
-			t.Errorf("Failed to open /2/body: %v", err)
+			t.Fatalf("Failed to open /2/body: %v", err)
 		}
 		buf := make([]byte, len(text))
 		_, err = fid.ReadFull(buf)
@@ -221,7 +221,7 @@ func TestFSys(t *testing.T) {
 
 		fid, err = fsys.Open("/2/addr", plan9.OWRITE)
 		if err != nil {
-			t.Errorf("Failed to open /2/addr: %v", err)
+			t.Fatalf("Failed to open /2/addr: %v", err)
 		}
 		fid.Write([]byte("#5"))
 		fid.Close()
@@ -229,14 +229,14 @@ func TestFSys(t *testing.T) {
 		// test insertion
 		fid, err = fsys.Open("/2/data", plan9.OWRITE)
 		if err != nil {
-			t.Errorf("Failed to open /2/data: %v", err)
+			t.Fatalf("Failed to open /2/data: %v", err)
 		}
 		fid.Write([]byte("insertion"))
 		fid.Close()
 
 		fid, err = fsys.Open("/2/body", plan9.OREAD)
 		if err != nil {
-			t.Errorf("Failed to open /2/body: %v", err)
+			t.Fatalf("Failed to open /2/body: %v", err)
 		}
 		text = append(text[0:5], append([]byte("insertion"), text[5:]...)...)
 		buf = make([]byte, len(text))
@@ -252,7 +252,7 @@ func TestFSys(t *testing.T) {
 		// Delete the window
 		fid, err = fsys.Open("/2/ctl", plan9.OWRITE)
 		if err != nil {
-			t.Errorf("Failed to open /2/ctl: %v", err)
+			t.Fatalf("Failed to open /2/ctl: %v", err)
 		}
 		fid.Write([]byte("delete"))
 		fid.Close()
@@ -260,7 +260,7 @@ func TestFSys(t *testing.T) {
 		// Make sure it's gone from the directory
 		fid, err = fsys.Open("/1", plan9.OREAD)
 		if err != nil {
-			t.Errorf("Failed to walk to /1: %v", err)
+			t.Fatalf("Failed to walk to /1: %v", err)
 		}
 		dirs, err := fid.Dirread()
 		if err != nil {
@@ -453,7 +453,7 @@ func (tfs tFsys) startlog() (rc chan string, exit chan struct{}) {
 	exit = make(chan struct{})
 	fid, err := tfs.fsys.Open("/log", plan9.OREAD)
 	if err != nil {
-		tfs.t.Errorf("Failed to open acme/log: %v", err)
+		tfs.t.Fatalf("Failed to open acme/log: %v", err)
 	}
 
 	go func() {
@@ -476,7 +476,7 @@ func (tfs tFsys) startlog() (rc chan string, exit chan struct{}) {
 func (tfs tFsys) Read(file string) (s string) {
 	fid, err := tfs.fsys.Open(file, plan9.OREAD)
 	if err != nil {
-		tfs.t.Errorf("Failed to open %s: %v", file, err)
+		tfs.t.Fatalf("Failed to open %s: %v", file, err)
 	}
 	var buf [8192]byte
 	n, err := fid.Read(buf[:])
@@ -490,7 +490,7 @@ func (tfs tFsys) Read(file string) (s string) {
 func (tfs tFsys) Write(file, s string) {
 	fid, err := tfs.fsys.Open(file, plan9.OWRITE)
 	if err != nil {
-		tfs.t.Errorf("Failed to open %s: %v", file, err)
+		tfs.t.Fatalf("Failed to open %s: %v", file, err)
 	}
 	_, err = fid.Write([]byte(s))
 	if err != nil {

--- a/row.go
+++ b/row.go
@@ -768,7 +768,7 @@ func (row *Row) loadimpl(file string, initing bool) error {
 				return fmt.Errorf("bad line %#v in dumpfile", l)
 			}
 			// We discard a line
-			l, err = readtrim(b) // ctl line; ignored
+			_, err = readtrim(b) // ctl line; ignored
 			if err != nil {
 				return err
 			}

--- a/text.go
+++ b/text.go
@@ -331,7 +331,7 @@ func (t *Text) Load(q0 int, filename string, setqid bool) (nread int, err error)
 		count, hasNulls, err = t.file.Load(q0, fd, setqid && q0 == 0)
 		if err != nil {
 			warning(nil, "Error reading file %s: %v", filename, err)
-			return 0, fmt.Errorf("Error reading file %s: %v", filename, err)
+			return 0, fmt.Errorf("error reading file %s: %v", filename, err)
 		}
 		q1 = q0 + count
 	}


### PR DESCRIPTION
The two bugs staticcheck found:
1. exec.go: Font command didn't parse arguments correctly
2. fsys.go: err shadowing bug in fsyswalk

```
$ staticcheck | grep -v U1000 | grep -v ST1012
exec.go:435:20: argument t is overwritten before first use (SA4009)
exec.go:695:22: argument t is overwritten before first use (SA4009)
exec.go:713:21: argument t is overwritten before first use (SA4009)
exec.go:762:22: argument t is overwritten before first use (SA4009)
exec.go:771:2: this value of r is never used (SA4006)
fsys.go:379:5: this value of err is never used (SA4006)
fsys.go:379:21: Errorf is a pure function but its return value is ignored (SA4017)
row.go:771:4: this value of l is never used (SA4006)
text.go:334:24: error strings should not be capitalized (ST1005)
```