### PR TITLE
Fix waitthread infinite loop trying to find PID in command list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
   global:
     - acmeshell=sh
     - GO111MODULE=on
+    - GOPROXY="https://proxy.golang.org"
 
 script:
   - go get -t -v ./...

--- a/acme_test.go
+++ b/acme_test.go
@@ -1,9 +1,13 @@
 package main
 
 import (
+	"context"
+	"fmt"
 	"os/exec"
 	"testing"
 	"time"
+
+	"github.com/rjkroege/edwood/internal/edwoodtest"
 )
 
 func TestIsmtpt(t *testing.T) {
@@ -56,3 +60,69 @@ func TestKillprocs(t *testing.T) {
 		t.Errorf("killprocs did not kill command in time")
 	}
 }
+
+// TestWaithreadCommandCycle tests that we don't create a cycle in the command linked list
+// (regression test for https://github.com/rjkroege/edwood/issues/279).
+func TestWaitthreadCommandCycle(t *testing.T) {
+	ccommand = make(chan *Command)
+	cwait = make(chan ProcessState)
+	row = Row{
+		display: edwoodtest.NewDisplay(),
+		tag: Text{
+			file: NewFile(""),
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		waitthread(ctx)
+		ccommand = nil
+		cwait = nil
+		row = Row{}
+		close(done)
+	}()
+
+	var (
+		c [4]*Command
+		w [4]*mockProcessState
+	)
+	for i := 0; i < len(c); i++ {
+		c[i] = &Command{
+			pid:  i,
+			name: fmt.Sprintf("proc%v", i),
+		}
+		w[i] = &mockProcessState{
+			pid:     i,
+			success: true,
+		}
+	}
+
+	ccommand <- c[3]
+	ccommand <- c[2]
+	ccommand <- c[1]
+	ccommand <- c[0]
+
+	// command is 0 -> 1 -> 2 -> 3
+
+	cwait <- w[2] // delete 2, command is 0 -> 1 -> 3, lc = 1 -> 3
+	cwait <- w[0] // delete 0, command is 1 -> 1 -> 1 -> ...
+	cwait <- w[3] // try to delete 2: infinite loop
+
+	cancel() // Ask waithtread to finish up.
+
+	// Wait for waithtread to return and finish clean up.
+	<-done
+}
+
+type mockProcessState struct {
+	pid     int
+	success bool
+}
+
+func (ps *mockProcessState) Pid() int { return ps.pid }
+func (ps *mockProcessState) String() string {
+	return fmt.Sprintf("pid %v, success %v", ps.pid, ps.success)
+}
+func (ps *mockProcessState) Success() bool { return ps.success }

--- a/dat.go
+++ b/dat.go
@@ -142,7 +142,6 @@ type Command struct {
 	av            []string
 	iseditcommand bool
 	md            *MntDir
-	next          *Command // TODO(flux).  This really wants to be a canonical slice instead of a linked list
 }
 
 // DirTab describes a file or directory in file server.

--- a/dat.go
+++ b/dat.go
@@ -107,7 +107,7 @@ var (
 	editing    = Inactive
 
 	cplumb     chan *plumb.Message
-	cwait      chan *os.ProcessState
+	cwait      chan ProcessState
 	ccommand   chan *Command
 	ckill      chan string
 	cxfidalloc chan *Xfid
@@ -123,6 +123,12 @@ var (
 
 	WinID = 0
 )
+
+type ProcessState interface {
+	Pid() int
+	String() string
+	Success() bool
+}
 
 type Range struct {
 	q0, q1 int

--- a/exec_test.go
+++ b/exec_test.go
@@ -12,7 +12,7 @@ import (
 
 func acmeTestingMain() {
 	acmeshell = os.Getenv("acmeshell")
-	cwait = make(chan *os.ProcessState)
+	cwait = make(chan ProcessState)
 	cerr = make(chan error)
 	go func() {
 		for range cerr {


### PR DESCRIPTION
* Prevent cycle in command linked list (Fixes #279)
* Change command linked list to a slice
* Change waitthread's pids from a linked list to a map
* Add more waitthread test
* Set `GOPROXY` environment variable in Travis (attempt to fix `go get` timeouts)