### PR TITLE
Change dump file format to use JSON

### DIFF
--- a/acme.go
+++ b/acme.go
@@ -16,6 +16,7 @@ import (
 
 	"9fans.net/go/plumb"
 	"github.com/rjkroege/edwood/internal/draw"
+	"github.com/rjkroege/edwood/internal/dumpfile"
 	"github.com/rjkroege/edwood/internal/frame"
 )
 
@@ -64,7 +65,7 @@ func main() {
 	}
 
 	if loadfile != "" {
-		fontnames := LoadFonts(loadfile) // Overrides fonts selected up to here.
+		fontnames := dumpfile.LoadFonts(loadfile) // Overrides fonts selected up to here.
 		if len(fontnames) == 2 {
 			*varfontflag = fontnames[0]
 			*fixedfontflag = fontnames[1]

--- a/acme.go
+++ b/acme.go
@@ -64,11 +64,18 @@ func main() {
 		maxtab = 4
 	}
 
+	var dump *dumpfile.Content
+
 	if loadfile != "" {
-		fontnames := dumpfile.LoadFonts(loadfile) // Overrides fonts selected up to here.
-		if len(fontnames) == 2 {
-			*varfontflag = fontnames[0]
-			*fixedfontflag = fontnames[1]
+		d, err := dumpfile.Load(loadfile) // Overrides fonts selected up to here.
+		if err == nil {
+			if d.VarFont != "" {
+				*varfontflag = d.VarFont
+			}
+			if d.FixedFont != "" {
+				*fixedfontflag = d.FixedFont
+			}
+			dump = d
 		}
 	}
 
@@ -121,7 +128,7 @@ func main() {
 		const WindowsPerCol = 6
 
 		row.Init(display.ScreenImage.R, display)
-		if loadfile == "" || row.Load(loadfile, true) != nil {
+		if loadfile == "" || row.Load(dump, loadfile, true) != nil {
 			// Open the files from the command line, up to WindowsPerCol each
 			files := flag.Args()
 			if ncol < 0 {

--- a/exec.go
+++ b/exec.go
@@ -1106,6 +1106,6 @@ func dump(et *Text, _ *Text, argt *Text, isdump bool, _ bool, arg string) {
 	if isdump {
 		row.Dump(name)
 	} else {
-		row.Load(name, false)
+		row.Load(nil, name, false)
 	}
 }

--- a/fsys_test.go
+++ b/fsys_test.go
@@ -109,7 +109,7 @@ func augmentPathEnv() {
 // startAcme runs an edwood process and 9p mounts it (at acme) in the
 // namespace so that a test may exercise IPC to the subordinate edwood
 // process.
-func startAcme(t *testing.T) *Acme {
+func startAcme(t *testing.T, args ...string) *Acme {
 	// If $USER is not set (i.e. running in a Docker container)
 	// MountService will fail. Detect this and give up if this is so.
 	if _, hzuser := os.LookupEnv("USER"); !hzuser {
@@ -123,7 +123,7 @@ func startAcme(t *testing.T) *Acme {
 	os.Setenv("NAMESPACE", ns)
 	augmentPathEnv()
 
-	acmd := exec.Command(os.Args[0])
+	acmd := exec.Command(os.Args[0], args...)
 	acmd.Env = append(os.Environ(), "TEST_MAIN=edwood")
 
 	acmd.Stdout = os.Stdout
@@ -407,7 +407,7 @@ func TestFSysAddr(t *testing.T) {
 	text := `
 This is a short block
 Of text crafted
-Just for this 
+Just for this
 Occasion
 `
 	reportchan, exitchan := tfs.startlog()

--- a/internal/dumpfile/parse.go
+++ b/internal/dumpfile/parse.go
@@ -29,7 +29,7 @@ type Content struct {
 	CurrentDir string   // Edwood's current working directory
 	VarFont    string   // Variable width font
 	FixedFont  string   // Fixed width font
-	RowTag     string   // Top-most tag (usually "Newcol ... Exit")
+	RowTag     Text     // Top-most tag (usually "Newcol ... Exit")
 	Columns    []Column // List of columns
 	Windows    []Window // List of windows across all columns
 }
@@ -37,7 +37,7 @@ type Content struct {
 // Column stores the state of a column in Edwood.
 type Column struct {
 	Position float64 // Position within the row (in percentage)
-	Tag      string  // Tag above the column (usually "New ... Delcol")
+	Tag      Text    // Tag above the column (usually "New ... Delcol")
 }
 
 // Window stores the state of a window in Edwood.
@@ -45,8 +45,6 @@ type Window struct {
 	Type WindowType // Type of window
 
 	Column   int     // Column index where the window will be placed
-	Q0       int     // Selection starts at the rune at this position
-	Q1       int     // Selection ends before the rune at this position
 	Position float64 // Position within the column (in percentage)
 	Font     string  `json:",omitempty"` // Font name or path
 
@@ -57,14 +55,23 @@ type Window struct {
 	//IsDir bool	// redundant
 	//Dirty bool	// WindowType == Unsaved
 
-	Tag string // Tag above this window (usually "/path/to/file Del ...")
+	Tag Text // Tag above this window (usually "/path/to/file Del ...")
 
-	// Used for Type == Unsaved
-	Body string `json:",omitempty"` // Unsaved text buffer
+	// Text buffer and selection of body.
+	// Body.Buffer is empty if Type == Unsaved.
+	Body Text
 
 	// Used for Type == Exec
 	ExecDir     string `json:",omitempty"` // Execute command in this directory
 	ExecCommand string `json:",omitempty"` // Command to execute
+}
+
+// Text is a UTF-8 encoded text with a substring selected
+// using rune-indexing (instead of byte-indexing).
+type Text struct {
+	Buffer string `json:",omitempty"` // UTF-8 encoded text
+	Q0     int    // Selection starts at this rune position
+	Q1     int    // Selection ends before this rune position
 }
 
 type versionedContent struct {

--- a/internal/dumpfile/parse.go
+++ b/internal/dumpfile/parse.go
@@ -26,49 +26,49 @@ const (
 
 // Content stores the state of Edwood.
 type Content struct {
-	CurrentDir string
-	VarFont    string // Variable width font
-	FixedFont  string // Fixed width font
-	RowTag     string
-	Columns    []Column
-	Windows    []Window
+	CurrentDir string   // Edwood's current working directory
+	VarFont    string   // Variable width font
+	FixedFont  string   // Fixed width font
+	RowTag     string   // Top-most tag (usually "Newcol ... Exit")
+	Columns    []Column // List of columns
+	Windows    []Window // List of windows across all columns
 }
 
 // Column stores the state of a column in Edwood.
 type Column struct {
 	Position float64 // Position within the row (in percentage)
-	Tag      string
+	Tag      string  // Tag above the column (usually "New ... Delcol")
 }
 
 // Window stores the state of a window in Edwood.
 type Window struct {
-	Type WindowType
+	Type WindowType // Type of window
 
-	ColumnID int
-	Q0       int
-	Q1       int
+	Column   int     // Column index where the window will be placed
+	Q0       int     // Selection starts at the rune at this position
+	Q1       int     // Selection ends before the rune at this position
 	Position float64 // Position within the column (in percentage)
-	Font     string  `json:",omitempty"`
+	Font     string  `json:",omitempty"` // Font name or path
 
 	// ctl line has these but there is no point storing them:
 	//ID	int	// we regenerate window IDs when loading
 	//TagLen	int	// redundant
 	//BodyLen int	// redundant
 	//IsDir bool	// redundant
+	//Dirty bool	// WindowType == Unsaved
 
-	Dirty bool
-	Tag   string
+	Tag string // Tag above this window (usually "/path/to/file Del ...")
 
 	// Used for Type == Unsaved
-	Body string `json:",omitempty"`
+	Body string `json:",omitempty"` // Unsaved text buffer
 
 	// Used for Type == Exec
-	ExecDir     string `json:",omitempty"`
-	ExecCommand string `json:",omitempty"`
+	ExecDir     string `json:",omitempty"` // Execute command in this directory
+	ExecCommand string `json:",omitempty"` // Command to execute
 }
 
 type versionedContent struct {
-	Version int
+	Version int // Dump file format version
 	*Content
 }
 

--- a/internal/dumpfile/parse.go
+++ b/internal/dumpfile/parse.go
@@ -123,23 +123,3 @@ func (c *Content) encode(w io.Writer) error {
 	enc.SetIndent("", "\t")
 	return enc.Encode(&vc)
 }
-
-// LoadFonts gets the font names from the load file so we don't load
-// fonts that we won't use.
-func LoadFonts(file string) []string {
-	// TODO(fhs): Maybe return two strings instead of a slice,
-	// or remove this function altogether and have Edwood's main call Load
-	// only once at the beginning.
-
-	dump, err := Load(file)
-	if err != nil {
-		return nil
-	}
-	if dump.VarFont == "" || dump.FixedFont == "" {
-		return nil
-	}
-	return []string{
-		dump.VarFont,
-		dump.FixedFont,
-	}
-}

--- a/internal/dumpfile/parse.go
+++ b/internal/dumpfile/parse.go
@@ -1,0 +1,138 @@
+// Package dumpfile implements encoding and decoding of Edwood dump file.
+//
+// A dump file stores the state of Edwood so that it can be restored
+// when Edwood is restarted.
+package dumpfile
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+)
+
+const version = 1
+
+// WindowType defines the type of window.
+type WindowType int
+
+const (
+	Saved   WindowType = iota // Saved is a File and directory stored on disk
+	Unsaved                   // Unsaved contains buffer that's not stored on disk
+	Zerox                     // Zerox is a copy of a Saved or Unsaved window
+	Exec                      // Exec is a window controlled by an outside process
+)
+
+// Content stores the state of Edwood.
+type Content struct {
+	CurrentDir string
+	VarFont    string // Variable width font
+	FixedFont  string // Fixed width font
+	RowTag     string
+	Columns    []Column
+	Windows    []Window
+}
+
+// Column stores the state of a column in Edwood.
+type Column struct {
+	Position float64 // Position within the row (in percentage)
+	Tag      string
+}
+
+// Window stores the state of a window in Edwood.
+type Window struct {
+	Type WindowType
+
+	ColumnID int
+	Q0       int
+	Q1       int
+	Position float64 // Position within the column (in percentage)
+	Font     string  `json:",omitempty"`
+
+	// ctl line has these but there is no point storing them:
+	//ID	int	// we regenerate window IDs when loading
+	//TagLen	int	// redundant
+	//BodyLen int	// redundant
+	//IsDir bool	// redundant
+
+	Dirty bool
+	Tag   string
+
+	// Used for Type == Unsaved
+	Body string `json:",omitempty"`
+
+	// Used for Type == Exec
+	ExecDir     string `json:",omitempty"`
+	ExecCommand string `json:",omitempty"`
+}
+
+type versionedContent struct {
+	Version int
+	*Content
+}
+
+// Load parses the dump file and returns its content.
+func Load(file string) (*Content, error) {
+	f, err := os.Open(file)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return decode(bufio.NewReader(f))
+}
+
+func decode(r io.Reader) (*Content, error) {
+	var vc versionedContent
+
+	dec := json.NewDecoder(r)
+	err := dec.Decode(&vc)
+	if err != nil {
+		return nil, err
+	}
+	if vc.Version != version {
+		return nil, fmt.Errorf("dump file format %v; expected %v", vc.Version, version)
+	}
+	return vc.Content, nil
+}
+
+// Save encodes the dump file content and writes it to file.
+func (c *Content) Save(file string) error {
+	f, err := os.OpenFile(file, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	return c.encode(f)
+}
+
+func (c *Content) encode(w io.Writer) error {
+	vc := versionedContent{
+		Version: version,
+		Content: c,
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "\t")
+	return enc.Encode(&vc)
+}
+
+// LoadFonts gets the font names from the load file so we don't load
+// fonts that we won't use.
+func LoadFonts(file string) []string {
+	// TODO(fhs): Maybe return two strings instead of a slice,
+	// or remove this function altogether and have Edwood's main call Load
+	// only once at the beginning.
+
+	dump, err := Load(file)
+	if err != nil {
+		return nil
+	}
+	if dump.VarFont == "" || dump.FixedFont == "" {
+		return nil
+	}
+	return []string{
+		dump.VarFont,
+		dump.FixedFont,
+	}
+}

--- a/internal/dumpfile/parse_test.go
+++ b/internal/dumpfile/parse_test.go
@@ -14,15 +14,21 @@ var testTab = []Content{
 		CurrentDir: "/home/gopher",
 		VarFont:    "/lib/fonts/go-font/regular.font",
 		FixedFont:  "/lib/fonts/go-font/mono.font",
-		RowTag:     "Newcol Kill Putall Dump Exit",
+		RowTag: Text{
+			Buffer: "Newcol Kill Putall Dump Exit",
+		},
 		Columns: []Column{
 			{
 				Position: 0,
-				Tag:      "New Cut Paste Snarf Sort Zerox Delcol",
+				Tag: Text{
+					Buffer: "New Cut Paste Snarf Sort Zerox Delcol",
+				},
 			},
 			{
 				Position: 50,
-				Tag:      "New Cut Paste Snarf Sort Zerox Delcol",
+				Tag: Text{
+					Buffer: "New Cut Paste Snarf Sort Zerox Delcol",
+				},
 			},
 		},
 		Windows: []Window{},

--- a/internal/dumpfile/parse_test.go
+++ b/internal/dumpfile/parse_test.go
@@ -1,0 +1,142 @@
+package dumpfile
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+var testTab = []Content{
+	{
+		CurrentDir: "/home/gopher",
+		VarFont:    "/lib/fonts/go-font/regular.font",
+		FixedFont:  "/lib/fonts/go-font/mono.font",
+		RowTag:     "Newcol Kill Putall Dump Exit",
+		Columns: []Column{
+			{
+				Position: 0,
+				Tag:      "New Cut Paste Snarf Sort Zerox Delcol",
+			},
+			{
+				Position: 50,
+				Tag:      "New Cut Paste Snarf Sort Zerox Delcol",
+			},
+		},
+		Windows: []Window{},
+	},
+}
+
+func TestEncodeDecode(t *testing.T) {
+	for _, tc := range testTab {
+		var b bytes.Buffer
+
+		err := tc.encode(&b)
+		if err != nil {
+			t.Errorf("Marshal failed: %v\n", err)
+			continue
+		}
+
+		dump := b.Bytes()
+
+		c, err := decode(bytes.NewReader(dump))
+		if err != nil {
+			t.Errorf("Unmarshal failed: %v\n", err)
+			continue
+		}
+		if reflect.DeepEqual(tc, c) {
+			t.Logf("Dump file:\n%s\n", dump)
+			t.Errorf("content is %#v; expected %#v\n", c, tc)
+		}
+	}
+}
+
+func TestSaveLoad(t *testing.T) {
+	var tc Content
+
+	file, err := ioutil.TempFile("", "edwood-dumpfile-")
+	if err != nil {
+		t.Fatalf("failed to create temporary file: %v", err)
+	}
+	defer os.Remove(file.Name())
+
+	err = tc.Save(file.Name())
+	if err != nil {
+		t.Fatalf("Save failed: %v\n", err)
+	}
+
+	c, err := Load(file.Name())
+	if err != nil {
+		t.Fatalf("Unmarshal failed: %v\n", err)
+	}
+	if reflect.DeepEqual(tc, c) {
+		t.Errorf("content is %#v; expected %#v\n", c, tc)
+	}
+}
+
+const shortFile = `{"Version": 1,
+"CurrentDir": "/Users/rjkroege/tools/gopkg/src/github.com/rjkroege/edwood",
+"VarFont": "/mnt/font/GoRegular/13a/font"}
+`
+
+const fullFile = `{"Version": 1,
+"CurrentDir": "/Users/rjkroege/tools/gopkg/src/github.com/rjkroege/edwood",
+"VarFont": "/mnt/font/GoRegular/13a/font",
+"FixedFont": "/mnt/font/Iosevka/12a/font"}
+`
+
+func TestLoadFonts(t *testing.T) {
+	dir, err := ioutil.TempDir("", "testloadfonts")
+	if err != nil {
+		t.Fatal("TestLoadFonts can't make directory:", err)
+	}
+	defer os.RemoveAll(dir)
+
+	if resp := LoadFonts(filepath.Join(dir, "not_there")); resp != nil {
+		t.Errorf("TestLoadFonts not_there want nil, got %#v", resp)
+	}
+
+	f, err := os.Create(filepath.Join(dir, "invalid_file"))
+	if err != nil {
+		t.Fatal("TestLoadFonts invalid_file can't create file:", err)
+	}
+	f.Close()
+
+	if resp := LoadFonts(filepath.Join(dir, "invalid_file")); resp != nil {
+		t.Errorf("TestLoadFonts invalid_file want nil, got %#v", resp)
+	}
+
+	f, err = os.Create(filepath.Join(dir, "short_file"))
+	if err != nil {
+		t.Fatal("TestLoadFonts short_file can't create file:", err)
+	}
+	if _, err := f.WriteString(shortFile); err != nil {
+		t.Fatal("TestLoadFonts short_file can't write file:", err)
+	}
+	f.Close()
+
+	if resp := LoadFonts(filepath.Join(dir, "short_file")); resp != nil {
+		t.Errorf("TestLoadFonts short_file want nil, got %#v", resp)
+	}
+
+	f, err = os.Create(filepath.Join(dir, "full_file"))
+	if err != nil {
+		t.Fatal("TestLoadFonts full_file can't create file:", err)
+	}
+	if _, err := f.WriteString(fullFile); err != nil {
+		t.Fatal("TestLoadFonts full_file can't write file:", err)
+	}
+	f.Close()
+
+	if resp := LoadFonts(filepath.Join(dir, "full_file")); !reflect.DeepEqual(resp, []string{
+		"/mnt/font/GoRegular/13a/font",
+		"/mnt/font/Iosevka/12a/font",
+	}) {
+		t.Errorf("TestLoadFonts full_file want %v, got %v", []string{
+			"/mnt/font/GoRegular/13a/font",
+			"/mnt/font/Iosevka/12a/font",
+		}, resp)
+	}
+}

--- a/internal/dumpfile/parse_test.go
+++ b/internal/dumpfile/parse_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"reflect"
 	"testing"
 )
@@ -79,70 +78,5 @@ func TestSaveLoad(t *testing.T) {
 	}
 	if reflect.DeepEqual(tc, c) {
 		t.Errorf("content is %#v; expected %#v\n", c, tc)
-	}
-}
-
-const shortFile = `{"Version": 1,
-"CurrentDir": "/Users/rjkroege/tools/gopkg/src/github.com/rjkroege/edwood",
-"VarFont": "/mnt/font/GoRegular/13a/font"}
-`
-
-const fullFile = `{"Version": 1,
-"CurrentDir": "/Users/rjkroege/tools/gopkg/src/github.com/rjkroege/edwood",
-"VarFont": "/mnt/font/GoRegular/13a/font",
-"FixedFont": "/mnt/font/Iosevka/12a/font"}
-`
-
-func TestLoadFonts(t *testing.T) {
-	dir, err := ioutil.TempDir("", "testloadfonts")
-	if err != nil {
-		t.Fatal("TestLoadFonts can't make directory:", err)
-	}
-	defer os.RemoveAll(dir)
-
-	if resp := LoadFonts(filepath.Join(dir, "not_there")); resp != nil {
-		t.Errorf("TestLoadFonts not_there want nil, got %#v", resp)
-	}
-
-	f, err := os.Create(filepath.Join(dir, "invalid_file"))
-	if err != nil {
-		t.Fatal("TestLoadFonts invalid_file can't create file:", err)
-	}
-	f.Close()
-
-	if resp := LoadFonts(filepath.Join(dir, "invalid_file")); resp != nil {
-		t.Errorf("TestLoadFonts invalid_file want nil, got %#v", resp)
-	}
-
-	f, err = os.Create(filepath.Join(dir, "short_file"))
-	if err != nil {
-		t.Fatal("TestLoadFonts short_file can't create file:", err)
-	}
-	if _, err := f.WriteString(shortFile); err != nil {
-		t.Fatal("TestLoadFonts short_file can't write file:", err)
-	}
-	f.Close()
-
-	if resp := LoadFonts(filepath.Join(dir, "short_file")); resp != nil {
-		t.Errorf("TestLoadFonts short_file want nil, got %#v", resp)
-	}
-
-	f, err = os.Create(filepath.Join(dir, "full_file"))
-	if err != nil {
-		t.Fatal("TestLoadFonts full_file can't create file:", err)
-	}
-	if _, err := f.WriteString(fullFile); err != nil {
-		t.Fatal("TestLoadFonts full_file can't write file:", err)
-	}
-	f.Close()
-
-	if resp := LoadFonts(filepath.Join(dir, "full_file")); !reflect.DeepEqual(resp, []string{
-		"/mnt/font/GoRegular/13a/font",
-		"/mnt/font/Iosevka/12a/font",
-	}) {
-		t.Errorf("TestLoadFonts full_file want %v, got %v", []string{
-			"/mnt/font/GoRegular/13a/font",
-			"/mnt/font/Iosevka/12a/font",
-		}, resp)
 	}
 }

--- a/look.go
+++ b/look.go
@@ -566,26 +566,6 @@ func lookfile(s string) *Window {
 	return nil
 }
 
-/*
-func lookid (int id, int dump) (Window*) {
-	int i, j;
-	Window *w;
-	Column *c;
-
-	for j=0; j<row.ncol; j++ {
-		c = row.col[j];
-		for i=0; i<c.nw; i++ {
-			w = c.w[i];
-			if dump && w.dumpid == id
-				return w;
-			if !dump && w.id == id
-				return w;
-		}
-	}
-	return nil;
-}
-*/
-
 func openfile(t *Text, e *Expand) *Window {
 	var (
 		r     Range

--- a/row.go
+++ b/row.go
@@ -342,7 +342,10 @@ func (r *Row) Dump(file string) {
 				Q1:     c.tag.q1,
 			},
 		}
-		// TODO(fhs): replace File.dumpid with a local variable map[*File]int
+		// TODO(fhs): replace File.dumpid with a local variable map[*File]int.
+		// Also, dumpid initialized here depends on the order of windows:
+		// we may be setting dumpid for an external window to -1, and then
+		// resetting it back to 0 for a zerox of that window.
 		for _, w := range c.w {
 			w.body.file.dumpid = 0
 			if w.nopen[QWevent] != 0 {
@@ -450,12 +453,12 @@ func (row *Row) loadhelper(win *dumpfile.Window) error {
 		return nil
 	}
 
-	// My understanding of the Acme code was that subl[0] is the original file name
-	// without spaces.
 	if win.Type != dumpfile.Zerox {
 		w.SetName(subl[0])
 	}
 
+	// TODO(rjk): I feel that the code for managing tags could be extracted and unified.
+	// Maybe later. Window.setTag1 would seem fixable.
 	afterbar := strings.SplitN(subl[1], "|", 2)
 	if len(afterbar) != 2 {
 		return fmt.Errorf("bad window tag in dump file %q", win.Tag)
@@ -600,7 +603,7 @@ func (row *Row) loadimpl(dump *dumpfile.Content, initing bool) error {
 	}
 
 	// Set row tag
-	row.tag.Delete(0, len(row.tag.file.b), true)
+	row.tag.Delete(0, row.tag.file.Size(), true)
 	row.tag.Insert(0, []rune(dump.RowTag.Buffer), true)
 	row.tag.Show(dump.RowTag.Q0, dump.RowTag.Q1, true)
 
@@ -609,7 +612,7 @@ func (row *Row) loadimpl(dump *dumpfile.Content, initing bool) error {
 		// Acme's handling of column headers is perplexing. It is conceivable
 		// that this code does not do the right thing even if it replicates Acme
 		// correctly.
-		row.col[i].tag.Delete(0, len(row.col[i].tag.file.b), true)
+		row.col[i].tag.Delete(0, row.col[i].tag.file.Size(), true)
 		row.col[i].tag.Insert(0, []rune(col.Tag.Buffer), true)
 		row.col[i].tag.Show(col.Tag.Q0, col.Tag.Q1, true)
 	}

--- a/row.go
+++ b/row.go
@@ -367,7 +367,7 @@ func (r *Row) Dump(file string) {
 			fontname := t.font
 
 			dump.Windows = append(dump.Windows, dumpfile.Window{
-				ColumnID: i,
+				Column:   i,
 				Q0:       w.body.q0,
 				Q1:       w.body.q1,
 				Position: 100.0 * float64(w.r.Min.Y-c.r.Min.Y) / float64(c.r.Dy()),
@@ -394,7 +394,6 @@ func (r *Row) Dump(file string) {
 				dw.Type = dumpfile.Unsaved
 				dw.Body = string(t.file.b)
 			}
-			dw.Dirty = t.file.Dirty()
 			dw.Tag = string(w.tag.file.b)
 
 		}
@@ -411,7 +410,7 @@ func (r *Row) Dump(file string) {
 // types.
 func (row *Row) loadhelper(win *dumpfile.Window) error {
 	// Column for this window.
-	i := win.ColumnID
+	i := win.Column
 
 	if i > len(row.col) { // Didn't we already make sure that we have a column?
 		i = len(row.col)

--- a/row_test.go
+++ b/row_test.go
@@ -1,72 +1,250 @@
 package main
 
 import (
+	"bytes"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"reflect"
+	"runtime"
+	"strconv"
+	"strings"
 	"testing"
+
+	"9fans.net/go/plan9"
+	"9fans.net/go/plan9/client"
+	"github.com/rjkroege/edwood/internal/dumpfile"
 )
 
-const shortFile = `/Users/rjkroege/tools/gopkg/src/github.com/rjkroege/edwood
-/mnt/font/GoRegular/13a/font
-`
+func TestRowLoad(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
 
-const fullFile = `/Users/rjkroege/tools/gopkg/src/github.com/rjkroege/edwood
-/mnt/font/GoRegular/13a/font
-/mnt/font/Iosevka/12a/font
-`
+	tt := []struct {
+		name     string
+		filename string
+	}{
+		{"empty-two-cols", "testdata/empty-two-cols.dump"},
+		{"example", "testdata/example.dump"},
+	}
 
-func TestLoadFonts(t *testing.T) {
-	dir, err := ioutil.TempDir("", "testloadfonts")
+	cwd, err := os.Getwd()
 	if err != nil {
-		t.Fatal("TestLoadFonts can't make directory:", err)
-	}
-	defer os.RemoveAll(dir)
-
-	if resp := LoadFonts(filepath.Join(dir, "not_there")); !reflect.DeepEqual(resp, []string{}) {
-		t.Errorf("TestLoadFonts not_there want %v, got %v", []string{}, resp)
+		t.Fatalf("failed to get current working directory: %v", err)
 	}
 
-	f, err := os.Create(filepath.Join(dir, "invalid_file"))
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := ioutil.ReadFile(tc.filename)
+			if err != nil {
+				t.Fatalf("ReadFile failed: %v", err)
+			}
+			b = bytes.Replace(b, []byte("/home/gopher/go/src/edwood"), []byte(cwd), -1)
+
+			f, err := ioutil.TempFile("", "edwood-*.dump")
+			if err != nil {
+				t.Fatalf("failed to create temporary file: %v", err)
+			}
+			defer os.Remove(f.Name())
+			_, err = f.Write(b)
+			if err != nil {
+				t.Fatalf("write failed: %v", err)
+			}
+			f.Close()
+
+			a := startAcme(t, "-l", f.Name())
+			defer a.Cleanup()
+
+			dump, err := dumpfile.Load(f.Name())
+			if err != nil {
+				t.Fatalf("failed to load dump file %v: %v", tc, err)
+			}
+			checkDump(t, dump, a.fsys)
+		})
+	}
+}
+
+// checkDump checks Edwood's current state matches dump file.
+// It checks that window's Tag, Font, Q0, Q1, and Body matches.
+func checkDump(t *testing.T, dump *dumpfile.Content, fsys *client.Fsys) {
+	wins, err := windows(fsys)
 	if err != nil {
-		t.Fatal("TestLoadFonts invalid_file can't create file:", err)
+		t.Fatalf("failed to get list of windows: %v", err)
 	}
-	f.Close()
-
-	if resp := LoadFonts(filepath.Join(dir, "invalid_file")); !reflect.DeepEqual(resp, []string{}) {
-		t.Errorf("TestLoadFonts invalid_file want %v, got %v", []string{}, resp)
+	printCurrentTags := func() {
+		for _, w := range wins {
+			t.Logf("window id=%v tag=%q", w.id, w.tag)
+		}
 	}
 
-	f, err = os.Create(filepath.Join(dir, "short_file"))
+	// Zerox-ed windows don't show up in index file.
+	// Check number of orginal windows matches.
+	norig := 0
+	for _, w := range dump.Windows {
+		if w.Type != dumpfile.Zerox {
+			norig++
+		}
+	}
+	if got, want := len(wins), norig; got != want {
+		printCurrentTags()
+		t.Fatalf("there are %v original windows; expected %v", got, want)
+	}
+
+	winByName := make(map[string]*winInfo)
+	for i, w := range wins {
+		winByName[w.name] = &wins[i]
+	}
+
+	for _, dw := range dump.Windows {
+		// Zerox-ed windows don't show up in index file.
+		if dw.Type == dumpfile.Zerox {
+			continue
+		}
+		name := strings.SplitN(dw.Tag, " ", 2)[0]
+
+		w, ok := winByName[name]
+		if !ok {
+			printCurrentTags()
+			t.Fatalf("could not find window with tag %q", dw.Tag)
+		}
+
+		// Unsaved window have "Undo" that doesn't get restored
+		if dw.Type != dumpfile.Unsaved && w.tag != dw.Tag {
+			t.Errorf("tag is %q; expected %q", w.tag, dw.Tag)
+		}
+
+		if p := plan9FontPath(dw.Font); w.font != p {
+			t.Errorf("font for %q is %q; expected %q", w.name, w.font, p)
+		}
+
+		if w.q0 != dw.Q0 || w.q1 != dw.Q1 {
+			t.Errorf("q0,q1 for %v is %v,%v; expected %v,%v", w.name, w.q0, w.q1, dw.Q0, dw.Q1)
+		}
+
+		if dw.Type == dumpfile.Unsaved && w.body != dw.Body {
+			t.Errorf("body for %q is %q; expected %q", w.name, w.body, dw.Body)
+		}
+	}
+}
+
+func plan9FontPath(name string) string {
+	const prefix = "/lib/font/bit"
+	if strings.HasPrefix(name, prefix) {
+		root := os.Getenv("PLAN9")
+		if root == "" {
+			root = "/usr/local/plan9"
+		}
+		return filepath.Join(root, "/font/", name[len(prefix):])
+	}
+	return name
+}
+
+type winInfo struct {
+	id     int
+	tag    string
+	name   string
+	font   string
+	q0, q1 int
+	body   string
+}
+
+func fsysReadFile(fsys *client.Fsys, filename string) ([]byte, error) {
+	fid, err := fsys.Open(filename, plan9.OREAD)
 	if err != nil {
-		t.Fatal("TestLoadFonts short_file can't create file:", err)
+		return nil, err
 	}
-	if _, err := f.WriteString(shortFile); err != nil {
-		t.Fatal("TestLoadFonts short_file can't write file:", err)
-	}
-	f.Close()
+	defer fid.Close()
 
-	if resp := LoadFonts(filepath.Join(dir, "short_file")); !reflect.DeepEqual(resp, []string{}) {
-		t.Errorf("TestLoadFonts short_file want %v, got %#v", []string{}, resp)
-	}
+	return ioutil.ReadAll(fid)
+}
 
-	f, err = os.Create(filepath.Join(dir, "full_file"))
+func fsysReadDot(fsys *client.Fsys, id int) (q0, q1 int, err error) {
+	addr, err := fsys.Open(fmt.Sprintf("%v/addr", id), plan9.OREAD)
 	if err != nil {
-		t.Fatal("TestLoadFonts full_file can't create file:", err)
+		return 0, 0, err
 	}
-	if _, err := f.WriteString(fullFile); err != nil {
-		t.Fatal("TestLoadFonts full_file can't write file:", err)
-	}
-	f.Close()
+	defer addr.Close()
 
-	if resp := LoadFonts(filepath.Join(dir, "full_file")); !reflect.DeepEqual(resp, []string{
-		"/mnt/font/GoRegular/13a/font",
-		"/mnt/font/Iosevka/12a/font",
-	}) {
-		t.Errorf("TestLoadFonts full_file want %v, got %v", []string{
-			"/mnt/font/GoRegular/13a/font",
-			"/mnt/font/Iosevka/12a/font",
-		}, resp)
+	ctl, err := fsys.Open(fmt.Sprintf("%v/ctl", id), plan9.OWRITE)
+	if err != nil {
+		return 0, 0, err
 	}
+	defer ctl.Close()
+
+	_, err = ctl.Write([]byte("addr=dot"))
+	if err != nil {
+		return 0, 0, err
+	}
+
+	b, err := ioutil.ReadAll(addr)
+	if err != nil {
+		return 0, 0, err
+	}
+	f := strings.Fields(string(b))
+	q0, err = strconv.Atoi(f[0])
+	if err != nil {
+		return 0, 0, err
+	}
+	q1, err = strconv.Atoi(f[1])
+	if err != nil {
+		return 0, 0, err
+	}
+	return q0, q1, nil
+}
+
+func windows(fsys *client.Fsys) ([]winInfo, error) {
+	index, err := fsysReadFile(fsys, "index")
+	if err != nil {
+		return nil, err
+	}
+
+	var info []winInfo
+	for _, line := range strings.Split(string(index), "\n") {
+		f := strings.Fields(line)
+		if len(f) < 6 {
+			continue
+		}
+		id, err := strconv.Atoi(f[0])
+		if err != nil {
+			return nil, err
+		}
+
+		b, err := fsysReadFile(fsys, fmt.Sprintf("%v/tag", id))
+		if err != nil {
+			return nil, err
+		}
+		tag := string(b)
+		f = strings.SplitN(tag, " ", 2)
+		name := f[0]
+
+		b, err = fsysReadFile(fsys, fmt.Sprintf("%v/ctl", id))
+		if err != nil {
+			return nil, err
+		}
+		f = strings.Fields(string(b))
+		font := f[6]
+
+		q0, q1, err := fsysReadDot(fsys, id)
+		if err != nil {
+			return nil, err
+		}
+
+		b, err = fsysReadFile(fsys, fmt.Sprintf("%v/body", id))
+		if err != nil {
+			return nil, err
+		}
+		body := string(b)
+
+		info = append(info, winInfo{
+			id:   id,
+			name: name,
+			tag:  tag,
+			font: font,
+			q0:   q0,
+			q1:   q1,
+			body: body,
+		})
+	}
+	return info, nil
 }

--- a/row_test.go
+++ b/row_test.go
@@ -27,6 +27,7 @@ func TestRowLoad(t *testing.T) {
 	}{
 		{"empty-two-cols", "testdata/empty-two-cols.dump"},
 		{"example", "testdata/example.dump"},
+		{"multi-line-tag", "testdata/multi-line-tag.dump"},
 	}
 
 	cwd, err := os.Getwd()
@@ -101,7 +102,7 @@ func checkDump(t *testing.T, dump *dumpfile.Content, fsys *client.Fsys) {
 		if dw.Type == dumpfile.Zerox {
 			continue
 		}
-		name := strings.SplitN(dw.Tag, " ", 2)[0]
+		name := strings.SplitN(dw.Tag.Buffer, " ", 2)[0]
 
 		w, ok := winByName[name]
 		if !ok {
@@ -110,7 +111,7 @@ func checkDump(t *testing.T, dump *dumpfile.Content, fsys *client.Fsys) {
 		}
 
 		// Unsaved window have "Undo" that doesn't get restored
-		if dw.Type != dumpfile.Unsaved && w.tag != dw.Tag {
+		if dw.Type != dumpfile.Unsaved && w.tag != dw.Tag.Buffer {
 			t.Errorf("tag is %q; expected %q", w.tag, dw.Tag)
 		}
 
@@ -118,12 +119,12 @@ func checkDump(t *testing.T, dump *dumpfile.Content, fsys *client.Fsys) {
 			t.Errorf("font for %q is %q; expected %q", w.name, w.font, p)
 		}
 
-		if w.q0 != dw.Q0 || w.q1 != dw.Q1 {
-			t.Errorf("q0,q1 for %v is %v,%v; expected %v,%v", w.name, w.q0, w.q1, dw.Q0, dw.Q1)
+		if w.q0 != dw.Body.Q0 || w.q1 != dw.Body.Q1 {
+			t.Errorf("q0,q1 for %v is %v,%v; expected %v,%v", w.name, w.q0, w.q1, dw.Body.Q0, dw.Body.Q1)
 		}
 
-		if dw.Type == dumpfile.Unsaved && w.body != dw.Body {
-			t.Errorf("body for %q is %q; expected %q", w.name, w.body, dw.Body)
+		if dw.Type == dumpfile.Unsaved && w.body != dw.Body.Buffer {
+			t.Errorf("body for %q is %q; expected %q", w.name, w.body, dw.Body.Buffer)
 		}
 	}
 }

--- a/testdata/empty-two-cols.dump
+++ b/testdata/empty-two-cols.dump
@@ -3,15 +3,27 @@
 	"CurrentDir": "/home/gopher/go/src/edwood",
 	"VarFont": "/lib/font/bit/lucsans/euro.8.font",
 	"FixedFont": "/lib/font/bit/lucm/unicode.9.font",
-	"RowTag": "Newcol Kill Putall Dump Exit ",
+	"RowTag": {
+		"Buffer": "Newcol Kill Putall Dump Exit ",
+		"Q0": 29,
+		"Q1": 29
+	},
 	"Columns": [
 		{
 			"Position": 0,
-			"Tag": "New Cut Paste Snarf Sort Zerox Delcol "
+			"Tag": {
+				"Buffer": "New Cut Paste Snarf Sort Zerox Delcol ",
+				"Q0": 38,
+				"Q1": 38
+			}
 		},
 		{
 			"Position": 59.9609375,
-			"Tag": "New Cut Paste Snarf Sort Zerox Delcol "
+			"Tag": {
+				"Buffer": "New Cut Paste Snarf Sort Zerox Delcol ",
+				"Q0": 38,
+				"Q1": 38
+			}
 		}
 	],
 	"Windows": null

--- a/testdata/empty-two-cols.dump
+++ b/testdata/empty-two-cols.dump
@@ -1,0 +1,18 @@
+{
+	"Version": 1,
+	"CurrentDir": "/home/gopher/go/src/edwood",
+	"VarFont": "/lib/font/bit/lucsans/euro.8.font",
+	"FixedFont": "/lib/font/bit/lucm/unicode.9.font",
+	"RowTag": "Newcol Kill Putall Dump Exit ",
+	"Columns": [
+		{
+			"Position": 0,
+			"Tag": "New Cut Paste Snarf Sort Zerox Delcol "
+		},
+		{
+			"Position": 59.9609375,
+			"Tag": "New Cut Paste Snarf Sort Zerox Delcol "
+		}
+	],
+	"Windows": null
+}

--- a/testdata/example.dump
+++ b/testdata/example.dump
@@ -17,53 +17,48 @@
 	"Windows": [
 		{
 			"Type": 1,
-			"ColumnID": 0,
+			"Column": 0,
 			"Q0": 6,
 			"Q1": 15,
 			"Position": 2.263648468708389,
 			"Font": "/lib/font/bit/lucsans/euro.8.font",
-			"Dirty": true,
 			"Tag": "glass Del Snarf Undo Put | Look Edit ",
 			"Body": "I can eat glass and it doesn't hurt me.\nJe peux manger du verre, ça ne me fait pas mal.\n私はガラスを食べられます。それは私を傷つけません。\nআমি কাঁচ খেতে পারি, তাতে আমার কোনো ক্ষতি হয় না।\n"
 		},
 		{
 			"Type": 0,
-			"ColumnID": 0,
+			"Column": 0,
 			"Q0": 8,
 			"Q1": 12,
 			"Position": 12.649800266311585,
 			"Font": "/lib/font/bit/lucsans/euro.8.font",
-			"Dirty": false,
 			"Tag": "/home/gopher/go/src/edwood/row_test.go Del Snarf | Look Edit "
 		},
 		{
 			"Type": 0,
-			"ColumnID": 1,
+			"Column": 1,
 			"Q0": 29,
 			"Q1": 41,
 			"Position": 2.263648468708389,
 			"Font": "/lib/font/bit/lucsans/euro.8.font",
-			"Dirty": true,
 			"Tag": "/home/gopher/go/src/edwood/ Del Snarf Get | Look Edit "
 		},
 		{
 			"Type": 2,
-			"ColumnID": 1,
+			"Column": 1,
 			"Q0": 8,
 			"Q1": 12,
 			"Position": 32.62316910785619,
 			"Font": "/lib/font/bit/lucsans/euro.8.font",
-			"Dirty": false,
 			"Tag": "/home/gopher/go/src/edwood/row_test.go Del Snarf | Look Edit "
 		},
 		{
 			"Type": 1,
-			"ColumnID": 1,
+			"Column": 1,
 			"Q0": 12,
 			"Q1": 23,
 			"Position": 74.96671105193076,
 			"Font": "/lib/font/bit/lucsans/euro.8.font",
-			"Dirty": true,
 			"Tag": " Del Snarf Undo | Look Edit ",
 			"Body": "This window has no name.\n"
 		}

--- a/testdata/example.dump
+++ b/testdata/example.dump
@@ -1,0 +1,71 @@
+{
+	"Version": 1,
+	"CurrentDir": "/home/gopher/go/src/edwood",
+	"VarFont": "/lib/font/bit/lucsans/euro.8.font",
+	"FixedFont": "/lib/font/bit/lucm/unicode.9.font",
+	"RowTag": "win Newcol Kill Putall Dump Exit win",
+	"Columns": [
+		{
+			"Position": 0,
+			"Tag": "New Cut Paste Snarf Sort Zerox Delcol "
+		},
+		{
+			"Position": 54.296875,
+			"Tag": "New Cut Paste Snarf Sort Zerox Delcol "
+		}
+	],
+	"Windows": [
+		{
+			"Type": 1,
+			"ColumnID": 0,
+			"Q0": 6,
+			"Q1": 15,
+			"Position": 2.263648468708389,
+			"Font": "/lib/font/bit/lucsans/euro.8.font",
+			"Dirty": true,
+			"Tag": "glass Del Snarf Undo Put | Look Edit ",
+			"Body": "I can eat glass and it doesn't hurt me.\nJe peux manger du verre, ça ne me fait pas mal.\n私はガラスを食べられます。それは私を傷つけません。\nআমি কাঁচ খেতে পারি, তাতে আমার কোনো ক্ষতি হয় না।\n"
+		},
+		{
+			"Type": 0,
+			"ColumnID": 0,
+			"Q0": 8,
+			"Q1": 12,
+			"Position": 12.649800266311585,
+			"Font": "/lib/font/bit/lucsans/euro.8.font",
+			"Dirty": false,
+			"Tag": "/home/gopher/go/src/edwood/row_test.go Del Snarf | Look Edit "
+		},
+		{
+			"Type": 0,
+			"ColumnID": 1,
+			"Q0": 29,
+			"Q1": 41,
+			"Position": 2.263648468708389,
+			"Font": "/lib/font/bit/lucsans/euro.8.font",
+			"Dirty": true,
+			"Tag": "/home/gopher/go/src/edwood/ Del Snarf Get | Look Edit "
+		},
+		{
+			"Type": 2,
+			"ColumnID": 1,
+			"Q0": 8,
+			"Q1": 12,
+			"Position": 32.62316910785619,
+			"Font": "/lib/font/bit/lucsans/euro.8.font",
+			"Dirty": false,
+			"Tag": "/home/gopher/go/src/edwood/row_test.go Del Snarf | Look Edit "
+		},
+		{
+			"Type": 1,
+			"ColumnID": 1,
+			"Q0": 12,
+			"Q1": 23,
+			"Position": 74.96671105193076,
+			"Font": "/lib/font/bit/lucsans/euro.8.font",
+			"Dirty": true,
+			"Tag": " Del Snarf Undo | Look Edit ",
+			"Body": "This window has no name.\n"
+		}
+	]
+}

--- a/testdata/example.dump
+++ b/testdata/example.dump
@@ -3,64 +3,106 @@
 	"CurrentDir": "/home/gopher/go/src/edwood",
 	"VarFont": "/lib/font/bit/lucsans/euro.8.font",
 	"FixedFont": "/lib/font/bit/lucm/unicode.9.font",
-	"RowTag": "win Newcol Kill Putall Dump Exit win",
+	"RowTag": {
+		"Buffer": "win Newcol Kill Putall Dump Exit win",
+		"Q0": 23,
+		"Q1": 27
+	},
 	"Columns": [
 		{
 			"Position": 0,
-			"Tag": "New Cut Paste Snarf Sort Zerox Delcol "
+			"Tag": {
+				"Buffer": "New Cut Paste Snarf Sort Zerox Delcol ",
+				"Q0": 14,
+				"Q1": 19
+			}
 		},
 		{
 			"Position": 54.296875,
-			"Tag": "New Cut Paste Snarf Sort Zerox Delcol "
+			"Tag": {
+				"Buffer": "New Cut Paste Snarf Sort Zerox Delcol ",
+				"Q0": 14,
+				"Q1": 19
+			}
 		}
 	],
 	"Windows": [
 		{
 			"Type": 1,
 			"Column": 0,
-			"Q0": 6,
-			"Q1": 15,
 			"Position": 2.263648468708389,
 			"Font": "/lib/font/bit/lucsans/euro.8.font",
-			"Tag": "glass Del Snarf Undo Put | Look Edit ",
-			"Body": "I can eat glass and it doesn't hurt me.\nJe peux manger du verre, ça ne me fait pas mal.\n私はガラスを食べられます。それは私を傷つけません。\nআমি কাঁচ খেতে পারি, তাতে আমার কোনো ক্ষতি হয় না।\n"
+			"Tag": {
+				"Buffer": "glass Del Snarf | Look Edit ",
+				"Q0": 10,
+				"Q1": 15
+			},
+			"Body": {
+				"Buffer": "I can eat glass and it doesn't hurt me.\nJe peux manger du verre, ça ne me fait pas mal.\n私はガラスを食べられます。それは私を傷つけません。\nআমি কাঁচ খেতে পারি, তাতে আমার কোনো ক্ষতি হয় না।\n",
+				"Q0": 6,
+				"Q1": 15
+			}
 		},
 		{
 			"Type": 0,
 			"Column": 0,
-			"Q0": 8,
-			"Q1": 12,
 			"Position": 12.649800266311585,
 			"Font": "/lib/font/bit/lucsans/euro.8.font",
-			"Tag": "/home/gopher/go/src/edwood/row_test.go Del Snarf | Look Edit "
+			"Tag": {
+				"Buffer": "/home/gopher/go/src/edwood/row_test.go Del Snarf | Look Edit ",
+				"Q0": 60,
+				"Q1": 65
+			},
+			"Body": {
+				"Q0": 8,
+				"Q1": 12
+			}
 		},
 		{
 			"Type": 0,
 			"Column": 1,
-			"Q0": 29,
-			"Q1": 41,
 			"Position": 2.263648468708389,
 			"Font": "/lib/font/bit/lucsans/euro.8.font",
-			"Tag": "/home/gopher/go/src/edwood/ Del Snarf Get | Look Edit "
+			"Tag": {
+				"Buffer": "/home/gopher/go/src/edwood/ Del Snarf Get | Look Edit ",
+				"Q0": 49,
+				"Q1": 54
+			},
+			"Body": {
+				"Q0": 29,
+				"Q1": 41
+			}
 		},
 		{
 			"Type": 2,
 			"Column": 1,
-			"Q0": 8,
-			"Q1": 12,
 			"Position": 32.62316910785619,
 			"Font": "/lib/font/bit/lucsans/euro.8.font",
-			"Tag": "/home/gopher/go/src/edwood/row_test.go Del Snarf | Look Edit "
+			"Tag": {
+				"Buffer": "/home/gopher/go/src/edwood/row_test.go Del Snarf | Look Edit ",
+				"Q0": 60,
+				"Q1": 65
+			},
+			"Body": {
+				"Q0": 8,
+				"Q1": 12
+			}
 		},
 		{
 			"Type": 1,
 			"Column": 1,
-			"Q0": 12,
-			"Q1": 23,
 			"Position": 74.96671105193076,
 			"Font": "/lib/font/bit/lucsans/euro.8.font",
-			"Tag": " Del Snarf Undo | Look Edit ",
-			"Body": "This window has no name.\n"
+			"Tag": {
+				"Buffer": " Del Snarf | Look Edit ",
+				"Q0": 5,
+				"Q1": 10
+			},
+			"Body": {
+				"Buffer": "This window has no name.\n",
+				"Q0": 12,
+				"Q1": 23
+			}
 		}
 	]
 }

--- a/testdata/multi-line-tag.dump
+++ b/testdata/multi-line-tag.dump
@@ -1,0 +1,84 @@
+{
+	"Version": 1,
+	"CurrentDir": "/home/gopher/go/src/edwood",
+	"VarFont": "/lib/font/bit/lucsans/euro.8.font",
+	"FixedFont": "/lib/font/bit/lucm/unicode.9.font",
+	"RowTag": {
+		"Buffer": "Newcol Kill Putall Dump Exit ",
+		"Q0": 29,
+		"Q1": 29
+	},
+	"Columns": [
+		{
+			"Position": 0,
+			"Tag": {
+				"Buffer": "New Cut Paste Snarf Sort Zerox Delcol ",
+				"Q0": 38,
+				"Q1": 38
+			}
+		}
+	],
+	"Windows": [
+		{
+			"Type": 0,
+			"Column": 0,
+			"Position": 2.263648468708389,
+			"Font": "/lib/font/bit/lucsans/euro.8.font",
+			"Tag": {
+				"Buffer": "/home/gopher/go/src/edwood/row_test.go Del Snarf | Look Edit The first line\nThe second line\nThe third line",
+				"Q0": 93,
+				"Q1": 108
+			},
+			"Body": {
+				"Q0": 57,
+				"Q1": 57
+			}
+		},
+		{
+			"Type": 2,
+			"Column": 0,
+			"Position": 20.63914780292943,
+			"Font": "/lib/font/bit/lucsans/euro.8.font",
+			"Tag": {
+				"Buffer": "/home/gopher/go/src/edwood/row_test.go Del Snarf | Look Edit The first line\nThe second line\nThe third line",
+				"Q0": 93,
+				"Q1": 108
+			},
+			"Body": {
+				"Q0": 57,
+				"Q1": 57
+			}
+		},
+		{
+			"Type": 0,
+			"Column": 0,
+			"Position": 49.00133155792277,
+			"Font": "/lib/font/bit/lucsans/euro.8.font",
+			"Tag": {
+				"Buffer": "/home/gopher/go/src/edwood/ Del Snarf Get | Look Edit The first line\nThe second line\nThe third line",
+				"Q0": 86,
+				"Q1": 101
+			},
+			"Body": {
+				"Q0": 0,
+				"Q1": 0
+			}
+		},
+		{
+			"Type": 1,
+			"Column": 0,
+			"Position": 77.3635153129161,
+			"Font": "/lib/font/bit/lucsans/euro.8.font",
+			"Tag": {
+				"Buffer": "foo Del Snarf Undo Put | Look Edit The first line\nThe second line\nThe third line",
+				"Q0": 50,
+				"Q1": 65
+			},
+			"Body": {
+				"Buffer": "hello\n",
+				"Q0": 6,
+				"Q1": 6
+			}
+		}
+	]
+}


### PR DESCRIPTION
* Create internal/dumpfile package which uses JSON to store dump data.
  This breaks compatiblity with acme. However, this will make it
  easier to extend the dump file, storing more data, adding support
  for things like multi-line tags. There is a proposed solution to
  add multi-line tags in acme which uses hacks like using unicode PUA:
  https://github.com/9fans/plan9port/pull/153

* We can now save and load multi-line tags

* Fix loading dump file with no windows (see #206)

* Remove temporary file containing window body after loading Unsaved
  window

* Move LoadFont into internal/dumpfile package

* Remove lookid (commened out C code) because it's already been
  implemented as Row.LookupWin.

Fixes #206