### PR TITLE
.travis.yml: run staticcheck and misspell

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,11 @@ script:
   - go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
   - go vet .
   - if [[ "$TRAVIS_OS_NAME" != "windows" ]]; then go get -tags 'duitdraw mux9p' -t -v ./...; fi
+  - go get honnef.co/go/tools/cmd/staticcheck
+  - staticcheck -debug.version
+  - staticcheck -checks inherit,-U1000,-SA4003 ./...
+  - go get github.com/client9/misspell/cmd/misspell
+  - misspell -error .
 
 after_success:
   # codecov can't seem to combine reports from multiple OSes correctly

--- a/fsys_windows.go
+++ b/fsys_windows.go
@@ -18,7 +18,7 @@ func newPipe() (net.Conn, net.Conn, error) {
 func post9pservice(conn net.Conn, name string, mtpt string) error {
 	l, err := net.Listen("tcp", "localhost:0")
 	if err != nil {
-		return fmt.Errorf("Listen failed: %v", err)
+		return fmt.Errorf("listen failed: %v", err)
 	}
 	go func() {
 		defer l.Close()

--- a/internal/frame/util.go
+++ b/internal/frame/util.go
@@ -128,7 +128,6 @@ func (f *frameimpl) clean(pt image.Point, n0, n1 int) {
 			pt.X+f.box[nb].Wid+f.box[nb+1].Wid < c {
 			f.mergebox(nb)
 			n1--
-			b = f.box[nb]
 		}
 		pt = f.advance(pt, f.box[nb])
 	}


### PR DESCRIPTION
Fix these two `staticcheck` warnings:
```
 fsys_windows.go:21:20: error strings should not be capitalized (ST1005)
 internal\frame\util.go:131:4: this value of b is never used (SA4006)
```
We ignore these two checks because there are failure cases that I'm not
sure is worth fixing:
```
 $ staticcheck -explain U1000
 Unused code
 $ staticcheck -explain SA4003
 Comparing unsigned values against negative values is pointless
```