### PR TITLE
Remove redundant parenthesis around function calls

### DIFF
--- a/buf.go
+++ b/buf.go
@@ -14,18 +14,18 @@ type Buffer []rune
 func NewBuffer() Buffer { return []rune{} }
 
 func (b *Buffer) Insert(q0 int, r []rune) {
-	if q0 > (len(*b)) {
+	if q0 > len(*b) {
 		panic("internal error: buffer.Insert: Out of range insertion")
 	}
 	(*b) = append((*b)[:q0], append(r, (*b)[q0:]...)...)
 }
 
 func (b *Buffer) Delete(q0, q1 int) {
-	if q0 > (len(*b)) || q1 > (len(*b)) {
+	if q0 > len(*b) || q1 > len(*b) {
 		panic("internal error: buffer.Delete: Out-of-range Delete")
 	}
 	copy((*b)[q0:], (*b)[q1:])
-	(*b) = (*b)[:(len(*b))-(q1-q0)] // Reslice to length
+	(*b) = (*b)[:len(*b)-(q1-q0)] // Reslice to length
 }
 
 func (b *Buffer) Load(q0 int, fd *os.File) (n int, h FileHash, hasNulls bool, err error) {

--- a/dat.go
+++ b/dat.go
@@ -236,7 +236,7 @@ func Unimpl() {
 }
 
 func WIN(q plan9.Qid) int {
-	return int(((uint(q.Path)) >> 8) & 0xFFFFFF)
+	return int((uint(q.Path) >> 8) & 0xFFFFFF)
 }
 
 func FILE(q plan9.Qid) uint64 {

--- a/elog.go
+++ b/elog.go
@@ -209,22 +209,22 @@ func (e *Elog) Apply(t Texter) {
 			t.Insert(tq0, eo.r, true)
 			// Mark selection
 			if t.Q0() == eo.q0 && t.Q1() == eo.q0 {
-				t.SetQ1(t.Q1() + (len(eo.r)))
+				t.SetQ1(t.Q1() + len(eo.r))
 			}
 		case Insert:
 			if tracelog {
 				fmt.Printf("elog insert %d %d (%d %d)\n",
-					eo.q0, eo.q0+(len(eo.r)), t.Q0(), t.Q1())
+					eo.q0, eo.q0+len(eo.r), t.Q0(), t.Q1())
 			}
 			tq0, _ := t.Constrain(eo.q0, eo.q0)
 			t.Insert(tq0, eo.r, true)
 			if t.Q0() == eo.q0 && t.Q1() == eo.q0 {
-				t.SetQ1(t.Q1() + (len(eo.r)))
+				t.SetQ1(t.Q1() + len(eo.r))
 			}
 		case Delete:
 			if tracelog {
 				fmt.Printf("elog delete %d %d (%d %d)\n",
-					eo.q0, eo.q0+(len(eo.r)), t.Q0(), t.Q1())
+					eo.q0, eo.q0+len(eo.r), t.Q0(), t.Q1())
 			}
 			tq0, tq1 := t.Constrain(eo.q0, eo.q0+eo.nd)
 			t.Delete(tq0, tq1, true)

--- a/fsys.go
+++ b/fsys.go
@@ -466,7 +466,7 @@ func (fs *fileServer) walk(x *Xfid, f *Fid) *Xfid {
 func (fs *fileServer) open(x *Xfid, f *Fid) *Xfid {
 	var m uint
 	// can't truncate anything, so just disregard
-	x.fcall.Mode &= ^(uint8(plan9.OTRUNC | plan9.OCEXEC))
+	x.fcall.Mode &= ^uint8(plan9.OTRUNC | plan9.OCEXEC)
 	// can't execute or remove anything
 	if x.fcall.Mode == plan9.OEXEC || (x.fcall.Mode&plan9.ORCLOSE) != 0 {
 		goto Deny

--- a/text.go
+++ b/text.go
@@ -466,7 +466,7 @@ func (t *Text) Insert(q0 int, r []rune, tofile bool) {
 			}
 		}
 	}
-	n := (len(r))
+	n := len(r)
 	if q0 < t.iq1 {
 		t.iq1 += n
 	}
@@ -1099,7 +1099,7 @@ func (t *Text) FrameScroll(fr frame.SelectScrollUpdater, dl int) {
 		if t.org+(fr.GetFrameFillStatus().Nchars) == t.file.b.Nc() {
 			return
 		}
-		q0 = t.org + (fr.Charofpt(image.Pt(fr.Rect().Min.X, fr.Rect().Min.Y+dl*fr.DefaultFontHeight())))
+		q0 = t.org + fr.Charofpt(image.Pt(fr.Rect().Min.X, fr.Rect().Min.Y+dl*fr.DefaultFontHeight()))
 	}
 	// Insert text into the frame.
 	t.setorigin(fr, q0, true, true)
@@ -1130,7 +1130,7 @@ func (t *Text) Select() {
 	b := mouse.Buttons
 	q0 := t.q0
 	q1 := t.q1
-	selectq = t.org + (t.fr.Charofpt(mouse.Point))
+	selectq = t.org + t.fr.Charofpt(mouse.Point)
 	//	fmt.Printf("Text.Select: mouse.Msec %v, clickmsec %v\n", mouse.Msec, clickmsec)
 	//	fmt.Printf("clicktext==t %v, (q0==q1 && selectq==q0): %v", clicktext == t, q0 == q1 && selectq == q0)
 	if (clicktext == t && mouse.Msec-clickmsec < 500) && (q0 == q1 && selectq == q0) {

--- a/texter.go
+++ b/texter.go
@@ -24,8 +24,8 @@ type TextBuffer struct {
 }
 
 func (t TextBuffer) Constrain(q0, q1 int) (p0, p1 int) {
-	p0 = min(q0, (len(t.buf)))
-	p1 = min(q1, (len(t.buf)))
+	p0 = min(q0, len(t.buf))
+	p1 = min(q1, len(t.buf))
 	return p0, p1
 }
 
@@ -38,16 +38,16 @@ func (t *TextBuffer) View(q0, q1 int) []rune {
 
 func (t *TextBuffer) Delete(q0, q1 int, tofile bool) {
 	_ = tofile
-	if q0 > (len(t.buf)) || q1 > (len(t.buf)) {
+	if q0 > len(t.buf) || q1 > len(t.buf) {
 		panic("Out-of-range Delete")
 	}
 	copy(t.buf[q0:], t.buf[q1:])
-	t.buf = t.buf[:(len(t.buf))-(q1-q0)] // Reslice to length
+	t.buf = t.buf[:len(t.buf)-(q1-q0)] // Reslice to length
 }
 
 func (t *TextBuffer) Insert(q0 int, r []rune, tofile bool) {
 	_ = tofile
-	if q0 > (len(t.buf)) {
+	if q0 > len(t.buf) {
 		panic("Out of range insertion")
 	}
 	t.buf = append(t.buf[:q0], append(r, t.buf[q0:]...)...)

--- a/wind.go
+++ b/wind.go
@@ -397,8 +397,8 @@ func (w *Window) Undo(isundo bool) {
 	for _, text := range f.text {
 		v := text.w
 		if v != w {
-			v.body.q0 = (getP0(v.body.fr)) + v.body.org
-			v.body.q1 = (getP1(v.body.fr)) + v.body.org
+			v.body.q0 = getP0(v.body.fr) + v.body.org
+			v.body.q1 = getP1(v.body.fr) + v.body.org
 		}
 	}
 	w.SetTag()

--- a/xfid.go
+++ b/xfid.go
@@ -502,9 +502,9 @@ func xfidwrite(x *Xfid) {
 		t = &w.body
 		w.Commit(t)
 		eval = true
-		a, eval, nb = address(false, t, w.limit, w.addr, 0, (len(r)),
+		a, eval, nb = address(false, t, w.limit, w.addr, 0, len(r),
 			func(q int) rune { return r[q] }, eval)
-		if nb < (len(r)) {
+		if nb < len(r) {
 			x.respond(&fc, ErrBadAddr)
 			break
 		}
@@ -568,14 +568,14 @@ func xfidwrite(x *Xfid) {
 		tq1 = t.q1
 		t.Insert(q0, r, true)
 		if tq0 >= q0 {
-			tq0 += (len(r))
+			tq0 += len(r)
 		}
 		if tq1 >= q0 {
-			tq1 += (len(r))
+			tq1 += len(r)
 		}
 		t.SetSelect(tq0, tq1)
 		if shouldscroll(t, q0, qid) {
-			t.Show(q0+(len(r)), q0+(len(r)), false)
+			t.Show(q0+len(r), q0+len(r), false)
 		}
 		t.ScrDraw(t.fr.GetFrameFillStatus().Nchars)
 		w.SetTag()


### PR DESCRIPTION
gofmt -r '(α(β)) -> α(β)' -w .