### PR TITLE
Change File.DelText to return error instead of panicking

### DIFF
--- a/file.go
+++ b/file.go
@@ -105,22 +105,22 @@ func (f *File) AddText(t *Text) *File {
 	return f
 }
 
-func (f *File) DelText(t *Text) {
+func (f *File) DelText(t *Text) error {
 	for i, text := range f.text {
 		if text == t {
 			f.text[i] = f.text[len(f.text)-1]
 			f.text = f.text[:len(f.text)-1]
 			if len(f.text) == 0 {
 				f.Close()
-				return
+				return nil
 			}
 			if t == f.curtext {
 				f.curtext = f.text[0]
 			}
-			return
+			return nil
 		}
 	}
-	acmeerror("can't find text in File.DelText", nil)
+	return fmt.Errorf("can't find text in File.DelText")
 }
 
 func (f *File) Insert(p0 int, s []rune) {

--- a/file_test.go
+++ b/file_test.go
@@ -7,16 +7,18 @@ func TestDelText(t *testing.T) {
 		text: []*Text{{}, {}, {}, {}, {}},
 	}
 	t.Run("Nonexistent", func(t *testing.T) {
-		defer func() {
-			if r := recover(); r == nil {
-				t.Errorf("expected panic when deleting nonexistent text")
-			}
-		}()
-		f.DelText(&Text{})
+		err := f.DelText(&Text{})
+		if err == nil {
+			t.Errorf("expected panic when deleting nonexistent text")
+		}
 	})
 	for i := len(f.text) - 1; i >= 0; i-- {
 		text := f.text[i]
-		f.DelText(text)
+		err := f.DelText(text)
+		if err != nil {
+			t.Errorf("DelText of text at index %d failed: %v", i, err)
+			continue
+		}
 		if got, want := len(f.text), i; got != want {
 			t.Fatalf("DelText resulted in text of length %v; expected %v", got, want)
 		}

--- a/text.go
+++ b/text.go
@@ -184,7 +184,9 @@ func (t *Text) Resize(r image.Rectangle, keepextra, noredraw bool) int {
 
 func (t *Text) Close() {
 	t.fr.Clear(true)
-	t.file.DelText(t)
+	if err := t.file.DelText(t); err != nil {
+		acmeerror(err.Error(), nil)
+	}
 	t.file = nil
 	if argtext == t {
 		argtext = nil


### PR DESCRIPTION
The panic message gets printed when running tests, even after recover.
This gets rid of the minor annoyance.