### PR TITLE
Terminate running commands when exiting

### DIFF
--- a/acme.go
+++ b/acme.go
@@ -640,11 +640,9 @@ func newwindowthread() {
 
 func killprocs() {
 	fsysclose()
-	/*
-		for _, c := range command {
-			c.Signal(os.Interrupt)
-		}
-	*/
+	for c := command; c != nil; c = c.next {
+		c.proc.Kill()
+	}
 }
 
 var dumping bool

--- a/acme_test.go
+++ b/acme_test.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"os/exec"
 	"testing"
+	"time"
 )
 
 func TestIsmtpt(t *testing.T) {
@@ -28,5 +30,29 @@ func TestIsmtpt(t *testing.T) {
 		if ok != tc.ok {
 			t.Errorf("ismtpt(%v) = %v; expected %v", tc.filename, ok, tc.ok)
 		}
+	}
+}
+
+func TestKillprocs(t *testing.T) {
+	cmd := exec.Command("sleep", "3600")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("failed start command: %v", err)
+	}
+	done := make(chan struct{})
+	go func() {
+		cmd.Wait()
+		close(done)
+	}()
+
+	command = &Command{
+		proc: cmd.Process,
+	}
+	killprocs()
+	timer := time.NewTimer(5 * time.Second)
+	select {
+	case <-done:
+		// Do nothing
+	case <-timer.C:
+		t.Errorf("killprocs did not kill command in time")
 	}
 }

--- a/fsys.go
+++ b/fsys.go
@@ -94,7 +94,7 @@ var mnt Mnt
 
 var (
 	username = "Wile E. Coyote"
-	closing  int
+	closing  bool
 )
 
 func fsysinit() {
@@ -118,6 +118,9 @@ func fsysproc() {
 	for {
 		fc, err := plan9.ReadFcall(sfd)
 		if err != nil || fc == nil {
+			if closing {
+				break
+			}
 			acmeerror("fsysproc", err)
 		}
 		if x == nil {
@@ -199,8 +202,10 @@ func fsysdelid(idm *MntDir) {
 }
 
 func fsysclose() {
-	closing = 1
-	sfd.Close()
+	closing = true
+	if sfd != nil {
+		sfd.Close()
+	}
 }
 
 func respond(x *Xfid, t *plan9.Fcall, err error) *Xfid {


### PR DESCRIPTION
* Also gracefully terminate fsys reader
* Use Kill instead of Interrupt because Interrupt is not implemented on
  Windows and it's what exec.CommandContext uses for cancellation.