### PR TITLE
Fix some Windows issues

### DIFF
--- a/acme.go
+++ b/acme.go
@@ -56,9 +56,11 @@ func main() {
 		}()
 	}
 
-	// TODO(fhs): This is not very portable.
-	// See https://github.com/rjkroege/edwood/issues/222
-	home = os.Getenv("HOME")
+	var err error
+	home, err = os.UserHomeDir()
+	if err != nil {
+		log.Fatalf("could not get user home directory: %v", err)
+	}
 	acmeshell = os.Getenv("acmeshell")
 	p := os.Getenv("tabstop")
 	if p != "" {

--- a/fsys_test.go
+++ b/fsys_test.go
@@ -693,10 +693,18 @@ func TestFileServerAttach(t *testing.T) {
 				Type:  plan9.Tattach,
 				Uname: "glenda",
 			},
+			f: &Fid{},
 		}
-		fs.attach(x, nil)
+		fs.attach(x, x.f)
 
-		want := errorFcall(ErrPermission)
+		want := &plan9.Fcall{
+			Type: plan9.Rattach,
+			Qid: plan9.Qid{
+				Path: Qdir,
+				Vers: 0,
+				Type: plan9.QTDIR,
+			},
+		}
 		if got := mc.ReadFcall(t); !cmp.Equal(got, want) {
 			t.Fatalf("got response %v; want %v", got, want)
 		}

--- a/fsys_windows.go
+++ b/fsys_windows.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"net"
 
@@ -8,7 +9,10 @@ import (
 	"github.com/fhs/mux9p"
 )
 
-var fsysAddr net.Addr
+var (
+	fsysAddrFlag = flag.String("fsys.addr", "localhost:0", "9P file system listen address")
+	fsysAddr     net.Addr
+)
 
 func newPipe() (net.Conn, net.Conn, error) {
 	c1, c2 := net.Pipe()
@@ -16,7 +20,7 @@ func newPipe() (net.Conn, net.Conn, error) {
 }
 
 func post9pservice(conn net.Conn, name string, mtpt string) error {
-	l, err := net.Listen("tcp", "localhost:0")
+	l, err := net.Listen("tcp", *fsysAddrFlag)
 	if err != nil {
 		return fmt.Errorf("listen failed: %v", err)
 	}


### PR DESCRIPTION
* Allow `Uname` mismatch in `Tattach`, since we don't have any authentication and some libraries (e.g. `9fans.net/go/plan9/client`) gets `Uname` wrong anyway.
* Add `-fsys.addr` flag for Windows. This allows user to listen to a specified port instead of a random one.
* Replace `$HOME` with `os.UserHomeDir()`, which was introduced in Go 1.12. Update #222

Helps https://github.com/fhs/acme-lsp/issues/14