### PR TITLE
Don't panic on out-of order sam commands.

### DIFF
--- a/acme.go
+++ b/acme.go
@@ -469,6 +469,7 @@ func keyboardthread(display draw.Display) {
 					activecol = t.col
 				}
 				if t != nil && t.w != nil {
+					// In a set of zeroxes, the last typed-in body becomes the curtext.
 					t.w.body.file.curtext = &t.w.body
 				}
 				if timer != nil {

--- a/edit_test.go
+++ b/edit_test.go
@@ -363,6 +363,27 @@ func TestEditMultipleWindows(t *testing.T) {
 		{Range{0, 0}, fn3, "w", []string{contents, alt_contents}, []string{
 			fn3 + " not written; file already exists\n",
 		}},
+
+		// b
+		{Range{0, 0}, "test", "b alt_example_2\ni/inserted/\n", []string{
+			contents,
+			"inserted" + alt_contents,
+		}, []string{
+			"'+  alt_example_2\n",
+		}},
+		{Range{0, 0}, "test", "b alt_example_2\n1 i/1/\n2 i/2/\n", []string{
+			contents,
+			"1A different text\n2With other contents\nSo there!\n",
+		}, []string{
+			"'+  alt_example_2\n",
+		}},
+		// TODO(rjk): the edit result here is wrong. See #236.
+		{Range{0, 0}, "test", "b alt_example_2\n2 i/2/\n1 i/1/\n", []string{
+			contents,
+			"1A different text2\nWith other contents\nSo there!\n",
+		}, []string{
+			"'+  alt_example_2\nwarning: changes out of sequence\nwarning: changes out of sequence, edit result probably wrong\n",
+		}},
 	}
 
 	buf := make([]rune, 8192)

--- a/elog.go
+++ b/elog.go
@@ -10,7 +10,8 @@ const (
 	DeleteType ElogType = iota
 	InsertType
 	FilenameType
-	Wsequence = "warning: changes out of sequence\n"
+	Wsequence     = "warning: changes out of sequence\n"
+	WsequenceDire = "warning: changes out of sequence, edit result probably wrong\n"
 )
 
 // Elog is a log of changes made by editing commands.  Three reasons for this:
@@ -114,7 +115,8 @@ func (e *Elog) Replace(q0, q1 int, r []rune) {
 	eo.nd = q1 - q0
 	eo.setr(r)
 	if eo.q0 < e.secondlast().q0 {
-		panic("Changes not in order")
+		e.warned = true
+		warning(nil, WsequenceDire)
 	}
 }
 
@@ -148,7 +150,8 @@ func (e *Elog) Insert(q0 int, r []rune) {
 	eo.setr(r)
 
 	if eo.q0 < e.secondlast().q0 {
-		panic("Changes not in order")
+		e.warned = true
+		warning(nil, WsequenceDire)
 	}
 }
 
@@ -178,7 +181,8 @@ func (e *Elog) Delete(q0, q1 int) {
 	eo.q0 = q0
 	eo.nd = q1 - q0
 	if eo.q0 < e.secondlast().q0 {
-		panic("Changes not in order")
+		e.warned = true
+		warning(nil, WsequenceDire)
 	}
 }
 

--- a/row.go
+++ b/row.go
@@ -278,6 +278,7 @@ func (row *Row) Type(r rune, p image.Point) *Text {
 	if t != nil && !(t.what == Tag && p.In(t.scrollr)) {
 		w = t.w
 		if w == nil {
+			// Texts in column tags or the very top.
 			t.Type(r)
 		} else {
 			w.Lock('K')


### PR DESCRIPTION
Warn instead of panic when running a sequence of sam commands in the
elog that are out of order. Fixes #177. Also add a test of the sam b
command.