### PR TITLE
Test xfidopen, xfidclose and xfidwrite

### DIFF
--- a/buf.go
+++ b/buf.go
@@ -43,6 +43,9 @@ func (b *Buffer) Reader(q0, q1 int) io.Reader {
 
 func (b *Buffer) ReadC(q int) rune { return (*b)[q] }
 
+// String returns a string representation of buffer. See fmt.Stringer interface.
+func (b *Buffer) String() string { return string(*b) }
+
 func (b *Buffer) Reset() {
 	(*b) = (*b)[0:0]
 }

--- a/wind.go
+++ b/wind.go
@@ -43,8 +43,8 @@ type Window struct {
 	dirnames    []string
 	widths      []int
 	incl        []string
-	ctrllock    sync.Mutex
-	ctlfid      uint32
+	ctrllock    sync.Mutex // used for lock/unlock ctl mesage
+	ctlfid      uint32     // ctl file Fid which has the ctrllock
 	dumpstr     string
 	dumpdir     string
 	utflastqid  int

--- a/wind.go
+++ b/wind.go
@@ -29,7 +29,7 @@ type Window struct {
 	addr  Range
 	limit Range
 
-	nopen      [QMAX]byte
+	nopen      [QMAX]byte // number of open Fid for each file in the file server
 	nomark     bool
 	wrselrange Range
 	rdselfd    *os.File // temporary file for rdsel read requests
@@ -38,12 +38,12 @@ type Window struct {
 	eventx *Xfid
 	events []byte
 
-	owner       int
+	owner       int // TODO(fhs): change type to rune
 	maxlines    int
 	dirnames    []string
 	widths      []int
 	incl        []string
-	ctrllock    *sync.Mutex
+	ctrllock    sync.Mutex
 	ctlfid      uint32
 	dumpstr     string
 	dumpdir     string

--- a/xfid.go
+++ b/xfid.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"log"
 	"os"
 	"strconv"
 	"strings"
@@ -563,14 +564,16 @@ forloop:
 		// Lock/unlock can hang or crash Edwood.
 		// They don't appear to be used for anything useful, so disable for now.
 		//
-		//case "lock": // make window exclusive use
-		//	// BUG(fhs): This will hang Edwood if the lock is already locked.
-		//	w.ctrllock.Lock()
-		//	w.ctlfid = x.f.fid
-		//case "unlock": // release exclusive use
-		//	w.ctlfid = math.MaxUint32
-		//	// BUG(fhs): This will crash if the lock isn't already locked.
-		//	w.ctrllock.Unlock()
+		case "lock": // make window exclusive use
+			//w.ctrllock.Lock() // This will hang Edwood if the lock is already locked.
+			//w.ctlfid = x.f.fid
+			fallthrough
+		case "unlock": // release exclusive use
+			//w.ctlfid = math.MaxUint32
+			//w.ctrllock.Unlock() // This will crash if the lock isn't already locked.
+			log.Printf("%v ctl message received for window %v (%v)\n", words[0], w.id, w.body.file.name)
+			err = ErrBadCtl
+			break forloop
 
 		case "clean": // mark window 'clean', seq=0
 			t = &w.body


### PR DESCRIPTION
* Fix crash due to Window.ctrllock not being initialized.
* Disable `unlock` and `lock` ctl messages because they can crash or hang Edwood.
* Fix `del` ctl message.
