### PR TITLE
.travis.yml: drop Go 1.11.x and add Go 1.13.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ os:
   - osx
 
 go:
-  - "1.11.x"
   - "1.12.x"
+  - "1.13.x"
 
 install:
   - # Do nothing. This is needed to prevent default install action "go get -t -v ./..." from happening here (we want it to happen inside script step).

--- a/acme.go
+++ b/acme.go
@@ -104,7 +104,7 @@ func main() {
 		if err := display.Attach(draw.Refnone); err != nil {
 			panic("failed to attach to window")
 		}
-		display.ScreenImage().Draw(display.ScreenImage().R(), display.White(), nil, image.ZP)
+		display.ScreenImage().Draw(display.ScreenImage().R(), display.White(), nil, image.Point{})
 
 		mousectl = display.InitMouse()
 		keyboardctl = display.InitKeyboard()
@@ -257,16 +257,16 @@ func iconinit(display draw.Display) {
 	button, _ = display.AllocImage(r, display.ScreenImage().Pix(), false, draw.Notacolor)
 	button.Draw(r, tagcolors[frame.ColBack], nil, r.Min)
 	r.Max.X -= display.ScaleSize(ButtonBorder)
-	button.Border(r, display.ScaleSize(ButtonBorder), tagcolors[frame.ColBord], image.ZP)
+	button.Border(r, display.ScaleSize(ButtonBorder), tagcolors[frame.ColBord], image.Point{})
 
 	r = button.R()
 	modbutton, _ = display.AllocImage(r, display.ScreenImage().Pix(), false, draw.Notacolor)
 	modbutton.Draw(r, tagcolors[frame.ColBack], nil, r.Min)
 	r.Max.X -= display.ScaleSize(ButtonBorder)
-	modbutton.Border(r, display.ScaleSize(ButtonBorder), tagcolors[frame.ColBord], image.ZP)
+	modbutton.Border(r, display.ScaleSize(ButtonBorder), tagcolors[frame.ColBord], image.Point{})
 	r = r.Inset(display.ScaleSize(ButtonBorder))
 	tmp, _ := display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, draw.Medblue)
-	modbutton.Draw(r, tmp, nil, image.ZP)
+	modbutton.Draw(r, tmp, nil, image.Point{})
 
 	r = button.R()
 	colbutton, _ = display.AllocImage(r, display.ScreenImage().Pix(), false, draw.Purpleblue)
@@ -299,7 +299,7 @@ func mousethread(display draw.Display) {
 			if err := display.Attach(draw.Refnone); err != nil {
 				panic("failed to attach to window")
 			}
-			display.ScreenImage().Draw(display.ScreenImage().R(), display.White(), nil, image.ZP)
+			display.ScreenImage().Draw(display.ScreenImage().R(), display.White(), nil, image.Point{})
 			iconinit(display)
 			ScrlResize(display)
 			row.Resize(display.ScreenImage().R())

--- a/col.go
+++ b/col.go
@@ -41,7 +41,7 @@ func (c *Column) Init(r image.Rectangle, dis draw.Display) *Column {
 	c.w = []*Window{}
 	c.Border = c.display.ScaleSize(Border)
 	if c.display != nil {
-		c.display.ScreenImage().Draw(r, c.display.White(), nil, image.ZP)
+		c.display.ScreenImage().Draw(r, c.display.White(), nil, image.Point{})
 		c.Border = c.display.ScaleSize(Border)
 	}
 	c.r = r
@@ -57,7 +57,7 @@ func (c *Column) Init(r image.Rectangle, dis draw.Display) *Column {
 	r1.Min.Y = r1.Max.Y
 	r1.Max.Y += c.display.ScaleSize(Border)
 	if c.display != nil {
-		c.display.ScreenImage().Draw(r1, c.display.Black(), nil, image.ZP)
+		c.display.ScreenImage().Draw(r1, c.display.Black(), nil, image.Point{})
 	}
 	c.tag.Insert(0, Lheader, true)
 	c.tag.SetSelect(c.tag.file.Size(), c.tag.file.Size())
@@ -158,7 +158,7 @@ func (c *Column) Add(w, clone *Window, y int) *Window {
 		r = v.r
 		r.Max.Y = ymax
 		if c.display != nil {
-			c.display.ScreenImage().Draw(r, textcolors[frame.ColBack], nil, image.ZP)
+			c.display.ScreenImage().Draw(r, textcolors[frame.ColBack], nil, image.Point{})
 		}
 		r1 := r
 		y = min(y, ymax-(v.tag.fr.DefaultFontHeight()*v.taglines+v.body.fr.DefaultFontHeight()+c.display.ScaleSize(Border)+1))
@@ -167,7 +167,7 @@ func (c *Column) Add(w, clone *Window, y int) *Window {
 		r1.Min.Y = v.Resize(r1, false, false)
 		r1.Max.Y = r1.Min.Y + c.display.ScaleSize(Border)
 		if c.display != nil {
-			c.display.ScreenImage().Draw(r1, c.display.Black(), nil, image.ZP)
+			c.display.ScreenImage().Draw(r1, c.display.Black(), nil, image.Point{})
 		}
 		//
 		// leave r with w's coordinates
@@ -178,7 +178,7 @@ func (c *Column) Add(w, clone *Window, y int) *Window {
 		w = NewWindow()
 		w.col = c
 		if c.display != nil {
-			c.display.ScreenImage().Draw(r, textcolors[frame.ColBack], nil, image.ZP)
+			c.display.ScreenImage().Draw(r, textcolors[frame.ColBack], nil, image.Point{})
 		}
 		w.Init(clone, r, c.display)
 	} else {
@@ -233,7 +233,7 @@ Found:
 	c.w = append(c.w[:i], c.w[i+1:]...)
 	if len(c.w) == 0 {
 		if c.display != nil {
-			c.display.ScreenImage().Draw(r, c.display.White(), nil, image.ZP)
+			c.display.ScreenImage().Draw(r, c.display.White(), nil, image.Point{})
 		}
 		return
 	}
@@ -248,7 +248,7 @@ Found:
 		r.Max.Y = w.r.Max.Y
 	}
 	if c.display != nil {
-		c.display.ScreenImage().Draw(r, textcolors[frame.ColBack], nil, image.ZP)
+		c.display.ScreenImage().Draw(r, textcolors[frame.ColBack], nil, image.Point{})
 	}
 	if c.safe && !c.fortest {
 		if !didmouse && up {
@@ -288,7 +288,7 @@ func (c *Column) Resize(r image.Rectangle) {
 	}
 	r1.Min.Y = r1.Max.Y
 	r1.Max.Y += c.display.ScaleSize(Border)
-	c.display.ScreenImage().Draw(r1, c.display.Black(), nil, image.ZP)
+	c.display.ScreenImage().Draw(r1, c.display.Black(), nil, image.Point{})
 	r1.Max.Y = r.Max.Y
 	for i := 0; i < c.nw(); i++ {
 		w := c.w[i]
@@ -304,7 +304,7 @@ func (c *Column) Resize(r image.Rectangle) {
 		r1.Max.Y = max(r1.Max.Y, r1.Min.Y+c.display.ScaleSize(Border)+fontget(tagfont, c.display).Height())
 		r2 := r1
 		r2.Max.Y = r2.Min.Y + c.display.ScaleSize(Border)
-		c.display.ScreenImage().Draw(r2, c.display.Black(), nil, image.ZP)
+		c.display.ScreenImage().Draw(r2, c.display.Black(), nil, image.Point{})
 		r1.Min.Y = r2.Max.Y
 		r1.Min.Y = w.Resize(r1, false, i == c.nw()-1)
 	}
@@ -316,7 +316,7 @@ func (c *Column) Sort() {
 
 	r := c.r
 	r.Min.Y = c.tag.fr.Rect().Max.Y
-	c.display.ScreenImage().Draw(r, textcolors[frame.ColBack], nil, image.ZP)
+	c.display.ScreenImage().Draw(r, textcolors[frame.ColBack], nil, image.Point{})
 	y := r.Min.Y
 	for i := 0; i < len(c.w); i++ {
 		w := c.w[i]
@@ -328,7 +328,7 @@ func (c *Column) Sort() {
 		}
 		r1 := r
 		r1.Max.Y = r1.Min.Y + c.display.ScaleSize(Border)
-		c.display.ScreenImage().Draw(r1, c.display.Black(), nil, image.ZP)
+		c.display.ScreenImage().Draw(r1, c.display.Black(), nil, image.Point{})
 		r.Min.Y = r1.Max.Y
 		y = w.Resize(r, false, i == len(c.w)-1)
 	}
@@ -368,7 +368,7 @@ func (c *Column) Grow(w *Window, but int) {
 			c.w[0] = w
 			c.w[windex] = v
 		}
-		c.display.ScreenImage().Draw(cr, textcolors[frame.ColBack], nil, image.ZP)
+		c.display.ScreenImage().Draw(cr, textcolors[frame.ColBack], nil, image.Point{})
 		w.Resize(cr, false, true)
 		for i := 1; i < c.nw(); i++ {
 			ffs := c.w[i].body.fr.GetFrameFillStatus()
@@ -444,7 +444,7 @@ Pack:
 		}
 		r.Min.Y = v.Resize(r, false, false)
 		r.Max.Y += c.display.ScaleSize(Border)
-		c.display.ScreenImage().Draw(r, c.display.Black(), nil, image.ZP)
+		c.display.ScreenImage().Draw(r, c.display.Black(), nil, image.Point{})
 		y1 = r.Max.Y
 	}
 	// scan to see new size of everyone below
@@ -473,7 +473,7 @@ Pack:
 	if windex < c.nw()-1 {
 		r.Min.Y = r.Max.Y
 		r.Max.Y += c.display.ScaleSize(Border)
-		c.display.ScreenImage().Draw(r, c.display.Black(), nil, image.ZP)
+		c.display.ScreenImage().Draw(r, c.display.Black(), nil, image.Point{})
 		for j := windex + 1; j < c.nw(); j++ {
 			ny[j] -= (y2 - r.Max.Y)
 		}
@@ -492,7 +492,7 @@ Pack:
 		if j < c.nw()-1 { // no border on last window
 			r.Min.Y = y1
 			r.Max.Y += c.display.ScaleSize(Border)
-			c.display.ScreenImage().Draw(r, c.display.Black(), nil, image.ZP)
+			c.display.ScreenImage().Draw(r, c.display.Black(), nil, image.Point{})
 			y1 = r.Max.Y
 		}
 	}
@@ -582,7 +582,7 @@ Found:
 	}
 	r.Min.Y = v.Resize(r, c.safe, false)
 	r.Max.Y = r.Min.Y + c.row.display.ScaleSize(Border)
-	c.display.ScreenImage().Draw(r, c.display.Black(), nil, image.ZP)
+	c.display.ScreenImage().Draw(r, c.display.Black(), nil, image.Point{})
 	r.Min.Y = r.Max.Y
 	if i == len(c.w)-1 {
 		r.Max.Y = c.r.Max.Y

--- a/exec.go
+++ b/exec.go
@@ -751,7 +751,7 @@ func fontx(et *Text, _ *Text, argt *Text, _, _ bool, arg string) {
 
 	if newfont := fontget(file, row.display); newfont != nil {
 		// TODO(rjk): maybe Frame should know how to clear itself on init?
-		row.display.ScreenImage().Draw(t.w.r, textcolors[frame.ColBack], nil, image.ZP)
+		row.display.ScreenImage().Draw(t.w.r, textcolors[frame.ColBack], nil, image.Point{})
 		t.font = file
 		t.fr.Init(t.w.r, frame.OptFont(newfont), frame.OptBackground(row.display.ScreenImage()))
 

--- a/internal/frame/draw.go
+++ b/internal/frame/draw.go
@@ -13,7 +13,7 @@ func (f *frameimpl) drawtext(pt image.Point, text draw.Image, back draw.Image) {
 		// log.Printf("box [%d] %#v pt %v NoRedraw %v nrune %d\n",  nb, string(b.Ptr), pt, f.NoRedraw, b.Nrune)
 
 		if !f.noredraw && b.Nrune >= 0 {
-			f.background.Bytes(pt, text, image.ZP, f.font, b.Ptr)
+			f.background.Bytes(pt, text, image.Point{}, f.font, b.Ptr)
 		}
 		pt.X += b.Wid
 	}
@@ -158,7 +158,7 @@ func (f *frameimpl) Drawsel0(pt image.Point, p0, p1 int, back draw.Image, text d
 		// f.drawBox(image.Rect(pt.X, pt.Y, x, pt.Y+f.Font.DefaultHeight()), text, back, pt)
 		f.background.Draw(image.Rect(pt.X, pt.Y, x, pt.Y+f.defaultfontheight), back, nil, pt)
 		if b.Nrune >= 0 {
-			f.background.Bytes(pt, text, image.ZP, f.font, ptr[0:runeindex(ptr, nr)])
+			f.background.Bytes(pt, text, image.Point{}, f.font, ptr[0:runeindex(ptr, nr)])
 		}
 		pt.X += w
 		p += nr
@@ -194,7 +194,7 @@ func (f *frameimpl) Redraw(enclosing image.Rectangle) {
 	f.lk.Lock()
 	defer f.lk.Unlock()
 	// log.Printf("Redraw %v %v", f.Rect, enclosing)
-	f.background.Draw(enclosing, f.cols[ColBack], nil, image.ZP)
+	f.background.Draw(enclosing, f.cols[ColBack], nil, image.Point{})
 }
 
 func (f *frameimpl) tick(pt image.Point, ticked bool) {
@@ -212,10 +212,10 @@ func (f *frameimpl) tick(pt image.Point, ticked bool) {
 
 	if ticked {
 		f.tickback.Draw(f.tickback.R(), f.background, nil, pt)
-		f.background.Draw(r, f.display.Black(), f.tickimage, image.ZP) // draws an alpha-blended box
+		f.background.Draw(r, f.display.Black(), f.tickimage, image.Point{}) // draws an alpha-blended box
 	} else {
 		// There is an issue with tick management
-		f.background.Draw(r, f.tickback, nil, image.ZP)
+		f.background.Draw(r, f.tickback, nil, image.Point{})
 	}
 	f.ticked = ticked
 }

--- a/internal/frame/select.go
+++ b/internal/frame/select.go
@@ -171,15 +171,15 @@ func (f *frameimpl) SelectPaint(p0, p1 image.Point, col draw.Image) {
 		return
 	}
 	if n == 0 {
-		f.background.Draw(Rpt(p0, q1), col, nil, image.ZP)
+		f.background.Draw(Rpt(p0, q1), col, nil, image.Point{})
 	} else {
 		if p0.X >= f.rect.Max.X {
 			p0.X = f.rect.Max.X - 1
 		}
-		f.background.Draw(image.Rect(p0.X, p0.Y, f.rect.Max.X, q0.Y), col, nil, image.ZP)
+		f.background.Draw(image.Rect(p0.X, p0.Y, f.rect.Max.X, q0.Y), col, nil, image.Point{})
 		if n > 1 {
-			f.background.Draw(image.Rect(f.rect.Min.X, q0.Y, f.rect.Max.X, p1.Y), col, nil, image.ZP)
+			f.background.Draw(image.Rect(f.rect.Min.X, q0.Y, f.rect.Max.X, p1.Y), col, nil, image.Point{})
 		}
-		f.background.Draw(image.Rect(f.rect.Min.X, p1.Y, q1.X, q1.Y), col, nil, image.ZP)
+		f.background.Draw(image.Rect(f.rect.Min.X, p1.Y, q1.X, q1.Y), col, nil, image.Point{})
 	}
 }

--- a/internal/frame/tick.go
+++ b/internal/frame/tick.go
@@ -35,7 +35,7 @@ func (f *frameimpl) InitTick() {
 		f.tickimage = nil
 		return
 	}
-	f.tickback.Draw(f.tickback.R(), f.cols[ColBack], nil, image.ZP)
+	f.tickback.Draw(f.tickback.R(), f.cols[ColBack], nil, image.Point{})
 
 	f.tickimage.Draw(f.tickimage.R(), f.display.Transparent(), nil, image.Pt(0, 0))
 	// vertical line

--- a/row.go
+++ b/row.go
@@ -26,7 +26,7 @@ func (row *Row) Init(r image.Rectangle, dis draw.Display) *Row {
 		row = &Row{}
 	}
 	row.display = dis
-	row.display.ScreenImage().Draw(r, row.display.White(), nil, image.ZP)
+	row.display.ScreenImage().Draw(r, row.display.White(), nil, image.Point{})
 	row.col = []*Column{}
 	row.r = r
 	r1 := r
@@ -41,7 +41,7 @@ func (row *Row) Init(r image.Rectangle, dis draw.Display) *Row {
 	t.col = nil
 	r1.Min.Y = r1.Max.Y
 	r1.Max.Y += row.display.ScaleSize(Border)
-	row.display.ScreenImage().Draw(r1, row.display.Black(), nil, image.ZP)
+	row.display.ScreenImage().Draw(r1, row.display.Black(), nil, image.Point{})
 	t.Insert(0, []rune("Newcol Kill Putall Dump Exit "), true)
 	t.SetSelect(t.file.Size(), t.file.Size())
 	return row
@@ -72,7 +72,7 @@ func (row *Row) Add(c *Column, x int) *Column {
 		if r.Dx() < 100 {
 			return nil // Refuse columns too narrow
 		}
-		row.display.ScreenImage().Draw(r, row.display.White(), nil, image.ZP)
+		row.display.ScreenImage().Draw(r, row.display.White(), nil, image.Point{})
 		r1 := r
 		r1.Max.X = min(x-row.display.ScaleSize(Border), r.Max.X-row.display.ScaleSize(50))
 		if r1.Dx() < row.display.ScaleSize(50) {
@@ -81,7 +81,7 @@ func (row *Row) Add(c *Column, x int) *Column {
 		d.Resize(r1)
 		r1.Min.X = r1.Max.X
 		r1.Max.X = r1.Min.X + row.display.ScaleSize(Border)
-		row.display.ScreenImage().Draw(r1, row.display.Black(), nil, image.ZP)
+		row.display.ScreenImage().Draw(r1, row.display.Black(), nil, image.Point{})
 		r.Min.X = r1.Max.X
 	}
 	if c == nil {
@@ -107,7 +107,7 @@ func (r *Row) Resize(rect image.Rectangle) {
 	row.tag.Resize(r1, true, false)
 	r1.Min.Y = r1.Max.Y
 	r1.Max.Y += row.display.ScaleSize(Border)
-	row.display.ScreenImage().Draw(r1, row.display.Black(), nil, image.ZP)
+	row.display.ScreenImage().Draw(r1, row.display.Black(), nil, image.Point{})
 	rect.Min.Y = r1.Max.Y
 	r1 = rect
 	r1.Max.X = r1.Min.X
@@ -123,7 +123,7 @@ func (r *Row) Resize(rect image.Rectangle) {
 		if i > 0 {
 			r2 := r1
 			r2.Max.X = r2.Min.X + row.display.ScaleSize(Border)
-			row.display.ScreenImage().Draw(r2, row.display.Black(), nil, image.ZP)
+			row.display.ScreenImage().Draw(r2, row.display.Black(), nil, image.Point{})
 			r1.Min.X = r2.Max.X
 		}
 		c.Resize(r1)
@@ -189,14 +189,14 @@ Found:
 	}
 	r = d.r
 	r.Max.X = c.r.Max.X
-	row.display.ScreenImage().Draw(r, row.display.White(), nil, image.ZP)
+	row.display.ScreenImage().Draw(r, row.display.White(), nil, image.Point{})
 	r.Max.X = p.X
 	d.Resize(r)
 	r = c.r
 	r.Min.X = p.X
 	r.Max.X = r.Min.X
 	r.Max.X += row.display.ScaleSize(Border)
-	row.display.ScreenImage().Draw(r, row.display.Black(), nil, image.ZP)
+	row.display.ScreenImage().Draw(r, row.display.Black(), nil, image.Point{})
 	r.Min.X = r.Max.X
 	r.Max.X = c.r.Max.X
 	c.Resize(r)
@@ -222,7 +222,7 @@ Found:
 	}
 	row.col = append(row.col[:i], row.col[i+1:]...)
 	if len(row.col) == 0 {
-		row.display.ScreenImage().Draw(r, row.display.White(), nil, image.ZP)
+		row.display.ScreenImage().Draw(r, row.display.White(), nil, image.Point{})
 		return
 	}
 	if i == len(row.col) { // extend last column right
@@ -233,7 +233,7 @@ Found:
 		c = row.col[i]
 		r.Max.X = c.r.Max.X
 	}
-	row.display.ScreenImage().Draw(r, row.display.White(), nil, image.ZP)
+	row.display.ScreenImage().Draw(r, row.display.White(), nil, image.Point{})
 	c.Resize(r)
 }
 
@@ -576,12 +576,12 @@ func (row *Row) loadimpl(dump *dumpfile.Content, initing bool) error {
 			if r1.Dx() < 50 || r2.Dx() < 50 {
 				continue
 			}
-			row.display.ScreenImage().Draw(image.Rectangle{r1.Min, r2.Max}, row.display.White(), nil, image.ZP)
+			row.display.ScreenImage().Draw(image.Rectangle{r1.Min, r2.Max}, row.display.White(), nil, image.Point{})
 			c1.Resize(r1)
 			c2.Resize(r2)
 			r2.Min.X = x - Border
 			r2.Max.X = x
-			row.display.ScreenImage().Draw(r2, row.display.Black(), nil, image.ZP)
+			row.display.ScreenImage().Draw(r2, row.display.Black(), nil, image.Point{})
 		}
 		if i >= len(row.col) {
 			row.Add(nil, x)

--- a/scrl.go
+++ b/scrl.go
@@ -84,10 +84,10 @@ func (t *Text) ScrDraw(nchars int) {
 	if !r2.Eq(t.lastsr) {
 		t.lastsr = r2
 		// rjk is assuming that only body Text instances have scrollers.
-		b.Draw(r1, textcolors[frame.ColBord], nil, image.ZP)
-		b.Draw(r2, textcolors[frame.ColBack], nil, image.ZP)
+		b.Draw(r1, textcolors[frame.ColBord], nil, image.Point{})
+		b.Draw(r2, textcolors[frame.ColBack], nil, image.Point{})
 		r2.Min.X = r2.Max.X - 1
-		b.Draw(r2, textcolors[frame.ColBord], nil, image.ZP)
+		b.Draw(r2, textcolors[frame.ColBord], nil, image.Point{})
 		row.display.ScreenImage().Draw(r, b, nil, image.Pt(0, r1.Min.Y))
 		// flushimage(display, 1); // BUG?
 	}

--- a/text.go
+++ b/text.go
@@ -97,7 +97,7 @@ func (t *Text) Init(r image.Rectangle, rf string, cols [frame.NumColours]draw.Im
 	t.all = r
 	t.scrollr = r
 	t.scrollr.Max.X = r.Min.X + t.display.ScaleSize(Scrollwid)
-	t.lastsr = image.ZR
+	t.lastsr = image.Rectangle{}
 	r.Min.X += t.display.ScaleSize(Scrollwid) + t.display.ScaleSize(Scrollgap)
 	t.eq0 = ^0
 	t.font = rf
@@ -175,7 +175,7 @@ func (t *Text) Resize(r image.Rectangle, keepextra, noredraw bool) int {
 	t.all = r
 	t.scrollr = r
 	t.scrollr.Max.X = r.Min.X + t.display.ScaleSize(Scrollwid)
-	t.lastsr = image.ZR
+	t.lastsr = image.Rectangle{}
 	r.Min.X += t.display.ScaleSize(Scrollwid + Scrollgap)
 	t.fr.Clear(false)
 	// TODO(rjk): Remove this Font accessor.

--- a/wind.go
+++ b/wind.go
@@ -137,7 +137,7 @@ func (w *Window) Init(clone *Window, r image.Rectangle, dis draw.Display) {
 	r1.Min.Y--
 	r1.Max.Y = r1.Min.Y + 1
 	if w.display != nil {
-		w.display.ScreenImage().Draw(r1, tagcolors[frame.ColBord], nil, image.ZP)
+		w.display.ScreenImage().Draw(r1, tagcolors[frame.ColBord], nil, image.Point{})
 	}
 	w.body.ScrDraw(w.body.fr.GetFrameFillStatus().Nchars)
 	w.r = r
@@ -292,7 +292,7 @@ func (w *Window) Resize(r image.Rectangle, safe, keepextra bool) int {
 			r1.Min.Y = y
 			r1.Max.Y = y + 1
 			if w.display != nil {
-				w.display.ScreenImage().Draw(r1, tagcolors[frame.ColBord], nil, image.ZP)
+				w.display.ScreenImage().Draw(r1, tagcolors[frame.ColBord], nil, image.Point{})
 			}
 			y++
 			r1.Min.Y = min(y, r.Max.Y)


### PR DESCRIPTION
Also, remove use of deprecated `image.ZP` and `image.ZR`. Go 1.13 has deprecated these variables in favor of struct literals. Staticcheck complains if we use them. Changes made with:
```
gofmt -w -r 'image.ZP -> image.Point{}' .
gofmt -w -r 'image.ZR -> image.Rectangle{}' .
```
