### PR TITLE
Refactored for changing File to oldeditablebuffer.go

### DIFF
--- a/addr_test.go
+++ b/addr_test.go
@@ -92,7 +92,7 @@ func TestAcmeregexp(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			warnings = nil
 			text := &Text{
-				file: &File{
+				file: &OldEditableBuffer{
 					b: RuneArray([]rune("abcd αβξδ\n")),
 				},
 			}

--- a/ecmd.go
+++ b/ecmd.go
@@ -33,7 +33,7 @@ func resetxec() {
 	clearcollection()
 }
 
-func mkaddr(f *File) (a Address) {
+func mkaddr(f *OldEditableBuffer) (a Address) {
 	a.r.q0 = f.curtext.q0
 	a.r.q1 = f.curtext.q1
 	a.f = f
@@ -54,7 +54,7 @@ func cmdexec(t *Text, cp *Cmd) bool {
 		editerror("no current window")
 	}
 	i := cmdlookup(cp.cmdc) // will be -1 for '{'
-	f := (*File)(nil)
+	f := (*OldEditableBuffer)(nil)
 	if t != nil && t.w != nil {
 		t = &t.w.body
 		f = t.file
@@ -297,7 +297,7 @@ func i_cmd(t *Text, cp *Cmd) bool {
 	return appendx(t.file, cp, addr.r.q0)
 }
 
-func copyx(f *File, addr2 Address) {
+func copyx(f *OldEditableBuffer, addr2 Address) {
 	ni := 0
 	buf := make([]rune, RBUFSIZE)
 	for p := addr.r.q0; p < addr.r.q1; p += ni {
@@ -310,7 +310,7 @@ func copyx(f *File, addr2 Address) {
 	}
 }
 
-func move(f *File, addr2 Address) {
+func move(f *OldEditableBuffer, addr2 Address) {
 	if addr.f != addr2.f || addr.r.q1 <= addr2.r.q0 {
 		f.elog.Delete(addr.r.q0, addr.r.q1)
 		copyx(f, addr2)
@@ -643,7 +643,7 @@ func nl_cmd(t *Text, cp *Cmd) bool {
 	return true
 }
 
-func appendx(f *File, cp *Cmd, p int) bool {
+func appendx(f *OldEditableBuffer, cp *Cmd, p int) bool {
 	if len(cp.text) > 0 {
 		f.elog.Insert(p, []rune(cp.text))
 	}
@@ -652,7 +652,7 @@ func appendx(f *File, cp *Cmd, p int) bool {
 	return true
 }
 
-func pdisplay(f *File) bool {
+func pdisplay(f *OldEditableBuffer) bool {
 	p1 := addr.r.q0
 	p2 := addr.r.q1
 	if p2 > f.Nr() {
@@ -673,7 +673,7 @@ func pdisplay(f *File) bool {
 	return true
 }
 
-func pfilename(f *File) {
+func pfilename(f *OldEditableBuffer) {
 	dirtychar := ' '
 	if f.SaveableAndDirty() {
 		dirtychar = '\''
@@ -686,7 +686,7 @@ func pfilename(f *File) {
 		'+', fc, f.name)
 }
 
-func loopcmd(f *File, cp *Cmd, rp []Range) {
+func loopcmd(f *OldEditableBuffer, cp *Cmd, rp []Range) {
 	for _, r := range rp {
 		f.curtext.q0 = r.q0
 		f.curtext.q1 = r.q1
@@ -694,7 +694,7 @@ func loopcmd(f *File, cp *Cmd, rp []Range) {
 	}
 }
 
-func looper(f *File, cp *Cmd, isX bool) {
+func looper(f *OldEditableBuffer, cp *Cmd, isX bool) {
 	rp := []Range{}
 	tr := Range{}
 	r := addr.r
@@ -735,7 +735,7 @@ func looper(f *File, cp *Cmd, isX bool) {
 	nest--
 }
 
-func linelooper(f *File, cp *Cmd) {
+func linelooper(f *OldEditableBuffer, cp *Cmd) {
 	//	long nrp, p;
 	//	Range r, linesel;
 	//	Address a, a3;
@@ -860,7 +860,7 @@ func filelooper(t *Text, cp *Cmd, XY bool) {
 
 // TODO(flux) This actually looks like "find one match after p"
 // This is almost certainly broken for ^
-func nextmatch(f *File, r string, p int, sign int) {
+func nextmatch(f *OldEditableBuffer, r string, p int, sign int) {
 	are, err := rxcompile(r)
 	if err != nil {
 		editerror("bad regexp in command address")
@@ -1009,7 +1009,7 @@ func cmdaddress(ap *Addr, a Address, sign int) Address {
 }
 
 type Tofile struct {
-	f *File
+	f *OldEditableBuffer
 	r string
 }
 
@@ -1032,7 +1032,7 @@ func alltofile(w *Window, tp *Tofile) {
 	}
 }
 
-func tofile(r string) *File {
+func tofile(r string) *OldEditableBuffer {
 	var t Tofile
 
 	t.r = strings.TrimLeft(r, " \t\n")
@@ -1063,7 +1063,7 @@ func allmatchfile(w *Window, tp *Tofile) {
 	}
 }
 
-func matchfile(r string) *File {
+func matchfile(r string) *OldEditableBuffer {
 	var tf Tofile
 
 	tf.f = nil
@@ -1076,7 +1076,7 @@ func matchfile(r string) *File {
 	return tf.f
 }
 
-func filematch(f *File, r string) bool {
+func filematch(f *OldEditableBuffer, r string) bool {
 	// compile expr first so if we get an error, we haven't allocated anything  {
 	are, err := rxcompile(r)
 	if err != nil {
@@ -1188,7 +1188,7 @@ func lineaddr(l int, addr Address, sign int) Address {
 }
 
 type Filecheck struct {
-	f *File
+	f *OldEditableBuffer
 	r string
 }
 
@@ -1202,7 +1202,7 @@ func allfilecheck(w *Window, fp *Filecheck) {
 	}
 }
 
-func cmdname(f *File, str string, set bool) string {
+func cmdname(f *OldEditableBuffer, str string, set bool) string {
 	var fc Filecheck
 	r := ""
 	s := ""

--- a/edit.go
+++ b/edit.go
@@ -39,7 +39,7 @@ type Addr struct {
 
 type Address struct {
 	r Range
-	f *File
+	f *OldEditableBuffer
 }
 
 type Cmd struct {

--- a/edit_test.go
+++ b/edit_test.go
@@ -120,7 +120,7 @@ func TestEdit(t *testing.T) {
 
 		n, _ := w.body.ReadB(0, buf[:])
 		if string(buf[:n]) != test.expected {
-			t.Errorf("test %d: File.b contents expected \n%#v\nbut got \n%#v\n", i, test.expected, string(buf[:n]))
+			t.Errorf("test %d: OldEditableBuffer.b contents expected \n%#v\nbut got \n%#v\n", i, test.expected, string(buf[:n]))
 		}
 
 		warningsMu.Lock()
@@ -235,10 +235,10 @@ func TestEditCmdWithFile(t *testing.T) {
 
 		// For e identical.
 		if got, want := w.body.file.Dirty(), filedirtystates[i].Dirty; got != want {
-			t.Errorf("test %d: File bad Dirty state. Got %v, want %v: dump %s", i, got, want /* litter.Sdump(w.body.file) */, "")
+			t.Errorf("test %d: OldEditableBuffer bad Dirty state. Got %v, want %v: dump %s", i, got, want /* litter.Sdump(w.body.file) */, "")
 		}
 		if got, want := w.body.file.SaveableAndDirty(), filedirtystates[i].SaveableAndDirty; got != want {
-			t.Errorf("test %d: File bad SaveableAndDirty state. Got %v, want %v: dump %s", i, got, want /* litter.Sdump(w.body.file) */, "")
+			t.Errorf("test %d: OldEditableBuffer bad SaveableAndDirty state. Got %v, want %v: dump %s", i, got, want /* litter.Sdump(w.body.file) */, "")
 		}
 
 		if got, want := len(warnings), len(test.expectedwarns); got != want {
@@ -391,7 +391,7 @@ func TestEditMultipleWindows(t *testing.T) {
 			w := row.col[0].w[j]
 			n, _ := w.body.ReadB(0, buf[:])
 			if string(buf[:n]) != exp {
-				t.Errorf("test %d: Window %d File.b contents expected %#v\nbut got \n%#v\n", i, j, exp, string(buf[:n]))
+				t.Errorf("test %d: Window %d OldEditableBuffer.b contents expected %#v\nbut got \n%#v\n", i, j, exp, string(buf[:n]))
 			}
 
 		}

--- a/exec.go
+++ b/exec.go
@@ -458,9 +458,9 @@ func get(et *Text, _ *Text, argt *Text, flag1 bool, _ bool, arg string) {
 	samename := name == t.file.name
 	t.Load(0, name, samename)
 
-	// Text.Delete followed by Text.Load will always mark the File as
+	// Text.Delete followed by Text.Load will always mark the OldEditableBuffer as
 	// modified unless loading a 0-length file over a 0-length file. But if
-	// samename is true here, we know that the Text.body.File is now the same
+	// samename is true here, we know that the Text.body.OldEditableBuffer is now the same
 	// as it is on disk. So indicate this with file.Clean().
 	if samename {
 		t.file.Clean()
@@ -490,10 +490,10 @@ func local(et, _, argt *Text, _, _ bool, arg string) {
 	run(nil, arg, dir, false, aa, a, false)
 }
 
-// putfile writes File to disk, if it's safe to do so.
+// putfile writes OldEditableBuffer to disk, if it's safe to do so.
 //
 // TODO(flux): Write this in terms of the various cases.
-func putfile(f *File, q0 int, q1 int, name string) error {
+func putfile(f *OldEditableBuffer, q0 int, q1 int, name string) error {
 	w := f.curtext.w
 	d, err := os.Stat(name)
 
@@ -503,16 +503,16 @@ func putfile(f *File, q0 int, q1 int, name string) error {
 			f.UpdateInfo(name, d)
 		}
 		if !os.SameFile(f.info, d) || d.ModTime().Sub(f.info.ModTime()) > time.Millisecond {
-			// By setting File.info here, a subsequent Put will ignore that
-			// the disk file was mutated and will write File to the disk file.
+			// By setting OldEditableBuffer.info here, a subsequent Put will ignore that
+			// the disk file was mutated and will write OldEditableBuffer to the disk file.
 			f.info = d
 
 			if f.hash == file.EmptyHash {
-				// Edwood created the File but a disk file with the same name exists.
+				// Edwood created the OldEditableBuffer but a disk file with the same name exists.
 				return warnError(nil, "%s not written; file already exists", name)
 			}
 
-			// Edwood loaded the disk file to File but the disk file has been modified since.
+			// Edwood loaded the disk file to OldEditableBuffer but the disk file has been modified since.
 			return warnError(nil, "%s modified since last read\n\twas %v; now %v", name, f.info.ModTime(), d.ModTime())
 		}
 	}
@@ -539,8 +539,8 @@ func putfile(f *File, q0 int, q1 int, name string) error {
 	// Putting to the same file as the one that we originally read from.
 	if name == f.name {
 		if q0 != 0 || q1 != f.Size() {
-			// The backing disk file contents now differ from File because
-			// we've over-written the disk file with part of File.
+			// The backing disk file contents now differ from OldEditableBuffer because
+			// we've over-written the disk file with part of OldEditableBuffer.
 			f.Modded()
 		} else {
 			// A normal put operation of a file modified in Edwood but not
@@ -753,7 +753,7 @@ func fontx(et *Text, _ *Text, argt *Text, _, _ bool, arg string) {
 			file = *fixedfontflag
 		case "var":
 			file = *varfontflag
-		default: // File/fontname
+		default: // OldEditableBuffer/fontname
 			file = wrd
 		}
 	}

--- a/exec_test.go
+++ b/exec_test.go
@@ -118,7 +118,7 @@ func TestPutfile(t *testing.T) {
 	want := "Hello, 世界\n"
 	w := &Window{
 		body: Text{
-			file: &File{
+			file: &OldEditableBuffer{
 				b:    RuneArray(want),
 				name: filename,
 			},
@@ -169,7 +169,7 @@ func TestExpandtabToggle(t *testing.T) {
 	want := true
 	w := &Window{
 		body: Text{
-			file:      &File{},
+			file:      &OldEditableBuffer{},
 			tabexpand: false,
 			tabstop:   4,
 		},

--- a/look_test.go
+++ b/look_test.go
@@ -59,7 +59,7 @@ func TestExpand(t *testing.T) {
 		t.Run(fmt.Sprintf("test-%02d", i), func(t *testing.T) {
 			r := []rune(tc.s)
 			text := &Text{
-				file: &File{
+				file: &OldEditableBuffer{
 					b: r,
 				},
 				q0: 0,
@@ -99,7 +99,7 @@ func TestExpandJump(t *testing.T) {
 
 	for _, tc := range tt {
 		text := &Text{
-			file: &File{
+			file: &OldEditableBuffer{
 				b: []rune("chicken"),
 			},
 			q0:   0,
@@ -186,5 +186,5 @@ func textSetSelection(t *Text, buf string) {
 
 	t.q0 = popRune('«')
 	t.q1 = popRune('»')
-	t.file = &File{b: RuneArray(b)}
+	t.file = &OldEditableBuffer{b: RuneArray(b)}
 }

--- a/oldeditablebuffer_test.go
+++ b/oldeditablebuffer_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestDelText(t *testing.T) {
-	f := &File{
+	f := &OldEditableBuffer{
 		text: []*Text{{}, {}, {}, {}, {}},
 	}
 	t.Run("Nonexistent", func(t *testing.T) {
@@ -86,7 +86,7 @@ func TestFileInsertAt(t *testing.T) {
 		&fileStateSummary{false, true, false, true, s1 + s2})
 }
 
-func readwholefile(t *testing.T, f *File) string {
+func readwholefile(t *testing.T, f *OldEditableBuffer) string {
 	var sb strings.Builder
 
 	// Currently ReadAtRune does not return runes in the cache.
@@ -99,7 +99,7 @@ func readwholefile(t *testing.T, f *File) string {
 
 	targetbuffer := make([]rune, f.Nr())
 	if _, err := f.ReadAtRune(targetbuffer, 0); err != nil {
-		t.Fatalf("readwhole could not read File %v", f)
+		t.Fatalf("readwhole could not read OldEditableBuffer %v", f)
 	}
 
 	for _, r := range targetbuffer {
@@ -149,7 +149,7 @@ type fileStateSummary struct {
 	filecontents         string
 }
 
-func check(t *testing.T, testname string, f *File, fss *fileStateSummary) {
+func check(t *testing.T, testname string, f *OldEditableBuffer, fss *fileStateSummary) {
 	if got, want := f.HasUncommitedChanges(), fss.HasUncommitedChanges; got != want {
 		t.Errorf("%s: HasUncommitedChanges failed. got %v want %v", testname, got, want)
 	}
@@ -163,7 +163,7 @@ func check(t *testing.T, testname string, f *File, fss *fileStateSummary) {
 		t.Errorf("%s: SaveableAndDirty failed. got %v want %v", testname, got, want)
 	}
 	if got, want := readwholefile(t, f), fss.filecontents; got != want {
-		t.Errorf("%s: File contents not expected. got «%#v» want «%#v»", testname, got, want)
+		t.Errorf("%s: OldEditableBuffer contents not expected. got «%#v» want «%#v»", testname, got, want)
 	}
 }
 
@@ -251,7 +251,7 @@ func TestFileLoadUndoHash(t *testing.T) {
 	check(t, "TestFileLoadUndoHash after Mark", f,
 		&fileStateSummary{false, false, false, true, s2 + s2})
 
-	// SaveableAndDirty should return true if the File is plausibly writable
+	// SaveableAndDirty should return true if the OldEditableBuffer is plausibly writable
 	// to f.name and has changes that might require writing it out.
 	f.SetName("plan9")
 	check(t, "TestFileLoadUndoHash after SetName", f,
@@ -274,7 +274,7 @@ func TestFileLoadUndoHash(t *testing.T) {
 func TestFileInsertDeleteUndo(t *testing.T) {
 	f := NewFile("edwood")
 
-	// Empty File is an Undo point and considered clean.
+	// Empty OldEditableBuffer is an Undo point and considered clean.
 	f.Mark(1)
 	f.Clean()
 
@@ -308,7 +308,7 @@ func TestFileInsertDeleteUndo(t *testing.T) {
 
 func TestFileRedoSeq(t *testing.T) {
 	f := NewFile("edwood")
-	// Empty File is an Undo point and considered clean
+	// Empty OldEditableBuffer is an Undo point and considered clean
 
 	f.Mark(1)
 	f.InsertAt(0, []rune(s1))
@@ -353,7 +353,7 @@ func TestFileUpdateInfo(t *testing.T) {
 	f.info = nil
 	f.UpdateInfo(filename, d)
 	if f.info != nil {
-		t.Errorf("File info is %v; want nil", f.info)
+		t.Errorf("OldEditableBuffer info is %v; want nil", f.info)
 	}
 
 	h, err := file.HashFor(filename)
@@ -364,7 +364,7 @@ func TestFileUpdateInfo(t *testing.T) {
 	f.info = nil
 	f.UpdateInfo(filename, d)
 	if f.info != d {
-		t.Errorf("File info is %v; want %v", f.info, d)
+		t.Errorf("OldEditableBuffer info is %v; want %v", f.info, d)
 	}
 }
 
@@ -374,13 +374,13 @@ func TestFileUpdateInfoError(t *testing.T) {
 	err := f.UpdateInfo(filename, nil)
 	want := "failed to compute hash for"
 	if err == nil || !strings.HasPrefix(err.Error(), want) {
-		t.Errorf("File.UpdateInfo returned error %q; want prefix %q", err, want)
+		t.Errorf("OldEditableBuffer.UpdateInfo returned error %q; want prefix %q", err, want)
 	}
 }
 
 func TestFileNameSettingWithScratch(t *testing.T) {
 	f := NewFile("edwood")
-	// Empty File is an Undo point and considered clean
+	// Empty OldEditableBuffer is an Undo point and considered clean
 
 	if got, want := f.name, "edwood"; got != want {
 		t.Errorf("TestFileNameSettingWithScratch failed to init name. got %v want %v", got, want)

--- a/row.go
+++ b/row.go
@@ -34,7 +34,7 @@ func (row *Row) Init(r image.Rectangle, dis draw.Display) *Row {
 	r1 := r
 	r1.Max.Y = r1.Min.Y + fontget(tagfont, row.display).Height()
 	t := &row.tag
-	f := new(File)
+	f := new(OldEditableBuffer)
 	t.file = f.AddText(t)
 	t.Init(r1, tagfont, tagcolors, row.display)
 	t.what = Rowtag
@@ -350,7 +350,7 @@ func (r *Row) dump() (*dumpfile.Content, error) {
 		Windows: nil,
 	}
 
-	dumpid := make(map[*File]int)
+	dumpid := make(map[*OldEditableBuffer]int)
 
 	for i, c := range r.col {
 		dump.Columns[i] = dumpfile.Column{

--- a/text.go
+++ b/text.go
@@ -56,7 +56,7 @@ const (
 // Files have possible multiple texts corresponding to clones.
 type Text struct {
 	display draw.Display
-	file    *File
+	file    *OldEditableBuffer
 	fr      frame.Frame
 	font    string
 
@@ -416,8 +416,8 @@ func (t *Text) BsInsert(q0 int, r []rune, tofile bool) (q, nr int) {
 	return q0, n
 }
 
-// inserted is a callback invoked by File on Insert* to update each Text
-// that is using a given File.
+// inserted is a callback invoked by OldEditableBuffer on Insert* to update each Text
+// that is using a given OldEditableBuffer.
 func (t *Text) inserted(q0 int, r []rune) {
 	if t.eq0 == -1 {
 		t.eq0 = q0
@@ -566,7 +566,7 @@ func (t *Text) Delete(q0, q1 int, _ bool) {
 }
 
 // deleted implements the single-text deletion observer for this Text's
-// backing File. It updates the Text (i.e. the view) for the removal of
+// backing OldEditableBuffer. It updates the Text (i.e. the view) for the removal of
 // runes [q0, q1).
 func (t *Text) deleted(q0, q1 int) {
 	n := q1 - q0

--- a/text_test.go
+++ b/text_test.go
@@ -17,7 +17,7 @@ import (
 func emptyText() *Text {
 	w := &Window{
 		body: Text{
-			file: &File{},
+			file: &OldEditableBuffer{},
 		},
 	}
 	t := &w.body
@@ -133,7 +133,7 @@ func TestClickHTMLMatch(t *testing.T) {
 		t.Run(fmt.Sprintf("test-%02d", i), func(t *testing.T) {
 			r := []rune(tc.s)
 			text := &Text{
-				file: &File{
+				file: &OldEditableBuffer{
 					b: RuneArray(r),
 				},
 			}
@@ -237,7 +237,7 @@ func TestGetDirNames(t *testing.T) {
 func TestGetDirNamesNil(t *testing.T) {
 	_, err := getDirNames(nil)
 	if err == nil {
-		t.Errorf("getDirNames was successful on nil File")
+		t.Errorf("getDirNames was successful on nil OldEditableBuffer")
 	}
 }
 
@@ -256,7 +256,7 @@ func (fr *textFillMockFrame) GetFrameFillStatus() frame.FrameFillStatus {
 
 func TestTextFill(t *testing.T) {
 	text := &Text{
-		file: &File{},
+		file: &OldEditableBuffer{},
 	}
 	err := text.fill(&textFillMockFrame{})
 	wantErr := "fill: negative slice length -100"
@@ -338,7 +338,7 @@ func TestTextAbsDirName(t *testing.T) {
 func windowWithTag(tag string) *Window {
 	return &Window{
 		tag: Text{
-			file: &File{
+			file: &OldEditableBuffer{
 				b: RuneArray([]rune(tag)),
 			},
 		},
@@ -368,7 +368,7 @@ func TestBackNL(t *testing.T) {
 
 	for _, tc := range tt {
 		text := &Text{
-			file: &File{
+			file: &OldEditableBuffer{
 				b: RuneArray(tc.buf),
 			},
 		}
@@ -401,7 +401,7 @@ func TestTextBsInsert(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			text := &Text{
 				what: tc.what,
-				file: &File{
+				file: &OldEditableBuffer{
 					b: RuneArray(tc.buf),
 				},
 			}
@@ -445,7 +445,7 @@ func TestTextTypeTabInBody(t *testing.T) {
 	checkTabexpand(t, func(tabexpand bool, tabstop int) *Text {
 		w := &Window{
 			body: Text{
-				file:      &File{},
+				file:      &OldEditableBuffer{},
 				tabexpand: tabexpand,
 				tabstop:   tabstop,
 			},
@@ -459,7 +459,7 @@ func TestTextTypeTabInBody(t *testing.T) {
 func TestTextTypeTabInTag(t *testing.T) {
 	checkTabexpand(t, func(tabexpand bool, tabstop int) *Text {
 		return &Text{
-			file:      &File{},
+			file:      &OldEditableBuffer{},
 			tabexpand: tabexpand,
 			tabstop:   tabstop,
 		}

--- a/util.go
+++ b/util.go
@@ -277,7 +277,7 @@ func flushwarnings() {
 		// place), to avoid a big memory footprint.
 		q0 = t.Nc()
 		r := make([]rune, RBUFSIZE)
-		// TODO(rjk): Figure out why Warning doesn't use a File.
+		// TODO(rjk): Figure out why Warning doesn't use a OldEditableBuffer.
 		for n = 0; n < warn.buf.nc(); n += nr {
 			nr = warn.buf.nc() - n
 			if nr > RBUFSIZE {

--- a/wind.go
+++ b/wind.go
@@ -551,7 +551,7 @@ func (w *Window) setTag1() {
 	}
 }
 
-// TODO(rjk): In the future of File's replacement with undo buffer,
+// TODO(rjk): In the future of OldEditableBuffer's replacement with undo buffer,
 // this method could be renamed to something like "UpdateTag"
 func (w *Window) Commit(t *Text) {
 	t.Commit() // will set the file.mod to true
@@ -607,7 +607,7 @@ func (w *Window) AddIncl(r string) {
 }
 
 // Clean returns true iff w can be treated as unmodified.
-// This will modify the File so that the next call to Clean will return true
+// This will modify the OldEditableBuffer so that the next call to Clean will return true
 // even if this one returned false.
 func (w *Window) Clean(conservative bool) bool {
 	if w.body.file.IsDirOrScratch() { // don't whine if it's a guide file, error window, etc.

--- a/wind_test.go
+++ b/wind_test.go
@@ -37,7 +37,7 @@ func TestWindowUndoSelection(t *testing.T) {
 			body: Text{
 				q0: tc.q0,
 				q1: tc.q1,
-				file: &File{
+				file: &OldEditableBuffer{
 					b:       RuneArray("This is an example sentence.\n"),
 					delta:   tc.delta,
 					epsilon: tc.epsilon,
@@ -71,12 +71,12 @@ func TestSetTag1(t *testing.T) {
 		w.body = Text{
 			display: display,
 			fr:      &MockFrame{},
-			file:    &File{name: name},
+			file:    &OldEditableBuffer{name: name},
 		}
 		w.tag = Text{
 			display: display,
 			fr:      &MockFrame{},
-			file:    &File{},
+			file:    &OldEditableBuffer{},
 		}
 
 		w.setTag1()
@@ -108,7 +108,7 @@ func TestWindowClampAddr(t *testing.T) {
 		w := &Window{
 			addr: tc.addr,
 			body: Text{
-				file: &File{
+				file: &OldEditableBuffer{
 					b: buf,
 				},
 			},
@@ -133,7 +133,7 @@ func TestWindowParseTag(t *testing.T) {
 	} {
 		w := &Window{
 			tag: Text{
-				file: &File{
+				file: &OldEditableBuffer{
 					b: RuneArray(tc.tag),
 				},
 			},
@@ -149,7 +149,7 @@ func TestWindowClearTag(t *testing.T) {
 	want := "/foo bar/test.txt Del Snarf Undo Put |"
 	w := &Window{
 		tag: Text{
-			file: &File{
+			file: &OldEditableBuffer{
 				b: RuneArray(tag),
 			},
 		},

--- a/xfid_test.go
+++ b/xfid_test.go
@@ -159,7 +159,7 @@ func TestXfidreadQWrdsel(t *testing.T) {
 		body: Text{fr: &MockFrame{}},
 		tag: Text{
 			fr:   &MockFrame{},
-			file: &File{},
+			file: &OldEditableBuffer{},
 		},
 		col: new(Column),
 	}
@@ -992,7 +992,7 @@ func TestXfidwriteQWeventExecuteSend(t *testing.T) {
 	defer func() { w.nopen[QWevent]-- }()
 	w.tag = Text{
 		w: w,
-		file: &File{
+		file: &OldEditableBuffer{
 			b:    RuneArray("Send"),
 			text: []*Text{&w.tag},
 		},
@@ -1001,7 +1001,7 @@ func TestXfidwriteQWeventExecuteSend(t *testing.T) {
 	}
 	w.body = Text{
 		w: w,
-		file: &File{
+		file: &OldEditableBuffer{
 			b:    RuneArray(""),
 			text: []*Text{&w.body},
 		},


### PR DESCRIPTION
Renamed File to make it easier to discuss the various parts of the new File going forward., as File is broken up, File.go no longer represents the File like it used to. #334