### PR TITLE
Add -debug flag for debugging using net/http/pprof

### DIFF
--- a/acme_test.go
+++ b/acme_test.go
@@ -9,7 +9,7 @@ import (
 func TestIsmtpt(t *testing.T) {
 	oldmtpt := mtpt
 	defer func() { mtpt = oldmtpt }()
-	mtpt = "/mnt/acme"
+	*mtpt = "/mnt/acme"
 
 	testCases := []struct {
 		filename string

--- a/dat.go
+++ b/dat.go
@@ -96,19 +96,15 @@ var (
 	typetext  *Text // global because Text.Close needs to clear it
 	barttext  *Text // shared between mousethread and keyboardthread
 
-	bartflag          bool
-	swapscrollbuttons bool
-	activewin         *Window
-	activecol         *Column
-	snarfbuf          Buffer
-	home              string
-	acmeshell         string
-	tagcolors         [frame.NumColours]draw.Image
-	textcolors        [frame.NumColours]draw.Image
-	wdir              string
-	editing           = Inactive
-	globalautoindent  bool
-	mtpt              string
+	activewin  *Window
+	activecol  *Column
+	snarfbuf   Buffer
+	home       string
+	acmeshell  string
+	tagcolors  [frame.NumColours]draw.Image
+	textcolors [frame.NumColours]draw.Image
+	wdir       string
+	editing    = Inactive
 
 	cplumb     chan *plumb.Message
 	cwait      chan *os.ProcessState

--- a/exec.go
+++ b/exec.go
@@ -1019,11 +1019,11 @@ func indentval(s string) int {
 	}
 	switch s {
 	case "ON":
-		globalautoindent = true
+		*globalAutoIndent = true
 		warning(nil, "Indent ON\n")
 		return IGlobal
 	case "OFF":
-		globalautoindent = false
+		*globalAutoIndent = false
 		warning(nil, "Indent OFF\n")
 		return IGlobal
 	case "on":
@@ -1048,7 +1048,7 @@ func indent(et *Text, _ *Text, argt *Text, _, _ bool, arg string) {
 		autoindent = indentval(strings.SplitN(arg, " ", 2)[0])
 	}
 	if autoindent == IGlobal {
-		row.AllWindows(func(w *Window) { w.autoindent = globalautoindent })
+		row.AllWindows(func(w *Window) { w.autoindent = *globalAutoIndent })
 	} else {
 		if w != nil && autoindent >= 0 {
 			w.autoindent = autoindent == Ion

--- a/fsys.go
+++ b/fsys.go
@@ -98,7 +98,7 @@ func fsysinit() *fileServer {
 	if err != nil {
 		acmeerror("failed to create pipe", err)
 	}
-	if err := post9pservice(reader, "acme", mtpt); err != nil {
+	if err := post9pservice(reader, "acme", *mtpt); err != nil {
 		acmeerror("can't post service", err)
 	}
 

--- a/fsys_plan9.go
+++ b/fsys_plan9.go
@@ -78,7 +78,7 @@ func fsysmount(dir string, incl []string) (*MntDir, *client.Fsys, error) {
 
 // Fsopenfd opens a plan9 Fid.
 func fsopenfd(fsys *client.Fsys, filename string, mode uint8) *os.File {
-	f, err := os.OpenFile(path.Join(mtpt, filename), int(mode), 0)
+	f, err := os.OpenFile(path.Join(*mtpt, filename), int(mode), 0)
 	if err != nil {
 		warning(nil, "Failed to open %v: %v", filename, err)
 		return nil

--- a/look.go
+++ b/look.go
@@ -585,7 +585,7 @@ func openfile(t *Text, e *Expand) *Window {
 			}
 			w.autoindent = ow.autoindent
 		} else {
-			w.autoindent = globalautoindent
+			w.autoindent = *globalAutoIndent
 		}
 		xfidlog(w, "new")
 	}

--- a/row.go
+++ b/row.go
@@ -270,7 +270,7 @@ func (row *Row) Type(r rune, p image.Point) *Text {
 
 	clearmouse()
 	row.lk.Lock()
-	if bartflag {
+	if *barflag {
 		t = barttext
 	} else {
 		t = row.Which(p)

--- a/text_test.go
+++ b/text_test.go
@@ -95,17 +95,17 @@ func TestLoadError(t *testing.T) {
 		t.Fatalf("LoadReader returned error %v; expected %v", err, wantErr)
 	}
 
-	mtpt = "/mnt/acme"
+	*mtpt = "/mnt/acme"
 	defer func() {
-		mtpt = ""
+		*mtpt = ""
 	}()
-	text.file.name = mtpt
+	text.file.name = *mtpt
 	wantErr = "will not open self mount point /mnt/acme"
-	_, err = text.Load(0, mtpt, true)
+	_, err = text.Load(0, *mtpt, true)
 	if err == nil || err.Error() != wantErr {
 		t.Fatalf("Load returned error %v; expected %v", err, wantErr)
 	}
-	_, err = text.LoadReader(0, mtpt, nil, true)
+	_, err = text.LoadReader(0, *mtpt, nil, true)
 	if err == nil || err.Error() != wantErr {
 		t.Fatalf("LoadReader returned error %v; expected %v", err, wantErr)
 	}

--- a/util.go
+++ b/util.go
@@ -136,7 +136,7 @@ func errorwin1(dir string, incl []string) *Window {
 	for _, in := range incl {
 		w.AddIncl(in)
 	}
-	w.autoindent = globalautoindent
+	w.autoindent = *globalAutoIndent
 	return w
 }
 

--- a/wind.go
+++ b/wind.go
@@ -92,7 +92,7 @@ func (w *Window) initHeadless(clone *Window) *Window {
 	w.body.file = f.AddText(&w.body)
 
 	w.filemenu = true
-	w.autoindent = globalautoindent
+	w.autoindent = *globalAutoIndent
 
 	if clone != nil {
 		w.autoindent = clone.autoindent


### PR DESCRIPTION
This flag will enable us to see Go runtime profiles from a HTTP server
(see https://golang.org/pkg/net/http/pprof/). When Edwood is misbehaving
but haven't crashed, it'll be useful for getting a stacktrace of all
running goroutines, run `pprof`, etc.

Also, fix `-r` flag (flag value wasn't being used),
and remove some flag related global variables.