### PR TITLE
Remove dumpid field from File and Window

### DIFF
--- a/file.go
+++ b/file.go
@@ -51,8 +51,6 @@ type File struct {
 	curtext *Text
 	text    []*Text // [private I think]
 
-	dumpid int // Used to track the identifying name of this File for Dump.
-
 	isscratch bool // Used to track if this File should warn on unsaved deletion.
 	isdir     bool // Used to track if this File is populated from a directory list.
 
@@ -421,7 +419,6 @@ func NewFile(filename string) *File {
 		curtext: nil,
 		text:    []*Text{},
 		//	ntext   int
-		//	dumpid  int
 	}
 }
 
@@ -444,7 +441,6 @@ func NewTagFile() *File {
 		//	curtext *Text
 		//	text    **Text
 		//	ntext   int
-		//	dumpid  int
 	}
 }
 

--- a/fsys.go
+++ b/fsys.go
@@ -376,7 +376,7 @@ func (fs *fileServer) walk(x *Xfid, f *Fid) *Xfid {
 				id = int(id64)
 			}
 			row.lk.Lock()
-			w = row.LookupWin(id, false)
+			w = row.LookupWin(id)
 			if w == nil {
 				row.lk.Unlock()
 				break

--- a/row_test.go
+++ b/row_test.go
@@ -249,3 +249,26 @@ func windows(fsys *client.Fsys) ([]winInfo, error) {
 	}
 	return info, nil
 }
+
+func TestRowLookupWin(t *testing.T) {
+	w42 := &Window{id: 42}
+	row := &Row{
+		col: []*Column{
+			{
+				w: []*Window{w42},
+			},
+		},
+	}
+	for _, tc := range []struct {
+		id int
+		w  *Window
+	}{
+		{42, w42},
+		{100, nil},
+	} {
+		w := row.LookupWin(tc.id)
+		if w != tc.w {
+			t.Errorf("LookupWin returned window %p for id %v; expected %p", w, tc.id, tc.w)
+		}
+	}
+}

--- a/wind.go
+++ b/wind.go
@@ -47,7 +47,6 @@ type Window struct {
 	ctlfid      uint32
 	dumpstr     string
 	dumpdir     string
-	dumpid      int
 	utflastqid  int
 	utflastboff uint64
 	utflastq    int


### PR DESCRIPTION
* Replace File.dumpid with a local variable. Also, fix how dumpid
  initialization depends on the order of windows: we were setting dumpid
  for an external window to -1, and then resetting it back to 0 for a
  zerox of that window.

* Window.dumpid was not being used. It's used in acme to find the
  original window that's zeroxed, but Edwood searches by filename instead.