### PR TITLE
Replace qidpath with os.FileInfo and call to os.SameFile

### DIFF
--- a/file.go
+++ b/file.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"time"
+	"os"
 
 	"github.com/rjkroege/edwood/internal/file"
 )
@@ -28,10 +28,7 @@ type File struct {
 	epsilon []*Undo // [private]
 	elog    Elog
 	name    string
-	qidpath string // TODO(flux): Gross hack to use filename instead of qidpath for file uniqueness
-	mtime   time.Time
-	// dev       int
-	// unread bool
+	info    os.FileInfo
 
 	// TODO(rjk): Remove this when I've inserted undo.Buffer.
 	// At present, InsertAt and DeleteAt have an implicit Commit operation
@@ -404,14 +401,11 @@ func (f *File) UnsetName(delta *[]*Undo) {
 
 func NewFile(filename string) *File {
 	return &File{
-		b:       NewBuffer(),
-		delta:   []*Undo{},
-		epsilon: []*Undo{},
-		elog:    MakeElog(),
-		name:    filename,
-		//	qidpath   uint64
-		//	mtime     uint64
-		//	dev       int
+		b:         NewBuffer(),
+		delta:     []*Undo{},
+		epsilon:   []*Undo{},
+		elog:      MakeElog(),
+		name:      filename,
 		editclean: true,
 		//	seq       int
 		mod: false,

--- a/text.go
+++ b/text.go
@@ -332,9 +332,7 @@ func (t *Text) Load(q0 int, filename string, setqid bool) (nread int, err error)
 		q1 = q0 + count
 	}
 	if setqid {
-		//t.file.dev = d.dev;
-		t.file.mtime = d.ModTime()
-		t.file.qidpath = d.Name() // TODO(flux): Gross hack to use filename as unique ID of file.
+		t.file.info = d
 	}
 	fd.Close()
 


### PR DESCRIPTION
SameFile will make use of Qid in [Plan 9](https://golang.org/src/os/types_plan9.go) and inode in [unix](https://golang.org/src/os/types_unix.go) systems (same as plan9port).