### PR TITLE
Get duitdraw working in macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,30 @@ Named *edwood* in celebration of the  formative influence of Ed Wood on
 Plan9 and the truth of
 [ed](http://www.dcs.ed.ac.uk/home/jec/texts/ed.html)-iting.
 
-Note that Edwood (as with Acme) requires some infrastructure from
+Note that on unix systems, Edwood (as with Acme) requires some infrastructure from
 [plan9port](https://9fans.github.io/plan9port/): in particular
-`devdraw` and the p9p font server. So to actually use this, you'll want
+`devdraw`, `9pserve` and `fontsrv`. So to actually use this, you'll want
 to install [plan9port](https://9fans.github.io/plan9port/) first.
+
+## Edwood without plan9port
+
+On Windows, plan9port is not required. Work to remove dependency
+on plan9port in unix systems is currently in progress (see [issue
+#205](https://github.com/rjkroege/edwood/issues/205)).  To use
+[duitdraw](https://github.com/ktye/duitdraw) instead of plan9port
+`devdraw`, us the `duitdraw` build tag:
+
+	go install -tags duitdraw
+
+Duitdraw can use TTF fonts or compressed Plan 9 bitmap fonts. If the font
+name is empty, the [Go Font](https://blog.golang.org/go-fonts) is used.
+Example usage:
+
+	edwood -f '' -F '' 	# Use Go font
+	edwood -f @12pt -F @12pt	# Go font at 12pt
+	edwood -f /usr/share/fonts/TTF/DejaVuSans.ttf@12pt -F /usr/share/fonts/TTF/DejaVuSansMono.ttf@12pt
+	edwood -f $PLAN9/font/lucsans/euro.8.font -F $PLAN9/font/lucm/unicode.9.font
+
 
 # Contributions
 Contributions are welcome. Just submit a pull request and we'll review
@@ -34,8 +54,3 @@ with Edwood or if your favourite Acme feature doesn't work.
 * More configurability: styles, keyboard shortcuts, autocomplete.
 * See the issues list for the details.
 * Improve the testing [code coverage](https://codecov.io/gh/rjkroege/edwood)
-
-
-
-
-

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/atotto/clipboard v0.1.1 // indirect
 	github.com/fhs/mux9p v0.1.0
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect
-	github.com/ktye/duitdraw v0.0.0-20190318200808-2a25ee932d93
+	github.com/ktye/duitdraw v0.0.0-20190325213621-8726aaefa68b
 	golang.org/x/exp v0.0.0-20190212162250-21964bba6549 // indirect
 	golang.org/x/image v0.0.0-20190209060608-ef4a1470e0dc // indirect
 	golang.org/x/mobile v0.0.0-20190127143845-a42111704963 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/ktye/duitdraw v0.0.0-20190219064924-3c3ad83d3d95 h1:CE5Ax9xJ0Z5qLxMZR
 github.com/ktye/duitdraw v0.0.0-20190219064924-3c3ad83d3d95/go.mod h1:TsTcPGNjOvXTtzBTFZdpRDbSnhDizngqzp0Q6ZipRYk=
 github.com/ktye/duitdraw v0.0.0-20190318200808-2a25ee932d93 h1:5PNDr3d4AwJNzdzaD48JIkP1YSOS8y6/vTGaBlVWY54=
 github.com/ktye/duitdraw v0.0.0-20190318200808-2a25ee932d93/go.mod h1:TsTcPGNjOvXTtzBTFZdpRDbSnhDizngqzp0Q6ZipRYk=
+github.com/ktye/duitdraw v0.0.0-20190325213621-8726aaefa68b h1:KRNdZ+TwKLodlevAwi6RQ736TE11t99BDw3EM7JWRrA=
+github.com/ktye/duitdraw v0.0.0-20190325213621-8726aaefa68b/go.mod h1:TsTcPGNjOvXTtzBTFZdpRDbSnhDizngqzp0Q6ZipRYk=
 golang.org/x/exp v0.0.0-20190212162250-21964bba6549 h1:lHlZGt5KQ2yKMtuXfrRfOEyKdH94NK3PR9o4Zr+Qn6g=
 golang.org/x/exp v0.0.0-20190212162250-21964bba6549/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/image v0.0.0-20190209060608-ef4a1470e0dc h1:P8UBp9iv2ZY5xjf9rnwI9s/hywlCgyKzpLsfk30IVyw=

--- a/internal/draw/9fans.go
+++ b/internal/draw/9fans.go
@@ -44,3 +44,13 @@ type (
 )
 
 var Init = draw.Init
+
+func Main(f func(*Device)) {
+	f(new(Device))
+}
+
+type Device struct{}
+
+func (dev *Device) NewDisplay(errch chan<- error, fontname, label, winsize string) (*Display, error) {
+	return Init(errch, fontname, label, winsize)
+}

--- a/internal/draw/duitdraw.go
+++ b/internal/draw/duitdraw.go
@@ -35,6 +35,7 @@ const (
 
 type (
 	Cursor      = draw.Cursor
+	Device      = draw.Device
 	Display     = draw.Display
 	Font        = draw.Font
 	Image       = draw.Image
@@ -43,4 +44,7 @@ type (
 	Mouse       = draw.Mouse
 )
 
-var Init = draw.Init
+var (
+	Init = draw.Init
+	Main = draw.Main
+)


### PR DESCRIPTION
Duitdraw in macOS require special handling so that things run on the
same thread as `main.main`. See
https://github.com/ktye/duitdraw/issues/12

Based on my testing, duitdraw on macOS is more buggy than X11 and
Windows, but this at least gets Edwood in a usable state. It often
segfaults when you resize Edwood.