### PR TITLE
Introduce a general row/column/window mock

### DIFF
--- a/rowmock_test.go
+++ b/rowmock_test.go
@@ -1,0 +1,88 @@
+package main
+
+// Utility functions to build complex mocks of the Edwood
+// row/column/window model.
+
+import (
+	"image"
+	"strings"
+
+	"github.com/rjkroege/edwood/internal/draw"
+	"github.com/rjkroege/edwood/internal/dumpfile"
+	"github.com/rjkroege/edwood/internal/edwoodtest"
+)
+
+// configureGlobals setups global variables so that Edwood can operate on
+// a scaffold model.
+func configureGlobals() {
+	// TODO(rjk): Make a proper mock draw.Mouse in edwoodtest.
+	mouse = new(draw.Mouse)
+	button = edwoodtest.NewImage(image.Rect(0, 0, 10, 10))
+	modbutton = edwoodtest.NewImage(image.Rect(0, 0, 10, 10))
+	colbutton = edwoodtest.NewImage(image.Rect(0, 0, 10, 10))
+
+	// Set up Undo to make sure that we see undoable results.
+	// By default, post-load, file.seq, file.putseq = 0, 0.
+	seq = 1
+}
+
+// makeText creates a minimal mock Text object from data embedded inside
+// of an Edwood dumpfile structure.
+func updateText(t *Text, sertext *dumpfile.Text, display draw.Display) *Text {
+	t.display = display
+	t.fr = &MockFrame{}
+	t.Insert(0, []rune(sertext.Buffer), true)
+	t.SetQ0(sertext.Q0)
+	t.SetQ1(sertext.Q1)
+
+	return t
+}
+
+// MakeWindowScaffold builds a complete scaffold model of the Edwood
+// row/col/window hierarchy sufficient to run sam commands. It is
+// configured from the intermediate model used by the Edwood JSON dump
+// file.
+func MakeWindowScaffold(content *dumpfile.Content) {
+	display := edwoodtest.NewDisplay()
+
+	row = Row{
+		display: display,
+		tag: *updateText(&Text{
+			what: Rowtag,
+			file: NewTagFile(),
+		}, &content.RowTag, display),
+	}
+
+	cols := make([]*Column, 0, len(content.Columns))
+	for _, sercol := range content.Columns {
+		col := &Column{
+			tag: *updateText(&Text{
+				what: Columntag,
+				file: NewTagFile(),
+			}, &sercol.Tag, display),
+			display: display,
+			fortest: true,
+			w:       make([]*Window, 0),
+		}
+		cols = append(cols, col)
+	}
+
+	for _, serwin := range content.Windows {
+		w := NewWindow().initHeadless(nil)
+		w.display = display
+		updateText(&w.body, &serwin.Body, display)
+		updateText(&w.tag, &serwin.Tag, display)
+		w.body.file.SetName(strings.SplitN(serwin.Tag.Buffer, " ", 2)[0])
+		w.body.w = w
+		w.tag.w = w
+
+		wincol := cols[serwin.Column]
+		wincol.w = append(wincol.w, w)
+		w.col = wincol
+		w.body.col = wincol
+		w.tag.col = wincol
+	}
+
+	row.col = cols
+	configureGlobals()
+}


### PR DESCRIPTION
The sam command tests needed a mock of the Edwood row/column/window
model. Refactor this somewhat adhoc code into a general framework
based on creating a test mock from Edwood intermediate dumpfile
format.