### PR TITLE
internal/runes: add IndexRune, ContainsRune and Equal

### DIFF
--- a/addr.go
+++ b/addr.go
@@ -27,7 +27,7 @@ func isregexc(r rune) bool {
 	if isalnum(r) {
 		return true
 	}
-	if utfrune([]rune("^+-.*?#,;[]()$"), r) != -1 {
+	if strings.ContainsRune("^+-.*?#,;[]()$", r) {
 		return true
 	}
 	return false

--- a/ecmd.go
+++ b/ecmd.go
@@ -48,7 +48,7 @@ func cmdexec(t *Text, cp *Cmd) bool {
 	}
 
 	if w == nil && (cp.addr == nil || cp.addr.typ != '"') &&
-		utfrune([]rune("bBnqUXY!"), cp.cmdc) == -1 && // Commands that don't need a window
+		!strings.ContainsRune("bBnqUXY!", cp.cmdc) && // Commands that don't need a window
 		!(cp.cmdc == 'D' && len(cp.text) > 0) {
 		editerror("no current window")
 	}

--- a/edit.go
+++ b/edit.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"runtime"
 	"runtime/debug"
+
+	"github.com/rjkroege/edwood/internal/runes"
 )
 
 type Addr struct {
@@ -341,7 +343,7 @@ func collecttoken(end []rune) string {
 	}
 	for {
 		c = getch()
-		if c <= 0 || utfrune(end, c) != -1 {
+		if c <= 0 || runes.ContainsRune(end, c) {
 			break
 		}
 		s += string(c)

--- a/exec.go
+++ b/exec.go
@@ -1000,7 +1000,7 @@ func runproc(win *Window, s string, dir string, newns bool, argaddr string, arg 
 		if r < ' ' {
 			return Hard()
 		}
-		if utfrune([]rune("#;&|^$=`'{}()<>[]*?^~`/"), r) != -1 {
+		if strings.ContainsRune("#;&|^$=`'{}()<>[]*?^~`/", r) {
 			return Hard()
 		}
 	}

--- a/internal/runes/runes.go
+++ b/internal/runes/runes.go
@@ -30,3 +30,33 @@ func Index(s, sep []rune) int {
 	}
 	return -1
 }
+
+// IndexRune returns the index of the first occurrence in s of the given rune r.
+// It returns -1 if rune is not present in s.
+func IndexRune(s []rune, r rune) int {
+	for i, c := range s {
+		if c == r {
+			return i
+		}
+	}
+	return -1
+}
+
+// ContainsRune reports whether the rune is contained in the runes slice s.
+func ContainsRune(s []rune, r rune) bool {
+	return IndexRune(s, r) >= 0
+}
+
+// Equal returns a boolean reporting whether a and b
+// are the same length and contain the same runes.
+func Equal(a, b []rune) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, r := range a {
+		if r != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/runes/runes_test.go
+++ b/internal/runes/runes_test.go
@@ -53,3 +53,66 @@ func TestHasPrefix(t *testing.T) {
 		}
 	}
 }
+
+var indexRuneTests = []struct {
+	s string
+	r rune
+	n int
+}{
+	{"", 'x', -1},
+	{"x", 'x', 0},
+	{"abcdef", 'a', 0},
+	{"abcdef", 'd', 3},
+	{"abcdef", 'f', 5},
+	{"abcdef", 'x', -1},
+	{"私はガラスを食べる", '私', 0},
+	{"私はガラスを食べる", 'を', 5},
+	{"私はガラスを食べる", 'る', 8},
+	{"私はガラスを食べる", 'α', -1},
+}
+
+func TestIndexRune(t *testing.T) {
+	for _, tc := range indexRuneTests {
+		n := IndexRune([]rune(tc.s), tc.r)
+		if n != tc.n {
+			t.Errorf("IndexRune(%q, %q) is %v; expected %v", tc.s, tc.r, n, tc.n)
+		}
+	}
+}
+
+func TestContainsRune(t *testing.T) {
+	for _, tc := range indexRuneTests {
+		ok := ContainsRune([]rune(tc.s), tc.r)
+		if want := tc.n >= 0; ok != want {
+			t.Errorf("ContainsRune(%q, %q) is %v; expected %v", tc.s, tc.r, ok, want)
+		}
+	}
+}
+
+func TestEqual(t *testing.T) {
+	tt := []struct {
+		a, b string
+		ok   bool
+	}{
+		{"", "", true},
+		{"a", "", false},
+		{"", "a", false},
+		{"a", "a", true},
+		{"ab", "ab", true},
+		{"abc", "abc", true},
+		{"abc", "axc", false},
+		{"axc", "abc", false},
+		{"私はガラスを食べる", "私はガラスを食べる", true},
+		{"私はガラスを食べる", "私はケーキを食べる", false},
+		{"私はケーキを食べる", "私はガラスを食べる", false},
+		{"私はガラスを食べる", "私はpieを食べる", false},
+		{"私はpieを食べる", "私はガラスを食べる", false},
+		{"私はpieを食べる", "私はpieを食べる", true},
+	}
+	for _, tc := range tt {
+		ok := Equal([]rune(tc.a), []rune(tc.b))
+		if ok != tc.ok {
+			t.Errorf("HasPrefix(%q, %q) returned %v; expected %v", tc.a, tc.b, ok, tc.ok)
+		}
+	}
+}

--- a/look.go
+++ b/look.go
@@ -13,6 +13,7 @@ import (
 	"9fans.net/go/plan9"
 	"9fans.net/go/plan9/client"
 	"9fans.net/go/plumb"
+	"github.com/rjkroege/edwood/internal/runes"
 )
 
 var (
@@ -290,7 +291,7 @@ func search(ct *Text, r []rune) bool {
 			//s[bi+nb] = 0; // null terminate
 		}
 		if nb > 0 {
-			ci := runestrchr(s[bi:bi+nb], r[0])
+			ci := runes.IndexRune(s[bi:bi+nb], r[0])
 			if ci == -1 {
 				q += nb
 				nb = 0
@@ -314,7 +315,7 @@ func search(ct *Text, r []rune) bool {
 			bi = 0
 		}
 		limit := min(len(s), bi+n)
-		if runeeq(s[bi:limit], r) {
+		if runes.Equal(s[bi:limit], r) {
 			if ct.w != nil {
 				ct.Show(q, q+n, true)
 				ct.w.SetTag()
@@ -340,7 +341,7 @@ func isfilec(r rune) bool {
 	if isalnum(r) {
 		return true
 	}
-	if runestrchr([]rune(Lx), r) != -1 {
+	if strings.ContainsRune(Lx, r) {
 		return true
 	}
 	return false

--- a/rune.go
+++ b/rune.go
@@ -1,5 +1,7 @@
 package main
 
+import "github.com/rjkroege/edwood/internal/runes"
+
 func (r Buffer) Index(set []rune) int {
 	return runeIndex([]rune(r), set)
 }
@@ -16,33 +18,12 @@ func runeIndex(r []rune, set []rune) int {
 }
 
 func (r Buffer) Eq(s Buffer) bool {
-	return runeEq(r, s)
-}
-
-func runeEq(r, s []rune) bool {
-	if len(s) != len(r) {
-		return false
-	}
-	for i, rr := range r {
-		if rr != s[i] {
-			return false
-		}
-	}
-	return true
-}
-
-func isIn(r []rune, s rune) bool {
-	for _, c := range r {
-		if s == c {
-			return true
-		}
-	}
-	return false
+	return runes.Equal(r, s)
 }
 
 func trimLeft(r []rune, skip []rune) []rune {
 	for i, c := range r {
-		if !isIn(skip, c) {
+		if !runes.ContainsRune(skip, c) {
 			return r[i:]
 		}
 	}

--- a/text.go
+++ b/text.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rjkroege/edwood/complete"
 	"github.com/rjkroege/edwood/frame"
 	"github.com/rjkroege/edwood/internal/drawutil"
+	"github.com/rjkroege/edwood/internal/runes"
 )
 
 const (
@@ -1373,7 +1374,7 @@ func (t *Text) DoubleClick(inq0, inq1 int) (q0, q1 int) {
 		} else {
 			c = t.ReadC(q - 1)
 		}
-		p := runestrchr(l, c)
+		p := runes.IndexRune(l, c)
 		if p != -1 {
 			if q, ok := t.ClickMatch(c, r[p], 1, q); ok {
 				q1 = q
@@ -1389,7 +1390,7 @@ func (t *Text) DoubleClick(inq0, inq1 int) (q0, q1 int) {
 		} else {
 			c = t.ReadC(q)
 		}
-		p = runestrchr(r, c)
+		p = runes.IndexRune(r, c)
 		if p != -1 {
 			if q, ok := t.ClickMatch(c, l[p], -1, q); ok {
 				q1 = inq0

--- a/util.go
+++ b/util.go
@@ -77,39 +77,10 @@ func isalnum(c rune) bool {
 	if 0x7F <= c && c <= 0xA0 {
 		return false
 	}
-	if utfrune([]rune("!\"#$%&'()*+,-./:;<=>?@[\\]^`{|}~"), c) != -1 {
+	if strings.ContainsRune("!\"#$%&'()*+,-./:;<=>?@[\\]^`{|}~", c) {
 		return false
 	}
 	return true
-}
-
-func runeeq(s1, s2 []rune) bool {
-	if len(s1) != len(s2) {
-		return false
-	}
-	for i := range s1 {
-		if s1[i] != s2[i] {
-			return false
-		}
-	}
-	return true
-}
-func runestrchr(s []rune, r rune) int {
-	for ret, sr := range s {
-		if sr == r {
-			return ret
-		}
-	}
-	return -1
-}
-
-func utfrune(s []rune, r rune) int {
-	for i, c := range s {
-		if c == r {
-			return i
-		}
-	}
-	return -1
 }
 
 // Cvttorunes decodes runes r from p. It's guaranteed that first n


### PR DESCRIPTION
Also use them:

  gofmt -r 'runeeq -> runes.Equal' -w .
  gofmt -r 'runestrchr -> runes.IndexRune' -w .
  gofmt -r 'utfrune -> runes.IndexRune' -w .
  gofmt -r 'runes.IndexRune(α, β) != -1 -> runes.ContainsRune(α, β)' -w .
  gofmt -r 'runes.IndexRune(α, β) == -1 -> !runes.ContainsRune(α, β)' -w .
  gofmt -r 'runes.ContainsRune([]rune(α), β) -> strings.ContainsRune(α, β)' -w .
  gofmt -r 'runeEq -> runes.Equal' -w .
  gofmt -r 'isIn -> runes.ContainsRune' -w .
