### PR TITLE
Fix incorrect window owner on writes to event file

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -21,7 +21,7 @@ import (
 
 type Exectab struct {
 	name  string
-	fn    func(t0, t1, t2 *Text, b0, b1 bool, arg string)
+	fn    func(t, seltext, argt *Text, flag1, flag2 bool, arg string)
 	mark  bool
 	flag1 bool
 	flag2 bool
@@ -120,14 +120,10 @@ func getarg(argt *Text, doaddr bool, dofile bool) (string, string) {
 
 // execute must run with an existing lock on t's Window
 func execute(t *Text, aq0 int, aq1 int, external bool, argt *Text) {
-	var (
-		q0, q1 int
-		r      []rune
-		n, f   int
-	)
+	var n, f int
 
-	q0 = aq0
-	q1 = aq1
+	q0 := aq0
+	q1 := aq1
 	if q1 == q0 { // expand to find word (actually file name)
 		// if in selection, choose selection
 		if t.inSelection(q0) {
@@ -155,7 +151,7 @@ func execute(t *Text, aq0 int, aq1 int, external bool, argt *Text) {
 			}
 		}
 	}
-	r = make([]rune, q1-q0)
+	r := make([]rune, q1-q0)
 	t.file.b.Read(q0, r)
 	e := lookup(string(r))
 	if !external && t.w != nil && t.w.nopen[QWevent] > 0 {
@@ -653,7 +649,8 @@ func run(win *Window, s string, rdir string, newns bool, argaddr string, xarg st
 	go runwaittask(c, cpid)
 }
 
-func sendx(et *Text, _ *Text, _ *Text, _, _ bool, _ string) {
+// sendx appends selected text or snarf buffer to end of body.
+func sendx(et, _, _ *Text, _, _ bool, _ string) {
 	if et.w == nil {
 		return
 	}

--- a/internal/edwoodtest/draw.go
+++ b/internal/edwoodtest/draw.go
@@ -2,7 +2,9 @@
 package edwoodtest
 
 import (
+	"errors"
 	"image"
+	"sync"
 	"unicode/utf8"
 
 	"github.com/rjkroege/edwood/internal/draw"
@@ -11,7 +13,10 @@ import (
 var _ = draw.Display((*mockDisplay)(nil))
 
 // mockDisplay implements draw.Display.
-type mockDisplay struct{}
+type mockDisplay struct {
+	snarfbuf []byte
+	mu       sync.Mutex
+}
 
 // NewDisplay returns a mock draw.Display.
 func NewDisplay() draw.Display {
@@ -31,13 +36,37 @@ func (d *mockDisplay) AllocImage(r image.Rectangle, pix draw.Pix, repl bool, val
 func (d *mockDisplay) AllocImageMix(color1, color3 draw.Color) draw.Image {
 	return NewImage(image.Rectangle{})
 }
-func (d *mockDisplay) Attach(ref int) error                   { return nil }
-func (d *mockDisplay) Flush() error                           { return nil }
-func (d *mockDisplay) ScaleSize(n int) int                    { return 0 }
-func (d *mockDisplay) ReadSnarf(buf []byte) (int, int, error) { return 0, 0, nil }
-func (d *mockDisplay) WriteSnarf(data []byte) error           { return nil }
-func (d *mockDisplay) MoveTo(pt image.Point) error            { return nil }
-func (d *mockDisplay) SetCursor(c *draw.Cursor) error         { return nil }
+func (d *mockDisplay) Attach(ref int) error { return nil }
+func (d *mockDisplay) Flush() error         { return nil }
+func (d *mockDisplay) ScaleSize(n int) int  { return 0 }
+
+// ReadSnarf reads the snarf buffer into buf, returning the number of bytes read,
+// the total size of the snarf buffer (useful if buf is too short), and any
+// error. No error is returned if there is no problem except for buf being too
+// short.
+func (d *mockDisplay) ReadSnarf(buf []byte) (int, int, error) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	n := copy(buf, d.snarfbuf)
+	if n < len(d.snarfbuf) {
+		return n, len(d.snarfbuf), errors.New("short read")
+	}
+	return n, n, nil
+}
+
+// WriteSnarf writes the data to the snarf buffer.
+func (d *mockDisplay) WriteSnarf(data []byte) error {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	d.snarfbuf = make([]byte, len(data))
+	copy(d.snarfbuf, data)
+	return nil
+}
+
+func (d *mockDisplay) MoveTo(pt image.Point) error    { return nil }
+func (d *mockDisplay) SetCursor(c *draw.Cursor) error { return nil }
 
 var _ = draw.Image((*mockImage)(nil))
 

--- a/xfid.go
+++ b/xfid.go
@@ -706,14 +706,14 @@ func xfideventwrite(x *Xfid, w *Window) {
 	// We can't lock row while we have a window locked
 	// because that can create deadlock with mousethread.
 	rowLock := func() {
-		w.Unlock()
+		defer w.Lock(w.owner)
+		w.Unlock() // sets w.owner to 0
 		row.lk.Lock()
-		w.Lock(w.owner)
 	}
 	rowUnlock := func() {
-		w.Unlock()
+		defer w.Lock(w.owner)
+		w.Unlock() // sets w.owner to 0
 		row.lk.Unlock()
-		w.Lock(w.owner)
 	}
 
 	// The messages have a fixed format: a character indicating the


### PR DESCRIPTION
This fixes Send command crashing Edwood, Edit command generating wrong
event, and possibly other issues caused by having window owner set to 0
while having a lock on it.

Window owner was being set to 0 following Unlock, Lock sequence.
Since Unlock sets owner to 0, we need to avoid using w.owner after
calling Unlock.

Fixes #284
Fixes #285