### PR TITLE
Add helper functions to fill in Fcall.Data and Fcall.Count for read requests

### DIFF
--- a/internal/edwoodtest/draw.go
+++ b/internal/edwoodtest/draw.go
@@ -75,7 +75,7 @@ func NewFont(width, height int) draw.Font {
 	}
 }
 
-func (f *mockFont) Name() string             { return "" }
+func (f *mockFont) Name() string             { return "/lib/font/edwood.font" }
 func (f *mockFont) Height() int              { return f.height }
 func (f *mockFont) BytesWidth(b []byte) int  { return f.width * utf8.RuneCount(b) }
 func (f *mockFont) RunesWidth(r []rune) int  { return f.width * len(r) }

--- a/internal/ninep/util.go
+++ b/internal/ninep/util.go
@@ -1,0 +1,33 @@
+// Package ninep contains helper routines for implementing a 9P2000 protocol server.
+package ninep
+
+import "9fans.net/go/plan9"
+
+// ReadBuffer sets Count and Data in response ofcall based the
+// request ifcall and full data src. The Data is set to a sub-slice of src
+// and the Count is set to the length of the sub-slice.
+// This function is similar to readbuf(3) in lib9p.
+func ReadBuffer(ofcall, ifcall *plan9.Fcall, src []byte) {
+	n := len(src)
+	off := ifcall.Offset
+	cnt := ifcall.Count
+
+	if len(src) == 0 || off >= uint64(n) {
+		ofcall.Count = 0
+		ofcall.Data = nil
+		return
+	}
+	if off+uint64(cnt) > uint64(n) {
+		cnt = uint32(uint64(n) - off)
+	}
+	ofcall.Count = cnt
+	ofcall.Data = src[off : off+uint64(cnt)]
+}
+
+// ReadString is the same as ReadBuffer but for a string src.
+// It trims src info blocks without respecting utf8 boundaries,
+// as it's generally the reader's responsibility to do more reads to get full runes.
+// This function is similar to readstr(3) in lib9p.
+func ReadString(ofcall, ifcall *plan9.Fcall, src string) {
+	ReadBuffer(ofcall, ifcall, []byte(src))
+}

--- a/internal/ninep/util_test.go
+++ b/internal/ninep/util_test.go
@@ -1,0 +1,44 @@
+package ninep
+
+import (
+	"testing"
+
+	"9fans.net/go/plan9"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestReadString(t *testing.T) {
+	tt := []struct {
+		ofcall, ifcall plan9.Fcall
+		src            string
+	}{
+		{
+			plan9.Fcall{Data: nil, Count: 0},
+			plan9.Fcall{Offset: 0, Count: 10},
+			"",
+		},
+		{
+			plan9.Fcall{Data: nil, Count: 0},
+			plan9.Fcall{Offset: 100, Count: 10},
+			"abcd",
+		},
+		{
+			plan9.Fcall{Data: []byte("abcd"), Count: 4},
+			plan9.Fcall{Offset: 0, Count: 10},
+			"abcd",
+		},
+		{
+			plan9.Fcall{Data: []byte("abcd"), Count: 4},
+			plan9.Fcall{Offset: 3, Count: 4},
+			"xxxabcdzzz",
+		},
+	}
+	for _, tc := range tt {
+		var got plan9.Fcall
+		ReadString(&got, &tc.ifcall, tc.src)
+		want := &tc.ofcall
+		if diff := cmp.Diff(want, &got); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+	}
+}

--- a/row_test.go
+++ b/row_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/rjkroege/edwood/internal/edwoodtest"
 )
 
+const gopherEdwoodDir = "/home/gopher/go/src/edwood"
+
 func TestRowLoadFsys(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping on windows")
@@ -46,7 +48,7 @@ func TestRowLoadFsys(t *testing.T) {
 			if err != nil {
 				t.Fatalf("ReadFile failed: %v", err)
 			}
-			b = bytes.Replace(b, []byte("/home/gopher/go/src/edwood"), []byte(cwd), -1)
+			b = bytes.Replace(b, []byte(gopherEdwoodDir), []byte(cwd), -1)
 
 			f, err := ioutil.TempFile("", "edwood_test")
 			if err != nil {
@@ -144,63 +146,32 @@ func TestRowLoad(t *testing.T) {
 		{"multi-line-tag", "testdata/multi-line-tag.dump"},
 	}
 
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("failed to get current working directory: %v", err)
-	}
-
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			b, err := ioutil.ReadFile(tc.filename)
-			if err != nil {
-				t.Fatalf("ReadFile failed: %v", err)
-			}
-			b = bytes.Replace(b, []byte("/home/gopher/go/src/edwood/"),
-				[]byte(jsonEscapePath(cwd+string(filepath.Separator))), -1)
-			b = bytes.Replace(b, []byte("/home/gopher/go/src/edwood"),
-				[]byte(jsonEscapePath(cwd)), -1)
+			filename := editDumpFileForTesting(t, tc.filename)
+			defer os.Remove(filename)
 
-			f, err := ioutil.TempFile("", "edwood_test")
-			if err != nil {
-				t.Fatalf("failed to create temporary file: %v", err)
-			}
-			defer os.Remove(f.Name())
-			_, err = f.Write(b)
-			if err != nil {
-				t.Fatalf("write failed: %v", err)
-			}
-			f.Close()
+			setGlobalsForLoadTesting()
 
-			colbutton = edwoodtest.NewImage(image.Rectangle{})
-			button = edwoodtest.NewImage(image.Rectangle{})
-			modbutton = edwoodtest.NewImage(image.Rectangle{})
-			mouse = &draw.Mouse{}
-			maxtab = 4
-
-			display := edwoodtest.NewDisplay()
-			row = Row{} // reset
-			row.Init(display.ScreenImage().R(), display)
-
-			err = row.Load(nil, f.Name(), true)
+			err := row.Load(nil, filename, true)
 			if err != nil {
 				t.Fatalf("Row.Load failed: %v", err)
 			}
-			dump, err := dumpfile.Load(f.Name())
+			want, err := dumpfile.Load(filename)
 			if err != nil {
 				t.Fatalf("failed to load dump file %v: %v", tc, err)
 			}
-			checkDump(t, f.Name(), dump)
+			got, err := row.dump()
+			if err != nil {
+				t.Fatalf("dump failed: %v", err)
+			}
+			checkDump(t, got, want)
 		})
 	}
 }
 
-// checkDump checks Edwood's current state matches loaded dump file content.
-func checkDump(t *testing.T, filename string, want *dumpfile.Content) {
-	got, err := row.dump()
-	if err != nil {
-		t.Fatalf("dump failed: %v", err)
-	}
-
+// checkDump checks Edwood's current state (got) matches loaded dump file content (want).
+func checkDump(t *testing.T, got, want *dumpfile.Content) {
 	// Ignore some mismatch. Positions may not match exactly.
 	// Window tags may get "Put" added or "Undo" removed, and
 	// because of the change in the tag, selection within the tag may not match.
@@ -454,4 +425,58 @@ func TestRowLookupWin(t *testing.T) {
 // jsonEscapePath escapes blackslashes in Windows path.
 func jsonEscapePath(s string) string {
 	return strings.Replace(s, "\\", "\\\\", -1)
+}
+
+func setGlobalsForLoadTesting() {
+	WinID = 0 // reset
+	colbutton = edwoodtest.NewImage(image.Rectangle{})
+	button = edwoodtest.NewImage(image.Rectangle{})
+	modbutton = edwoodtest.NewImage(image.Rectangle{})
+	mouse = &draw.Mouse{}
+	maxtab = 4
+
+	display := edwoodtest.NewDisplay()
+	row = Row{} // reset
+	row.Init(display.ScreenImage().R(), display)
+}
+
+func replacePathsForTesting(t *testing.T, b []byte, isJSON bool) []byte {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current working directory: %v", err)
+	}
+	d := filepath.Join(cwd, "testdata")
+	gd := gopherEdwoodDir + "/testdata"
+
+	escape := jsonEscapePath
+	if !isJSON {
+		escape = func(s string) string { return s }
+	}
+
+	b = bytes.Replace(b, []byte(gd+"/"),
+		[]byte(escape(d+string(filepath.Separator))), -1)
+	b = bytes.Replace(b, []byte(gd),
+		[]byte(escape(d)), -1)
+	b = bytes.Replace(b, []byte(gopherEdwoodDir),
+		[]byte(escape(cwd)), -1) // CurrentDir
+	return b
+}
+
+func editDumpFileForTesting(t *testing.T, filename string) string {
+	b, err := ioutil.ReadFile(filename)
+	if err != nil {
+		t.Fatalf("ReadFile failed: %v", err)
+	}
+	b = replacePathsForTesting(t, b, true)
+
+	f, err := ioutil.TempFile("", "edwood_test")
+	if err != nil {
+		t.Fatalf("failed to create temporary file: %v", err)
+	}
+	_, err = f.Write(b)
+	if err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	f.Close()
+	return f.Name()
 }

--- a/testdata/example.dump
+++ b/testdata/example.dump
@@ -49,7 +49,7 @@
 			"Position": 12.649800266311585,
 			"Font": "/lib/font/bit/lucsans/euro.8.font",
 			"Tag": {
-				"Buffer": "/home/gopher/go/src/edwood/row_test.go Del Snarf | Look Edit ",
+				"Buffer": "/home/gopher/go/src/edwood/testdata/hello.go Del Snarf | Look Edit ",
 				"Q0": 60,
 				"Q1": 65
 			},
@@ -64,7 +64,7 @@
 			"Position": 2.263648468708389,
 			"Font": "/lib/font/bit/lucsans/euro.8.font",
 			"Tag": {
-				"Buffer": "/home/gopher/go/src/edwood/ Del Snarf Get | Look Edit ",
+				"Buffer": "/home/gopher/go/src/edwood/testdata/ Del Snarf Get | Look Edit ",
 				"Q0": 49,
 				"Q1": 54
 			},
@@ -76,10 +76,10 @@
 		{
 			"Type": 2,
 			"Column": 1,
-			"Position": 32.62316910785619,
+			"Position": 18.8135593220339,
 			"Font": "/lib/font/bit/lucsans/euro.8.font",
 			"Tag": {
-				"Buffer": "/home/gopher/go/src/edwood/row_test.go Del Snarf | Look Edit ",
+				"Buffer": "/home/gopher/go/src/edwood/testdata/hello.go Del Snarf | Look Edit ",
 				"Q0": 60,
 				"Q1": 65
 			},
@@ -91,7 +91,7 @@
 		{
 			"Type": 1,
 			"Column": 1,
-			"Position": 74.96671105193076,
+			"Position": 35.932203389830505,
 			"Font": "/lib/font/bit/lucsans/euro.8.font",
 			"Tag": {
 				"Buffer": " Del Snarf | Look Edit ",

--- a/testdata/example.index
+++ b/testdata/example.index
@@ -1,0 +1,4 @@
+          1          32         162           0           0 glass Del Snarf Put | Look Edit 
+          3          63         118           1           0 /home/gopher/go/src/edwood/testdata/ Del Snarf Get | Look Edit 
+          4          67          70           0           0 /home/gopher/go/src/edwood/testdata/hello.go Del Snarf | Look Edit 
+          5          23          25           0           0  Del Snarf | Look Edit 

--- a/testdata/hello.go
+++ b/testdata/hello.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, 世界")
+}

--- a/testdata/multi-line-tag.dump
+++ b/testdata/multi-line-tag.dump
@@ -25,7 +25,7 @@
 			"Position": 2.263648468708389,
 			"Font": "/lib/font/bit/lucsans/euro.8.font",
 			"Tag": {
-				"Buffer": "/home/gopher/go/src/edwood/row_test.go Del Snarf | Look Edit The first line\nThe second line\nThe third line",
+				"Buffer": "/home/gopher/go/src/edwood/testdata/hello.go Del Snarf | Look Edit The first line\nThe second line\nThe third line",
 				"Q0": 93,
 				"Q1": 108
 			},
@@ -40,7 +40,7 @@
 			"Position": 20.63914780292943,
 			"Font": "/lib/font/bit/lucsans/euro.8.font",
 			"Tag": {
-				"Buffer": "/home/gopher/go/src/edwood/row_test.go Del Snarf | Look Edit The first line\nThe second line\nThe third line",
+				"Buffer": "/home/gopher/go/src/edwood/testdata/hello.go Del Snarf | Look Edit The first line\nThe second line\nThe third line",
 				"Q0": 93,
 				"Q1": 108
 			},
@@ -55,7 +55,7 @@
 			"Position": 49.00133155792277,
 			"Font": "/lib/font/bit/lucsans/euro.8.font",
 			"Tag": {
-				"Buffer": "/home/gopher/go/src/edwood/ Del Snarf Get | Look Edit The first line\nThe second line\nThe third line",
+				"Buffer": "/home/gopher/go/src/edwood/testdata/ Del Snarf Get | Look Edit The first line\nThe second line\nThe third line",
 				"Q0": 86,
 				"Q1": 101
 			},
@@ -67,7 +67,7 @@
 		{
 			"Type": 1,
 			"Column": 0,
-			"Position": 77.3635153129161,
+			"Position": 53.05084745762712,
 			"Font": "/lib/font/bit/lucsans/euro.8.font",
 			"Tag": {
 				"Buffer": "foo Del Snarf Undo Put | Look Edit The first line\nThe second line\nThe third line",

--- a/testdata/multi-line-tag.index
+++ b/testdata/multi-line-tag.index
@@ -1,0 +1,3 @@
+          2         112          70           0           0 /home/gopher/go/src/edwood/testdata/hello.go Del Snarf | Look Edit The first line
+          3         108         120           1           0 /home/gopher/go/src/edwood/testdata/ Del Snarf Get | Look Edit The first line
+          4          75           6           0           0 foo Del Snarf Put | Look Edit The first line


### PR DESCRIPTION
* The helper functions are similar to readbuf(3) and readstr(3) in lib9p.

* Remove TODO about not respecting utf8 boundaries for read requests as
it's generally the client's responsibility to make sure full runes are
read.

* Only include the first line of a multi-line tag for index file.

* Adjust test dump files to only use files within the testdata directory.