### PR TITLE
Fix race when saving to dump file before exit

### DIFF
--- a/fsys_p9p.go
+++ b/fsys_p9p.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"net"
 	"os"
 	"os/exec"
@@ -56,7 +57,9 @@ func post9pservice(conn net.Conn, name string, mtpt string) error {
 			// Now wait for I/O to finish.
 			err = cmd.Wait()
 			if err != nil {
-				acmeerror("9pserve wait failed", err)
+				// Most likely Edwood is preparing to exit and closed its end of the pipe.
+				// Don't panic -- give Edwood a chance to clean up before exit.
+				log.Printf("9pserve wait failed: %v", err)
 			}
 			conn.Close()
 		}()
@@ -111,7 +114,7 @@ func post9pservice(conn net.Conn, name string, mtpt string) error {
 		go func() {
 			err = cmd.Wait()
 			if err != nil {
-				acmeerror("wait failed", err)
+				log.Printf("mount9p/9pfuse wait failed: %v", err)
 			}
 			fd.Close()
 		}()


### PR DESCRIPTION
When Edwood closes connection to the file server before exit, wait for
`9pserve` can return this error:

	9pserve wait failed: waitid: no child processes.

It's important that we don't panic for this error, so that Edwood has a
chance to finish cleaning up before exit. In particular, if Edwood is in
the middle of writing to the dump file, the dump file may end up being
truncated to an empty file.

We also move `killprocs` to *after* `row.Dump`. This leads to a dump
file more consistent with the `Dump` command. It ensures that all the
external commands currently running show up in the row tag inside the
dump file, even if its undesirable (at least to me).

Also, do not write to dump file on `Exit` command. We only write to dump
file on unexpected signals (SIGINT, SIGTERM, etc.). This behavior is
consistent with acme.

Removed some unnecessary (and racy) synchronization using PID and global
variable `dumping`. The C code needed them because the signal handler was
a callback. We receive the signal from a channel.

The TODO regarding saving the state on crash is a separate issue, which
we can solve by not crashing in the first place. We should always try to
recover from error (and maybe show an warning) instead of panic. Also,
autosave (issue #71) can help here.