### PR TITLE
Refactor and test directory read in file server

### DIFF
--- a/fsys.go
+++ b/fsys.go
@@ -291,9 +291,7 @@ func (fs *fileServer) attach(x *Xfid, f *Fid) *Xfid {
 		err := fmt.Errorf("unknown id %q in Aname", x.fcall.Aname)
 		return fs.respond(x, nil, err)
 	}
-	if m != nil {
-		f.mntdir = m
-	}
+	f.mntdir = m
 	f.busy = true
 	f.open = false
 	f.qid.Path = Qdir
@@ -302,7 +300,6 @@ func (fs *fileServer) attach(x *Xfid, f *Fid) *Xfid {
 	f.dir = dirtab[0] // '.'
 	f.nrpart = 0
 	f.w = nil
-	f.mntdir = nil
 	t := plan9.Fcall{
 		Qid: f.qid,
 	}

--- a/internal/ninep/util.go
+++ b/internal/ninep/util.go
@@ -1,7 +1,11 @@
 // Package ninep contains helper routines for implementing a 9P2000 protocol server.
 package ninep
 
-import "9fans.net/go/plan9"
+import (
+	"fmt"
+
+	"9fans.net/go/plan9"
+)
 
 // ReadBuffer sets Count and Data in response ofcall based the
 // request ifcall and full data src. The Data is set to a sub-slice of src
@@ -30,4 +34,65 @@ func ReadBuffer(ofcall, ifcall *plan9.Fcall, src []byte) {
 // This function is similar to readstr(3) in lib9p.
 func ReadString(ofcall, ifcall *plan9.Fcall, src string) {
 	ReadBuffer(ofcall, ifcall, []byte(src))
+}
+
+// DirRead sets ofcall.Data to at most ifcall.Count bytes of directory
+// entries read from offset ifcall.Offset. The function gen is called
+// to obtain the n-th directory entry. Gen should return nil on end
+// of directory. DirRead returns the number of directory entries read.
+// This function is similar to dirread9p(3) in lib9p.
+func DirRead(ofcall, ifcall *plan9.Fcall, gen func(i int) *plan9.Dir) int {
+	o := ifcall.Offset
+	e := ifcall.Offset + uint64(ifcall.Count)
+	data := make([]byte, ifcall.Count)
+	n := 0
+	i := uint64(0)
+	dirindex := 0
+	for i < e {
+		d := gen(dirindex)
+		if d == nil {
+			break
+		}
+		b, _ := d.Bytes()
+		length := len(b)
+		if length > len(data[n:]) {
+			break
+		}
+		if i >= o {
+			copy(data[n:], b)
+			n += length
+		}
+		dirindex++
+		i += uint64(length)
+	}
+	ofcall.Data = data[:n]
+	return dirindex
+}
+
+func gbit16(b []byte) (uint16, []byte) {
+	return uint16(b[0]) | uint16(b[1])<<8, b[2:]
+}
+
+// UnmarshalDirs decodes and returns one or more directory entries in b.
+// This function exists because plan9.UnmarshalDir cannot deal with
+// multiple entries.
+func UnmarshalDirs(b []byte) ([]plan9.Dir, error) {
+	var result []plan9.Dir
+	for {
+		if len(b) <= 2 {
+			break
+		}
+		n, _ := gbit16(b)
+		d, err := plan9.UnmarshalDir(b[:2+n])
+		if err != nil {
+			return nil, err
+		}
+		b = b[2+n:]
+
+		result = append(result, *d)
+	}
+	if len(b) != 0 {
+		return nil, fmt.Errorf("partial directory entry")
+	}
+	return result, nil
 }

--- a/internal/ninep/util_test.go
+++ b/internal/ninep/util_test.go
@@ -1,6 +1,7 @@
 package ninep
 
 import (
+	"fmt"
 	"testing"
 
 	"9fans.net/go/plan9"
@@ -40,5 +41,73 @@ func TestReadString(t *testing.T) {
 		if diff := cmp.Diff(want, &got); diff != "" {
 			t.Errorf("mismatch (-want +got):\n%s", diff)
 		}
+	}
+}
+
+func TestDirRead(t *testing.T) {
+	want := []plan9.Dir{
+		{Name: "one"},
+		{Name: "two"},
+	}
+
+	for _, tc := range []struct {
+		name  string
+		count uint32
+		ndir  int
+	}{
+		{"TwoEntries", 512, 2},
+		{"OneEntry", 80, 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ifcall := plan9.Fcall{
+				Count: tc.count,
+			}
+			var ofcall plan9.Fcall
+
+			DirRead(&ofcall, &ifcall, func(i int) *plan9.Dir {
+				if i < len(want) {
+					return &want[i]
+				}
+				return nil
+			})
+			got, err := UnmarshalDirs(ofcall.Data)
+			if err != nil {
+				t.Fatalf("failed to unmarshal directory entries: %v", err)
+			}
+			if diff := cmp.Diff(want[:tc.ndir], got); diff != "" {
+				t.Errorf("directory entries mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestUnmarshalDirs(t *testing.T) {
+	dir := plan9.Dir{Name: "hello.txt"}
+	b, _ := dir.Bytes()
+	for _, tc := range []struct {
+		name string
+		b    []byte
+		dirs []plan9.Dir
+		err  error
+	}{
+		{"Success", b, []plan9.Dir{dir}, nil},
+		{"PartialDir", []byte{0, 0}, []plan9.Dir{dir}, fmt.Errorf("partial directory entry")},
+		{"MalformedDir", []byte{2, 0, 0, 0}, []plan9.Dir{dir}, fmt.Errorf("malformed Dir")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := UnmarshalDirs(tc.b)
+			if tc.err != nil {
+				if err != tc.err && err.Error() != tc.err.Error() {
+					t.Fatalf("got error %v; want %v", err, tc.err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("got error %v", err)
+			}
+			if diff := cmp.Diff(tc.dirs, got); diff != "" {
+				t.Errorf("directory entries mismatch (-want +got):\n%s", diff)
+			}
+		})
 	}
 }


### PR DESCRIPTION
* Fix crash if read buffer is not large enough to fit a directory entry.

* Added a helper function similar to lib9p's dirread9p(3).

* Don't send partial directory entry for Tstat.