### PR TITLE
Rename errors to conform to Go style

### DIFF
--- a/ecmd.go
+++ b/ecmd.go
@@ -113,7 +113,7 @@ func cmdexec(t *Text, cp *Cmd) bool {
 func edittext(w *Window, q int, r []rune) error {
 	switch editing {
 	case Inactive:
-		return Eperm
+		return ErrPermission
 	case Inserting:
 		f := w.body.file
 		f.elog.Insert(q, r)

--- a/fsys.go
+++ b/fsys.go
@@ -48,10 +48,11 @@ func initfcall() {
 	fcall[plan9.Twstat] = fsyswstat
 }
 
+// Errors returned by file server.
 var (
-	Eperm   = errors.New("permission denied")
-	Eexist  = errors.New("file does not exist")
-	Enotdir = errors.New("not a directory")
+	ErrPermission = os.ErrPermission
+	ErrNotExist   = os.ErrNotExist
+	ErrNotDir     = errors.New("not a directory")
 )
 
 var dirtab = []*DirTab{
@@ -245,7 +246,7 @@ func fsysflush(x *Xfid, f *Fid) *Xfid {
 func fsysattach(x *Xfid, f *Fid) *Xfid {
 	if x.fcall.Uname != username {
 		var t plan9.Fcall
-		return respond(x, &t, Eperm)
+		return respond(x, &t, ErrPermission)
 	}
 	f.busy = true
 	f.open = false
@@ -333,7 +334,7 @@ func fsyswalk(x *Xfid, f *Fid) *Xfid {
 		for i = 0; i < len(x.fcall.Wname); i++ {
 			wname = x.fcall.Wname[i]
 			if (q.Type & plan9.QTDIR) == 0 {
-				err = Enotdir
+				err = ErrNotDir
 				break
 			}
 
@@ -426,7 +427,7 @@ func fsyswalk(x *Xfid, f *Fid) *Xfid {
 
 		// If we never incremented
 		if i == 0 && err == nil {
-			err = Eexist
+			err = ErrNotExist
 		}
 		if i == plan9.MAXWELEM {
 			err = fmt.Errorf("name too long")
@@ -484,12 +485,12 @@ func fsysopen(x *Xfid, f *Fid) *Xfid {
 
 Deny:
 	var t plan9.Fcall
-	return respond(x, &t, Eperm)
+	return respond(x, &t, ErrPermission)
 }
 
 func fsyscreate(x *Xfid, f *Fid) *Xfid {
 	var t plan9.Fcall
-	return respond(x, &t, Eperm)
+	return respond(x, &t, ErrPermission)
 }
 
 //func idcmp (const  void *a, const  void *b) (int) {
@@ -588,7 +589,7 @@ func fsysclunk(x *Xfid, f *Fid) *Xfid {
 
 func fsysremove(x *Xfid, f *Fid) *Xfid {
 	var t plan9.Fcall
-	return respond(x, &t, Eperm)
+	return respond(x, &t, ErrPermission)
 }
 
 func fsysstat(x *Xfid, f *Fid) *Xfid {
@@ -604,7 +605,7 @@ func fsysstat(x *Xfid, f *Fid) *Xfid {
 func fsyswstat(x *Xfid, f *Fid) *Xfid {
 	var t plan9.Fcall
 
-	return respond(x, &t, Eperm)
+	return respond(x, &t, ErrPermission)
 }
 
 func newfid(fid uint32) *Fid {

--- a/fsys_test.go
+++ b/fsys_test.go
@@ -351,8 +351,8 @@ func TestFSys(t *testing.T) {
 		}
 		defer fid.Close()
 		_, err = fid.Write([]byte("hello\n"))
-		if err == nil || err.Error() != Eperm.Error() {
-			t.Fatalf("write to editout returned %v; expected %v", err, Eperm)
+		if err == nil || err.Error() != ErrPermission.Error() {
+			t.Fatalf("write to editout returned %v; expected %v", err, ErrPermission)
 		}
 	})
 	t.Run("WriteEvent", func(t *testing.T) {
@@ -372,15 +372,15 @@ func TestFSys(t *testing.T) {
 			{nil, "Ml0 0 \n"},
 			{nil, "MX0 0 \n"},
 			{nil, "ML0 0 \nMl0 0 \n"},
-			{Ebadevent, "M\n"},
-			{Ebadevent, "ML\n"},
-			{Ebadevent, "ML0 \n"},
-			{Ebadevent, "MLA 0 \n"},
-			{Ebadevent, "ML0 A \n"},
-			{Ebadevent, "M40 0 \n"},
-			{Ebadevent, "ML9 9 \n"},
-			{Ebadevent, "MZ0 0 \n"},
-			{Ebadevent, "MZ0 0 \nML0 0 \n"}, // bad event followed by a good one
+			{ErrBadEvent, "M\n"},
+			{ErrBadEvent, "ML\n"},
+			{ErrBadEvent, "ML0 \n"},
+			{ErrBadEvent, "MLA 0 \n"},
+			{ErrBadEvent, "ML0 A \n"},
+			{ErrBadEvent, "M40 0 \n"},
+			{ErrBadEvent, "ML9 9 \n"},
+			{ErrBadEvent, "MZ0 0 \n"},
+			{ErrBadEvent, "MZ0 0 \nML0 0 \n"}, // bad event followed by a good one
 		}
 		for _, tc := range tt {
 			_, err = w.Write("event", []byte(tc.s))


### PR DESCRIPTION
Renaming was done by gorename, so should be correct.
```
$ staticcheck -checks ST1012
fsys.go:52:2: error var Eperm should have name of the form ErrFoo (ST1012)
fsys.go:53:2: error var Eexist should have name of the form ErrFoo (ST1012)
fsys.go:54:2: error var Enotdir should have name of the form ErrFoo (ST1012)
xfid.go:19:5: error var Edel should have name of the form ErrFoo (ST1012)
xfid.go:20:5: error var Ebadctl should have name of the form ErrFoo (ST1012)
xfid.go:21:5: error var Ebadaddr should have name of the form ErrFoo (ST1012)
xfid.go:22:5: error var Eaddr should have name of the form ErrFoo (ST1012)
xfid.go:23:5: error var Einuse should have name of the form ErrFoo (ST1012)
xfid.go:24:5: error var Ebadevent should have name of the form ErrFoo (ST1012)
```