### PR TITLE
Remove broken symlink warning on directory listing

### DIFF
--- a/text_test.go
+++ b/text_test.go
@@ -2,6 +2,10 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
 	"testing"
 )
 
@@ -64,5 +68,72 @@ func TestTextKindString(t *testing.T) {
 		if s != tc.s {
 			t.Errorf("string representation of TextKind(%d) is %s; expected %s", int(tc.tk), s, tc.s)
 		}
+	}
+}
+
+func TestGetDirNames(t *testing.T) {
+	dir, err := ioutil.TempDir("", "edwood")
+	if err != nil {
+		t.Fatalf("TempDir failed: %v", err)
+	}
+	defer os.RemoveAll(dir)
+
+	var want []string
+
+	// add a directory file
+	name := "a_dir" + string(filepath.Separator)
+	err = os.Mkdir(filepath.Join(dir, name), 0755)
+	if err != nil {
+		t.Fatalf("Mkdir failed: %v", err)
+	}
+	want = append(want, name)
+
+	// add a broken symlink
+	name = "broken-link"
+	err = os.Symlink("/non/existant/file", filepath.Join(dir, name))
+	if err != nil {
+		t.Fatalf("Symlink failed: %v", err)
+	}
+	want = append(want, name)
+
+	// add a regular file
+	name = "example.txt"
+	err = ioutil.WriteFile(filepath.Join(dir, name), []byte("hello\n"), 0644)
+	if err != nil {
+		t.Fatalf("WriteFile failed: %v", err)
+	}
+	want = append(want, name)
+
+	cwarn = nil
+	warnings = nil
+	defer func() {
+		warnings = nil
+	}()
+
+	f, err := os.Open(dir)
+	if err != nil {
+		t.Fatalf("Open failed: %v", err)
+	}
+	defer f.Close()
+
+	got, err := getDirNames(f)
+	if err != nil {
+		t.Fatalf("getDirNames failed: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got entries %v; expected %v", got, want)
+	}
+	if len(warnings) > 0 {
+		for _, warn := range warnings {
+			t.Logf("warning: %v\n", string(warn.buf))
+		}
+		t.Errorf("getDirnames generated %v warning(s)", len(warnings))
+	}
+}
+
+func TestGetDirNamesNil(t *testing.T) {
+	_, err := getDirNames(nil)
+	if err == nil {
+		t.Errorf("getDirNames was successful on nil File")
 	}
 }


### PR DESCRIPTION
The warning looked like this when listing /some/dir:

    can't stat foo: stat /some/dir/foo: no such file or directory