### PR TITLE
Fix new JSON dump test on retina displays

### DIFF
--- a/row_test.go
+++ b/row_test.go
@@ -114,9 +114,9 @@ func checkDump(t *testing.T, dump *dumpfile.Content, fsys *client.Fsys) {
 		if dw.Type != dumpfile.Unsaved && w.tag != dw.Tag.Buffer {
 			t.Errorf("tag is %q; expected %q", w.tag, dw.Tag)
 		}
-
-		if p := plan9FontPath(dw.Font); w.font != p {
-			t.Errorf("font for %q is %q; expected %q", w.name, w.font, p)
+		
+		if p := plan9FontPath(dw.Font); unscaledFontName(w.font) != p {
+			t.Errorf("font for %q is %q; expected %q", w.name, unscaledFontName(w.font), p)
 		}
 
 		if w.q0 != dw.Body.Q0 || w.q1 != dw.Body.Q1 {
@@ -127,6 +127,17 @@ func checkDump(t *testing.T, dump *dumpfile.Content, fsys *client.Fsys) {
 			t.Errorf("body for %q is %q; expected %q", w.name, w.body, dw.Body.Buffer)
 		}
 	}
+}
+
+// unscaledFontName converts the given fname to an unscaled
+// representation without the leading scaling indicator.
+func unscaledFontName(fname string) string {
+	return strings.TrimLeftFunc(fname, func(r rune) bool {
+		if (r >= '0' && r <= '9') || r == '*' {
+			return true
+		}
+		return false
+	})
 }
 
 func plan9FontPath(name string) string {

--- a/row_test.go
+++ b/row_test.go
@@ -133,10 +133,7 @@ func checkDump(t *testing.T, dump *dumpfile.Content, fsys *client.Fsys) {
 // representation without the leading scaling indicator.
 func unscaledFontName(fname string) string {
 	return strings.TrimLeftFunc(fname, func(r rune) bool {
-		if (r >= '0' && r <= '9') || r == '*' {
-			return true
-		}
-		return false
+		return  (r >= '0' && r <= '9') || r == '*' 
 	})
 }
 

--- a/row_test.go
+++ b/row_test.go
@@ -133,7 +133,7 @@ func checkDump(t *testing.T, dump *dumpfile.Content, fsys *client.Fsys) {
 // representation without the leading scaling indicator.
 func unscaledFontName(fname string) string {
 	return strings.TrimLeftFunc(fname, func(r rune) bool {
-		return  (r >= '0' && r <= '9') || r == '*' 
+		return (r >= '0' && r <= '9') || r == '*'
 	})
 }
 

--- a/row_test.go
+++ b/row_test.go
@@ -114,7 +114,7 @@ func checkDump(t *testing.T, dump *dumpfile.Content, fsys *client.Fsys) {
 		if dw.Type != dumpfile.Unsaved && w.tag != dw.Tag.Buffer {
 			t.Errorf("tag is %q; expected %q", w.tag, dw.Tag)
 		}
-		
+
 		if p := plan9FontPath(dw.Font); unscaledFontName(w.font) != p {
 			t.Errorf("font for %q is %q; expected %q", w.name, unscaledFontName(w.font), p)
 		}

--- a/wind.go
+++ b/wind.go
@@ -651,7 +651,7 @@ func (w *Window) CtlPrint(fonts bool) string {
 		w.body.Nc(), isdir, dirty)
 	if fonts {
 		// fsys exposes the actual physical font name.
-		return fmt.Sprintf("%s%11d %s %11d ", buf, w.body.fr.Rect().Dx(),
+		buf =  fmt.Sprintf("%s%11d %s %11d ", buf, w.body.fr.Rect().Dx(),
 			quote(fontget(w.body.font, w.display).Name), w.body.fr.GetMaxtab())
 	}
 	return buf

--- a/wind.go
+++ b/wind.go
@@ -651,7 +651,7 @@ func (w *Window) CtlPrint(fonts bool) string {
 		w.body.Nc(), isdir, dirty)
 	if fonts {
 		// fsys exposes the actual physical font name.
-		buf =  fmt.Sprintf("%s%11d %s %11d ", buf, w.body.fr.Rect().Dx(),
+		buf = fmt.Sprintf("%s%11d %s %11d ", buf, w.body.fr.Rect().Dx(),
 			quote(fontget(w.body.font, w.display).Name), w.body.fr.GetMaxtab())
 	}
 	return buf


### PR DESCRIPTION
When operating on a retina display, 9fans draw.Font prefixes font
names with its scale factor. Dump files are font resolution
independent so ignore the scale factor when validating Dump/Load
configuration.