### PR TITLE
Send coverage report to codecov in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,8 @@ env:
 script:
   - go get -t -v ./...
   - diff -u <(echo -n) <(gofmt -d -s .)
-  - go test -v -race ./...
+  - go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
   - go tool vet .
+
+after_success:
+  - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This is what the coverage report looks like: https://codecov.io/gh/fhs/edwood/branch/codecov
I'm not sure if you need to enable it at https://codecov.io/gh/rjkroege/edwood