### PR TITLE
Remove some global variables

### DIFF
--- a/acme.go
+++ b/acme.go
@@ -52,8 +52,6 @@ func main() {
 	bartflag = *bartflagflag
 	swapscrollbuttons = *swapscrollbuttonsflag
 
-	cputype = os.Getenv("cputype")
-	objtype = os.Getenv("objtype")
 	home = os.Getenv("HOME")
 	acmeshell = os.Getenv("acmeshell")
 	p := os.Getenv("tabstop")

--- a/dat.go
+++ b/dat.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"image"
 	"math"
 	"os"
 	"runtime/debug"
@@ -102,16 +101,12 @@ var (
 	activewin         *Window
 	activecol         *Column
 	snarfbuf          Buffer
-	nullrect          image.Rectangle
-	cputype           string
-	objtype           string
 	home              string
 	acmeshell         string
 	tagcolors         [frame.NumColours]*draw.Image
 	textcolors        [frame.NumColours]*draw.Image
 	wdir              string
 	editing           = Inactive
-	messagesize       int
 	globalautoindent  bool
 	mtpt              string
 
@@ -189,6 +184,7 @@ type Xfid struct {
 
 type responder interface {
 	respond(x *Xfid, t *plan9.Fcall, err error) *Xfid
+	msize() int
 }
 
 type RangeSet []Range

--- a/text.go
+++ b/text.go
@@ -96,7 +96,7 @@ func (t *Text) Init(r image.Rectangle, rf string, cols [frame.NumColours]*draw.I
 	t.all = r
 	t.scrollr = r
 	t.scrollr.Max.X = r.Min.X + t.display.ScaleSize(Scrollwid)
-	t.lastsr = nullrect
+	t.lastsr = image.ZR
 	r.Min.X += t.display.ScaleSize(Scrollwid) + t.display.ScaleSize(Scrollgap)
 	t.eq0 = ^0
 	t.font = rf

--- a/wind.go
+++ b/wind.go
@@ -39,7 +39,6 @@ type Window struct {
 	eventx *Xfid
 	events []byte
 
-	nevents     int
 	owner       int
 	maxlines    int
 	dirnames    []string
@@ -683,7 +682,6 @@ func (w *Window) Eventf(format string, args ...interface{}) {
 	b := []byte(fmt.Sprintf(format, args...))
 	w.events = append(w.events, byte(w.owner))
 	w.events = append(w.events, b...)
-	w.nevents = len(w.events)
 	x = w.eventx
 	if x != nil {
 		w.eventx = nil

--- a/xfid.go
+++ b/xfid.go
@@ -201,7 +201,7 @@ func xfidopen(x *Xfid) {
 		}
 	}
 	fc.Qid = x.f.qid
-	fc.Iounit = uint32(messagesize - plan9.IOHDRSZ)
+	fc.Iounit = uint32(x.fs.msize() - plan9.IOHDRSZ)
 	x.f.open = true
 	x.respond(&fc, nil)
 }


### PR DESCRIPTION
- Remove cputype/objtype because we have runtime.GOARCH/runtime.GOOS
- Move messagesize to fileServer struct
- Replace nullrect with image.ZR