### PR TITLE
Add support for filenames with spaces

### DIFF
--- a/edit_test.go
+++ b/edit_test.go
@@ -123,6 +123,7 @@ func TestEdit(t *testing.T) {
 			t.Errorf("test %d: File.b contents expected \n%#v\nbut got \n%#v\n", i, test.expected, string(buf[:n]))
 		}
 
+		warningsMu.Lock()
 		if got, want := len(warnings), len(test.expectedwarns); got != want {
 			t.Errorf("text %d: expected %d warnings but got %d warnings", i, want, got)
 			break
@@ -135,7 +136,7 @@ func TestEdit(t *testing.T) {
 			}
 
 		}
-
+		warningsMu.Unlock()
 	}
 }
 

--- a/look.go
+++ b/look.go
@@ -456,7 +456,7 @@ func expandfile(t *Text, q0 int, q1 int, e *Expand) (success bool) {
 		nname = n
 	}
 	for i := 0; i < nname; i++ {
-		if !isfilec(rb[i]) {
+		if !isfilec(rb[i]) && rb[i] != ' ' {
 			return false
 		}
 	}

--- a/text.go
+++ b/text.go
@@ -1604,9 +1604,7 @@ func (t *Text) dirName(name string) string {
 	if nt == 0 {
 		return name
 	}
-	b := make([]rune, nt)
-	t.w.tag.file.b.Read(0, b)
-	spl := strings.SplitN(string(b), " ", 2)[0]
+	spl := t.w.ParseTag()
 	if !strings.HasSuffix(spl, string(filepath.Separator)) {
 		spl = filepath.Dir(spl)
 	}

--- a/text_test.go
+++ b/text_test.go
@@ -291,6 +291,8 @@ func TestTextDirName(t *testing.T) {
 		{"RelativeFile,file=''", windowWithTag("a/b/c/d.go Del Snarf | Look "), "", "a/b/c"},
 		{"RelativeFile", windowWithTag("a/b/c/d.go Del Snarf | Look "), "e.go", "a/b/c/e.go"},
 		{"IgnoreTag", windowWithTag("/a/b/c/d.go Del Snarf | Look "), "/x/e.go", "/x/e.go"},
+		{"FileWithSpace", windowWithTag("/a/b c/d.go Del Snarf | Look "), "/a/b c/d.go", "/a/b c/d.go"},
+		{"DirWithSpace", windowWithTag("/a/b c/ Del Snarf | Look "), "", "/a/b c"},
 	}
 
 	for _, tc := range tt {

--- a/wind_test.go
+++ b/wind_test.go
@@ -119,3 +119,44 @@ func TestWindowClampAddr(t *testing.T) {
 		}
 	}
 }
+
+func TestWindowParseTag(t *testing.T) {
+	for _, tc := range []struct {
+		tag      string
+		filename string
+	}{
+		{"/foo/bar.txt Del Snarf | Look", "/foo/bar.txt"},
+		{"/foo/bar quux.txt Del Snarf | Look", "/foo/bar quux.txt"},
+		{"/foo/bar.txt", "/foo/bar.txt"},
+		{"/foo/bar.txt | Look", "/foo/bar.txt"},
+		{"/foo/bar.txt Del Snarf\t| Look", "/foo/bar.txt"},
+	} {
+		w := &Window{
+			tag: Text{
+				file: &File{
+					b: Buffer(tc.tag),
+				},
+			},
+		}
+		if got, want := w.ParseTag(), tc.filename; got != want {
+			t.Errorf("tag %q has filename %q; want %q", tc.tag, got, want)
+		}
+	}
+}
+
+func TestWindowClearTag(t *testing.T) {
+	tag := "/foo bar/test.txt Del Snarf Undo Put | Look |fmt mk"
+	want := "/foo bar/test.txt Del Snarf Undo Put |"
+	w := &Window{
+		tag: Text{
+			file: &File{
+				b: Buffer(tag),
+			},
+		},
+	}
+	w.ClearTag()
+	got := w.tag.file.b.String()
+	if got != want {
+		t.Errorf("got %q; want %q", got, want)
+	}
+}


### PR DESCRIPTION
This is based on the following p9p acme change:

    $ git log --oneline d2df5d..573169d src/cmd/acme
    573169dd acme: fix buffer overflow introduced in parsetag refactor
    86bfd607 acme: fix movetodel for spaces in file names
    7b1c85f6 acme: allow spaces in window names
    6bddb06b acme: one more place to use parsetag
    81d992e3 acme: factor out tag parsing code

Notably https://github.com/9fans/plan9port/commit/7b1c85f6e8031a50e8e6f5977d12bea820e921ca

Fixes #292