### PR TITLE
edwood: implement "font" ctl message to change font

### DIFF
--- a/xfid.go
+++ b/xfid.go
@@ -672,7 +672,17 @@ forloop:
 		case "cleartag": // wipe tag right of bar
 			w.ClearTag()
 			settag = true
-
+		case "font":
+			if len(words) < 2 {
+				err = ErrBadCtl
+				break forloop
+			}
+			r, _, nulls := cvttorunes([]byte(words[1]), len(words[1]))
+			if nulls {
+				err = fmt.Errorf("nulls in font name")
+				break forloop
+			}
+			fontx(&w.body, nil, nil, XXX, XXX, string(r))
 		default:
 			err = ErrBadCtl
 			break forloop

--- a/xfid_test.go
+++ b/xfid_test.go
@@ -886,6 +886,9 @@ func TestXfidwriteQWctl(t *testing.T) {
 		{fmt.Errorf("file dirty"), "del\ndel\nclean"},
 		{nil, "clean\ndel"},
 		{nil, "clean\ndelete"},
+		{ErrBadCtl, "font"},
+		{fmt.Errorf("nulls in font name"), "font /path/with/\x00nulls"},
+		{nil, "font /path/to/font"},
 	} {
 		t.Run(fmt.Sprintf("Data=%q", tc.data), func(t *testing.T) {
 			mr := new(mockResponder)
@@ -900,6 +903,7 @@ func TestXfidwriteQWctl(t *testing.T) {
 			w.body.fr = &MockFrame{}
 			w.tag.display = display
 			w.tag.fr = &MockFrame{}
+			row.display = display
 
 			// mark window dirty
 			f := w.body.file


### PR DESCRIPTION
The "font" ctl message accepts an absolute path to a font. If the font
exists, the window will use the given font.

This control message exists in acme:
https://github.com/9fans/plan9port/blob/master/src/cmd/acme/xfid.c#L704-L721