### PR TITLE
Test xfidread, xfidflush and xfidctl

### DIFF
--- a/acme.go
+++ b/acme.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"image"
@@ -175,7 +176,7 @@ func main() {
 		go keyboardthread(display)
 		go waitthread()
 		go newwindowthread()
-		go xfidallocthread(display)
+		go xfidallocthread(context.Background(), display)
 
 		signal.Ignore(ignoreSignals...)
 		signal.Notify(csignal, hangupSignals...)
@@ -610,10 +611,12 @@ func waitthread() {
 // it instead of using a send and a receive to get one.
 // Frankly, it would be more idiomatic to let the GC take care of them,
 // though that would require an exit signal in xfidctl.
-func xfidallocthread(d draw.Display) {
+func xfidallocthread(ctx context.Context, d draw.Display) {
 	xfree := (*Xfid)(nil)
 	for {
 		select {
+		case <-ctx.Done():
+			return
 		case <-cxfidalloc:
 			x := xfree
 			if x != nil {

--- a/wind.go
+++ b/wind.go
@@ -47,9 +47,9 @@ type Window struct {
 	ctlfid      uint32     // ctl file Fid which has the ctrllock
 	dumpstr     string
 	dumpdir     string
-	utflastqid  int
-	utflastboff uint64
-	utflastq    int
+	utflastqid  int    // Qid of last read request (QWbody or QWtag)
+	utflastboff uint64 // Byte offset of last read of body or tag
+	utflastq    int    // Rune offset of last read of body or tag
 	tagsafe     bool
 	tagexpand   bool
 	taglines    int


### PR DESCRIPTION
* Always send error response to 9P client for invalid QID (instead of
showing a warning to user).

* Clean up xfidallocthread goroutine after test as having it running in
the background can interfere with other tests.