### PR TITLE
Test Text.DirName and fix plumbing from row tag

### DIFF
--- a/ecmd.go
+++ b/ecmd.go
@@ -206,10 +206,10 @@ func D_cmd(t *Text, cp *Cmd) bool {
 		D1(t)
 		return true
 	}
-	dir := dirname(t, nil)
+	dir := t.DirName("")
 	for _, s := range strings.Fields(list) {
 		if !filepath.IsAbs(s) {
-			s = filepath.Join(string(dir), s)
+			s = filepath.Join(dir, s)
 		}
 		w := lookfile(s)
 		if w == nil {
@@ -473,7 +473,6 @@ func init() {
 func runpipe(t *Text, cmd rune, cr []rune, state int) {
 	var (
 		r, s []rune
-		dir  string
 		w    *Window
 	)
 
@@ -492,13 +491,7 @@ func runpipe(t *Text, cmd rune, cr []rune, state int) {
 	}
 	s = append([]rune{cmd}, r...)
 
-	dir = ""
-	if t != nil {
-		dir = t.DirName("")
-	}
-	if len(dir) == 1 && dir[0] == '.' { // sigh
-		dir = dir[0:0]
-	}
+	dir := t.DirName("") // exec.Cmd.Dir
 	editing = state
 	if t != nil && t.w != nil {
 		t.w.ref.Inc()

--- a/edit_test.go
+++ b/edit_test.go
@@ -90,9 +90,9 @@ func TestEdit(t *testing.T) {
 
 		// | > <
 		// 30
-		{Range{0, 4}, "test", "|pipe", "{\"|pipe\" \"\" true \"\" \"\" true} is a\nshort text\nto try addressing\n", []string{}},
+		{Range{0, 4}, "test", "|pipe", "{\"|pipe\" \".\" true \"\" \"\" true} is a\nshort text\nto try addressing\n", []string{}},
 		{Range{0, 4}, "test", ">greater", "This is a\nshort text\nto try addressing\n", []string{}},
-		{Range{0, 4}, "test", "<less", "{\"<less\" \"\" true \"\" \"\" true} is a\nshort text\nto try addressing\n", []string{}},
+		{Range{0, 4}, "test", "<less", "{\"<less\" \".\" true \"\" \"\" true} is a\nshort text\nto try addressing\n", []string{}},
 		{Range{0, 4}, "test", "<error", "This is a\nshort text\nto try addressing\n", []string{"Edit: mockrun failed!\n"}},
 
 		// { } NB: grouping requires newlines. And sets . the same for each of the commands.
@@ -682,7 +682,7 @@ func mockrun(win *Window, s string, rdir string, newns bool, argaddr string, xar
 	go func() {
 		// At this point, an external command attaches to the Edwood and writes
 		// data to somewhere in the filesystem. This comes from xfidwrite via
-		// edittext into the elog. We write exepctations in string form into the
+		// edittext into the elog. We write expectations in string form into the
 		// buffer here from the inputs so that the test harness can validate
 		// them.
 

--- a/exec.go
+++ b/exec.go
@@ -124,7 +124,6 @@ func execute(t *Text, aq0 int, aq1 int, external bool, argt *Text) {
 		q0, q1 int
 		r      []rune
 		n, f   int
-		dir    string
 	)
 
 	q0 = aq0
@@ -224,10 +223,7 @@ func execute(t *Text, aq0 int, aq1 int, external bool, argt *Text) {
 	}
 
 	b := r
-	dir = t.DirName("")
-	if dir == "." { // sigh
-		dir = ""
-	}
+	dir := t.DirName("") // exec.Cmd.Dir
 	a, aa := getarg(argt, true, true)
 	if t.w != nil {
 		t.w.ref.Inc()
@@ -491,11 +487,8 @@ func xkill(_, _ *Text, argt *Text, _, _ bool, args string) {
 
 func local(et, _, argt *Text, _, _ bool, arg string) {
 	a, aa := getarg(argt, true, true)
-	dir := dirname(et, nil)
-	if len(dir) == 1 && dir[0] == '.' { // sigh
-		dir = dir[:0]
-	}
-	run(nil, arg, string(dir), false, aa, a, false)
+	dir := et.DirName("") // exec.Cmd.Dir
+	run(nil, arg, dir, false, aa, a, false)
 }
 
 // putfile writes File to disk, if it's safe to do so.

--- a/look.go
+++ b/look.go
@@ -135,48 +135,10 @@ func look3(t *Text, q0 int, q1 int, external bool) {
 		return
 	}
 	if plumbsendfid != nil {
-		// send whitespace-delimited word to plumber
-		m := plumb.Message{}
-		m.Src = "acme"
-		m.Dst = ""
-		dir := t.DirName("")
-		if dir == "." { // sigh
-			dir = ""
+		m, err := look3Message(t, q0, q1)
+		if err != nil {
+			return
 		}
-		m.Dir = dir
-		m.Type = "text"
-		m.Attr = nil
-		if q1 == q0 {
-			if t.q1 > t.q0 && t.q0 <= q0 && q0 <= t.q1 {
-				q0 = t.q0
-				q1 = t.q1
-			} else {
-				p := q0
-				for q0 > 0 {
-					c := t.ReadC(q0 - 1)
-					if !(c != ' ' && c != '\t' && c != '\n') {
-						break
-					}
-					q0--
-				}
-				for q1 < t.file.Size() {
-					// TODO(rjk): utf8 conversion change point.
-					c := t.ReadC(q1)
-					if !(c != ' ' && c != '\t' && c != '\n') {
-						break
-					}
-					q1++
-				}
-				if q1 == q0 {
-					return
-				}
-				s := fmt.Sprintf("%d", p-q0)
-				m.Attr = &plumb.Attribute{Name: "click", Value: s, Next: nil}
-			}
-		}
-		r = make([]rune, q1-q0)
-		t.file.b.Read(q0, r[:q1-q0])
-		m.Data = []byte(string(r[:q1-q0]))
 		if m.Send(plumbsendfid) == nil {
 			return
 		}
@@ -207,6 +169,50 @@ func look3(t *Text, q0 int, q1 int, external bool) {
 			row.display.MoveTo(ct.fr.Ptofchar(getP0(ct.fr)).Add(image.Pt(4, ct.fr.DefaultFontHeight()-4)))
 		}
 	}
+}
+
+// look3Message generates a plumb message for the text in t at range [q0, q1).
+// If q0 == q1, the range will be expanded to the current selection if q0/q1 falls
+// within the selection. Otherwise, it'll expand to a whitespace-delimited word.
+func look3Message(t *Text, q0, q1 int) (*plumb.Message, error) {
+	m := &plumb.Message{
+		Src:  "acme",
+		Dst:  "",
+		Dir:  t.AbsDirName(""),
+		Type: "text",
+	}
+	if q1 == q0 {
+		if t.q1 > t.q0 && t.q0 <= q0 && q0 <= t.q1 {
+			q0 = t.q0
+			q1 = t.q1
+		} else {
+			p := q0
+			for q0 > 0 {
+				c := t.ReadC(q0 - 1)
+				if !(c != ' ' && c != '\t' && c != '\n') {
+					break
+				}
+				q0--
+			}
+			for q1 < t.file.Size() {
+				// TODO(rjk): utf8 conversion change point.
+				c := t.ReadC(q1)
+				if !(c != ' ' && c != '\t' && c != '\n') {
+					break
+				}
+				q1++
+			}
+			if q1 == q0 {
+				return nil, fmt.Errorf("empty selection")
+			}
+			s := fmt.Sprintf("%d", p-q0)
+			m.Attr = &plumb.Attribute{Name: "click", Value: s, Next: nil}
+		}
+	}
+	r := make([]rune, q1-q0)
+	t.file.b.Read(q0, r[:q1-q0])
+	m.Data = []byte(string(r[:q1-q0]))
+	return m, nil
 }
 
 func plumblook(m *plumb.Message) {
@@ -348,48 +354,6 @@ func isfilec(r rune) bool {
 func cleanrname(rs []rune) []rune {
 	s := filepath.Clean(string(rs))
 	r, _, _ := cvttorunes([]byte(s), len(s))
-	return r
-}
-
-// Dirname returns the directory name of the path in the tag file of t.
-// If the filename r is not nil, it'll be appended to the result.
-func dirname(t *Text, r []rune) []rune {
-	var (
-		b     []rune
-		c     rune
-		nt    int
-		slash int
-	)
-
-	if t == nil || t.w == nil {
-		goto Rescue
-	}
-	nt = t.w.tag.file.Size()
-	if nt == 0 || filepath.IsAbs(string(r)) {
-		goto Rescue
-	}
-	b = make([]rune, nt)
-	t.w.tag.file.b.Read(0, b)
-	slash = -1
-	for m := 0; m < nt; m++ {
-		c = b[m]
-		if c == '/' {
-			slash = m
-		}
-		if c == ' ' || c == '\t' {
-			break
-		}
-	}
-	if slash < 0 {
-		goto Rescue
-	}
-	b = append(b[:slash+1], r...)
-	return cleanrname(b)
-
-Rescue:
-	if len(r) > 0 {
-		return cleanrname(r)
-	}
 	return r
 }
 

--- a/util.go
+++ b/util.go
@@ -116,17 +116,7 @@ func cvttorunes(p []byte, n int) (r []rune, nb int, nulls bool) {
 }
 
 func errorwin1Name(dir string) string {
-	const Lpluserrors = "+Errors"
-	var b strings.Builder
-
-	if len(dir) > 0 {
-		b.WriteString(dir)
-		if !strings.HasSuffix(dir, string(filepath.Separator)) {
-			b.WriteRune(filepath.Separator)
-		}
-	}
-	b.WriteString(Lpluserrors)
-	return b.String()
+	return filepath.Join(dir, "+Errors")
 }
 
 func errorwin1(dir string, incl []string) *Window {
@@ -177,15 +167,11 @@ func errorwinforwin(w *Window) *Window {
 	var (
 		owner int
 		incl  []string
-		dir   string
 		t     *Text
 	)
 
 	t = &w.body
-	dir = t.DirName("")
-	if dir == "." { // sigh
-		dir = ""
-	}
+	dir := t.DirName("")
 	incl = append(incl, w.incl...)
 	owner = w.owner
 	w.Unlock()

--- a/util_test.go
+++ b/util_test.go
@@ -39,12 +39,12 @@ func TestErrorwin1Name(t *testing.T) {
 		dir, name string
 	}{
 		{"", "+Errors"},
+		{".", "+Errors"},
 		{"/", "/+Errors"},
 		{"/home/gopher", "/home/gopher/+Errors"},
 		{"/home/gopher/", "/home/gopher/+Errors"},
 		{"C:/Users/gopher", "C:/Users/gopher/+Errors"},
 		{"C:/Users/gopher/", "C:/Users/gopher/+Errors"},
-		{"C:", "C:/+Errors"},
 		{"C:/", "C:/+Errors"},
 	}
 	for _, tc := range tt {

--- a/wind.go
+++ b/wind.go
@@ -592,7 +592,7 @@ func (w *Window) AddIncl(r string) {
 			warning(nil, "%s: Not a directory: %v", r, err)
 			return
 		}
-		r = string(dirname(&w.body, []rune(r)))
+		r = w.body.DirName(r)
 		d, err := isDir(r)
 		if !d {
 			warning(nil, "%s: Not a directory: %v", r, err)


### PR DESCRIPTION
* When plumbing from the row tag, we were sending "" as the `Dir` in the
`plumb.Message`. We now send the absolute path to current working
directory instead.

* Remove `dirname` function, which had the same functionality as
`Text.DirName`.

* Change `Text.DirName` to always return a cleaned path (as returned by
`filepath.Clean`). This means we'll never return "", which becomes "."
after clean.

* Removed some hacks (marked with "sigh") where "." was being converted
to "" for some unknown reason. As far as I can see, this hack isn't
necessary in Go. When "." is used in `filepath.Join` and `exec.Cmd.Dir`,
it works as expected.