### PR TITLE
Remove slash from default error window name

### DIFF
--- a/text.go
+++ b/text.go
@@ -302,9 +302,8 @@ func (t *Text) Load(q0 int, filename string, setqid bool) (nread int, err error)
 		}
 		t.file.isdir = true
 		t.w.filemenu = false
-		// TODO(flux): Find all '/' and replace with filepath.Separator properly
-		if len(t.file.name) > 0 && !strings.HasSuffix(t.file.name, "/") {
-			t.file.name = t.file.name + "/"
+		if len(t.file.name) > 0 && !strings.HasSuffix(t.file.name, string(filepath.Separator)) {
+			t.file.name = t.file.name + string(filepath.Separator)
 			t.w.SetName(t.file.name)
 		}
 		dirNames, err := fd.Readdirnames(0)
@@ -318,7 +317,7 @@ func (t *Text) Load(q0 int, filename string, setqid bool) (nread int, err error)
 				warning(nil, "can't stat %s: %v\n", dn, err)
 			} else {
 				if s.IsDir() {
-					dirNames[i] = dn + "/"
+					dirNames[i] = dn + string(filepath.Separator)
 				}
 			}
 		}

--- a/util.go
+++ b/util.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"image"
 	"log"
+	"path/filepath"
 	"strings"
 	"unicode/utf8"
 
@@ -114,10 +115,22 @@ func cvttorunes(p []byte, n int) (r []rune, nb int, nulls bool) {
 	return
 }
 
-func errorwin1(dir string, incl []string) *Window {
-	var Lpluserrors = "+Errors"
+func errorwin1Name(dir string) string {
+	const Lpluserrors = "+Errors"
+	var b strings.Builder
 
-	r := dir + string("/") + Lpluserrors
+	if len(dir) > 0 {
+		b.WriteString(dir)
+		if !strings.HasSuffix(dir, string(filepath.Separator)) {
+			b.WriteRune(filepath.Separator)
+		}
+	}
+	b.WriteString(Lpluserrors)
+	return b.String()
+}
+
+func errorwin1(dir string, incl []string) *Window {
+	r := errorwin1Name(dir)
 	w := lookfile(r)
 	if w == nil {
 		if len(row.col) == 0 {

--- a/util_test.go
+++ b/util_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 )
@@ -29,6 +30,27 @@ func TestCvttorunes(t *testing.T) {
 		if !reflect.DeepEqual(r, tc.r) || nb != tc.nb || nulls != tc.nulls {
 			t.Errorf("cvttorunes of (%q, %v) returned %q, %v, %v; expected %q, %v, %v\n",
 				tc.p, tc.n, r, nb, nulls, tc.r, tc.nb, tc.nulls)
+		}
+	}
+}
+
+func TestErrorwin1Name(t *testing.T) {
+	tt := []struct {
+		dir, name string
+	}{
+		{"", "+Errors"},
+		{"/", "/+Errors"},
+		{"/home/gopher", "/home/gopher/+Errors"},
+		{"/home/gopher/", "/home/gopher/+Errors"},
+		{"C:/Users/gopher", "C:/Users/gopher/+Errors"},
+		{"C:/Users/gopher/", "C:/Users/gopher/+Errors"},
+		{"C:", "C:/+Errors"},
+		{"C:/", "C:/+Errors"},
+	}
+	for _, tc := range tt {
+		name := filepath.ToSlash(errorwin1Name(filepath.FromSlash(tc.dir)))
+		if name != tc.name {
+			t.Errorf("errorwin1Name(%q) is %q; expected %q", tc.dir, name, tc.name)
 		}
 	}
 }


### PR DESCRIPTION
Default error window name should be "+Error", not "/+Error". This
allows access to files relative to the directory Edwood was launched in,
instead of relative to /.

Also append `\` instead of `/` to directories in Windows.