### PR TITLE
Fix crash in 'Edit X |cat' with multiple windows

### DIFF
--- a/acme.go
+++ b/acme.go
@@ -362,7 +362,7 @@ func MovedMouse(m draw.Mouse) {
 		return
 	}
 	w := t.w
-	if t == nil || m.Buttons == 0 {
+	if m.Buttons == 0 {
 		return
 	}
 	but := 0

--- a/ecmd_test.go
+++ b/ecmd_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"testing"
+)
+
+// Test for https://github.com/rjkroege/edwood/issues/291
+func TestXCmdPipeMultipleWindows(t *testing.T) {
+	cedit = make(chan int)
+	editoutlk = make(chan bool)
+	ccommand = make(chan *Command)
+	cwait = make(chan ProcessState)
+
+	newWindow := func(name string) *Window {
+		w := NewWindow()
+		w.body.file = NewFile(name)
+		w.body.w = w
+		w.body.fr = &MockFrame{}
+		w.body.file.text = []*Text{&w.body}
+		w.body.file.curtext = &w.body
+		w.tag.file = NewFile("")
+		w.tag.w = w
+		w.tag.fr = &MockFrame{}
+		w.tag.file.text = []*Text{&w.tag}
+		w.tag.file.curtext = &w.tag
+		w.editoutlk = make(chan bool)
+		return w
+	}
+	row.col = []*Column{
+		{
+			w: []*Window{
+				newWindow("one.txt"),
+				newWindow("two.txt"),
+			},
+		},
+	}
+
+	go func() {
+		row.AllWindows(func(w *Window) {
+			cedit <- 0
+			<-w.editoutlk
+			w.editoutlk <- true
+		})
+	}()
+
+	// All middle button commands including Edit run inside a lock discipline
+	// set up by MovedMouse.
+	row.lk.Lock()
+	defer row.lk.Unlock()
+
+	cp := &cmdParser{
+		buf: []rune("X |cat\n"),
+		pos: 0,
+	}
+	cmd, err := cp.parse(0)
+	if err != nil {
+		t.Fatalf("failed to parse command: %v", err)
+	}
+	X_cmd(nil, cmd)
+}

--- a/ecmd_test.go
+++ b/ecmd_test.go
@@ -40,14 +40,11 @@ func TestXCmdPipeMultipleWindows(t *testing.T) {
 		ccommand = nil
 		cwait = nil
 		row = Row{}
-	}()
 
-	done := make(chan struct{})
-	go func() { // waitthread
-		<-ccommand
-		<-cwait
-		cedit <- 0
-		close(done)
+		warningsMu.Lock()
+		defer warningsMu.Unlock()
+		// remove fsysmount failure warning
+		warnings = []*Warning{}
 	}()
 
 	// All middle button commands including Edit run inside a lock discipline
@@ -64,5 +61,4 @@ func TestXCmdPipeMultipleWindows(t *testing.T) {
 		t.Fatalf("failed to parse command: %v", err)
 	}
 	X_cmd(nil, cmd)
-	<-done
 }

--- a/edit_test.go
+++ b/edit_test.go
@@ -374,7 +374,9 @@ func TestEditMultipleWindows(t *testing.T) {
 		}
 
 		w := row.col[0].w[0]
+		w.Lock('M')
 		editcmd(&w.body, []rune(test.expr))
+		w.Unlock()
 
 		if got, want := len(row.col[0].w), len(test.expected); got != want {
 			t.Errorf("test %d: expected %d windows but got %d windows", i, want, got)

--- a/edit_test.go
+++ b/edit_test.go
@@ -103,7 +103,10 @@ func TestEdit(t *testing.T) {
 	buf := make([]rune, 8192)
 
 	for i, test := range testtab {
+		warningsMu.Lock()
 		warnings = []*Warning{}
+		warningsMu.Unlock()
+
 		w := makeSkeletonWindowModel(test.dot, test.filename)
 
 		// All middle button commands including Edit run inside a lock discipline

--- a/exec.go
+++ b/exec.go
@@ -931,6 +931,7 @@ func runproc(win *Window, s string, dir string, newns bool, argaddr string, arg 
 		var err error
 		c.md, fs, err = fsysmount(dir, incl)
 		if err != nil {
+			Fail()
 			return fmt.Errorf("fsysmount: %v", err)
 		}
 		if winid > 0 && (pipechar == '|' || pipechar == '>') {

--- a/exec.go
+++ b/exec.go
@@ -943,7 +943,7 @@ func runproc(win *Window, s string, dir string, newns bool, argaddr string, arg 
 				if winid > 0 {
 					buf = fmt.Sprintf("%d/editout", winid)
 				} else {
-					buf = fmt.Sprintf("editout")
+					buf = "editout"
 				}
 			} else {
 				buf = fmt.Sprintf("%d/wrsel", winid)

--- a/fsys_test.go
+++ b/fsys_test.go
@@ -51,6 +51,10 @@ func TestMain(m *testing.M) {
 				os.Setenv("DISPLAY", dp)
 			}
 		}
+
+		// Prevent mounting any acme file server being run by the user running tests.
+		os.Unsetenv("NAMESPACE")
+
 		e := m.Run()
 
 		if x != nil {

--- a/fsys_windows.go
+++ b/fsys_windows.go
@@ -45,6 +45,9 @@ func fsysmount(dir string, incl []string) (*MntDir, *client.Fsys, error) {
 	if md == nil {
 		return nil, nil, fmt.Errorf("child: can't allocate mntdir")
 	}
+	if fsysAddr == nil {
+		return nil, nil, fmt.Errorf("child: unknown address")
+	}
 	conn, err := client.Dial(fsysAddr.Network(), fsysAddr.String())
 	if err != nil {
 		mnt.DecRef(md)

--- a/internal/frame/util.go
+++ b/internal/frame/util.go
@@ -173,7 +173,7 @@ func (f *frameimpl) Logboxes(message string, args ...interface{}) {
 
 func (b *frbox) String() string {
 	if b.Nrune == -1 && b.Bc == '\n' {
-		return fmt.Sprintf("newline")
+		return "newline"
 	} else if b.Nrune == -1 && b.Bc == '\t' {
 		return fmt.Sprintf("tab width=%d,%d", b.Wid, b.Minwid)
 	}

--- a/internal/regexp/onepass.go
+++ b/internal/regexp/onepass.go
@@ -2,6 +2,10 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+// Ignore some staticcheck errors because this file is a copy of
+// $GOROOT/src/regexp/onepass.go.
+//lint:file-ignore SA4006 Ignore unused value error
+
 package regexp
 
 import (

--- a/util.go
+++ b/util.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"path/filepath"
 	"strings"
+	"sync"
 	"unicode/utf8"
 
 	"github.com/rjkroege/edwood/internal/runes"
@@ -251,6 +252,7 @@ type Warning struct {
 }
 
 var warnings = []*Warning{}
+var warningsMu sync.Mutex
 
 func flushwarnings() {
 	var (
@@ -310,6 +312,9 @@ func warnError(md *MntDir, s string, args ...interface{}) error {
 }
 
 func addwarningtext(md *MntDir, r []rune) {
+	warningsMu.Lock()
+	defer warningsMu.Unlock()
+
 	for _, warn := range warnings {
 		if warn.md == md {
 			warn.buf.Insert(warn.buf.nc(), r)


### PR DESCRIPTION
This is just a copy of the fix applied to p9p acme:
https://github.com/9fans/plan9port/commit/d2df5d6cbd345e101732fe7d22bb5b3baa5fb61a

Fixes #291