### PR TITLE
Remove Unimpl, Untested, and other debugging prints

### DIFF
--- a/acme.go
+++ b/acme.go
@@ -552,16 +552,7 @@ func waitthread() {
 			t := &row.tag
 			t.Commit()
 			if c == nil {
-				// helper processes use this exit status
-				// TODO(flux): I don't understand what this libthread code is doing
-				Untested()
-				if strings.HasPrefix(w.String(), "libthread") {
-					p := &Pid{}
-					p.pid = pid
-					p.msg = w.String()
-					p.next = pids
-					pids = p
-				}
+				warning(nil, "unknown command (pid %v) exited: %v\n", pid, w.String())
 			} else {
 				if search(t, []rune(c.name)) {
 					t.Delete(t.q0, t.q1, true)

--- a/dat.go
+++ b/dat.go
@@ -1,11 +1,8 @@
 package main
 
 import (
-	"fmt"
 	"math"
 	"os"
-	"runtime/debug"
-	"strings"
 	"unicode/utf8"
 
 	"9fans.net/go/plan9"
@@ -216,26 +213,6 @@ func (r *Ref) Inc() {
 func (r *Ref) Dec() int {
 	*r--
 	return int(*r)
-}
-func Untested() {
-	stack := strings.Split(string(debug.Stack()), "\n")
-	for i, l := range stack {
-		if l == "main.Untested()" {
-			fmt.Printf("Untested: %v: %v\n", stack[i+2], strings.TrimLeft(stack[i+3], " \t"))
-			//	runtime.Breakpoint()
-			break
-		}
-	}
-}
-func Unimpl() {
-	stack := strings.Split(string(debug.Stack()), "\n")
-	for i, l := range stack {
-		if l == "main.Unimpl()" {
-			fmt.Printf("Unimplemented: %v: %v\n", stack[i+2], strings.TrimLeft(stack[i+3], " \t"))
-			//	runtime.Breakpoint()
-			break
-		}
-	}
 }
 
 func WIN(q plan9.Qid) int {

--- a/file.go
+++ b/file.go
@@ -227,6 +227,18 @@ func (f *File) Load(q0 int, fd io.Reader, sethash bool) (n int, hasNulls bool, e
 	return len(runes), hasNulls, err
 }
 
+// UpdateInfo updates File's info to d if file hash hasn't changed.
+func (f *File) UpdateInfo(filename string, d os.FileInfo) {
+	h, err := file.HashFor(filename)
+	if err != nil {
+		warning(nil, "failed to open %v to compute hash", filename)
+		return
+	}
+	if h.Eq(f.hash) {
+		f.info = d
+	}
+}
+
 // SnapshotSeq saves the current seq to putseq. Call this on Put actions.
 // TODO(rjk): switching to undo.Buffer will require removing use of seq
 func (f *File) SnapshotSeq() {

--- a/text.go
+++ b/text.go
@@ -16,8 +16,6 @@ import (
 	"github.com/rjkroege/edwood/internal/draw/drawutil"
 	"github.com/rjkroege/edwood/internal/frame"
 	"github.com/rjkroege/edwood/internal/runes"
-
-	"log"
 )
 
 const (
@@ -991,7 +989,6 @@ func (t *Text) Type(r rune) {
 			return
 		}
 
-		log.Println("erasing!")
 		nnb = t.BsWidth(r)
 		q1 = t.q0
 		q0 = q1 - nnb
@@ -1110,7 +1107,6 @@ func (t *Text) Select() {
 	//	fmt.Printf("clicktext==t %v, (q0==q1 && selectq==q0): %v", clicktext == t, q0 == q1 && selectq == q0)
 	if (clicktext == t && mouse.Msec-clickmsec < 500) && (q0 == q1 && selectq == q0) {
 		q0, q1 = t.DoubleClick(q0, q1)
-		fmt.Printf("Text.Select: DoubleClick returned %d, %d\n", q0, q1)
 		t.SetSelect(q0, q1)
 		t.display.Flush()
 		x := mouse.Point.X


### PR DESCRIPTION
* Remove `Unimpl` because everything has been implemented!
* Three places where `Untested` was use:
  - `waitthread`: removed `libthread` related code we should never reach
  - `checkhash`: added a test
  - `run`: already tested mostly via `runproc`
* Code coverage report is a better alternative to `Untested`.
* Removed other prints that are too noisy.