### PR TITLE
Fix crash while attempting to lock a closed window in mousethread

### DIFF
--- a/dat.go
+++ b/dat.go
@@ -89,9 +89,9 @@ var (
 
 	seltext   *Text
 	argtext   *Text
-	mousetext *Text
-	typetext  *Text
-	barttext  *Text
+	mousetext *Text // global because Text.Close needs to clear it
+	typetext  *Text // global because Text.Close needs to clear it
+	barttext  *Text // shared between mousethread and keyboardthread
 
 	bartflag          bool
 	swapscrollbuttons bool

--- a/xfid.go
+++ b/xfid.go
@@ -229,6 +229,10 @@ func xfidclose(x *Xfid) {
 	q = FILE(x.f.qid)
 	x.f.open = false
 	if w != nil {
+		// We need to lock row here before locking window (just like mousethread)
+		// in order to synchronize mousetext with mousethread: mousetext is
+		// set to nil when the associated window is closed.
+		row.lk.Lock()
 		w.Lock('E')
 		switch q {
 		case QWctl:
@@ -271,6 +275,7 @@ func xfidclose(x *Xfid) {
 		}
 		w.Close()
 		w.Unlock()
+		row.lk.Unlock()
 	} else {
 		switch q {
 		case Qeditout:


### PR DESCRIPTION
The closed window is the one associated with mousetext. Lock row while
mousetext is set to nil (due to window close), which prevents
mousethread from attempting to lock the closed window.

Fixes #235