### PR TITLE
Handle ESC like Acme

### DIFF
--- a/text.go
+++ b/text.go
@@ -74,7 +74,7 @@ type Text struct {
 	col       *Column
 
 	iq1 int
-	eq0 int
+	eq0 int // When 0, typing has started
 
 	nofill   bool // When true, updates to the Text shouldn't update the frame.
 	needundo bool
@@ -419,6 +419,9 @@ func (t *Text) BsInsert(q0 int, r []rune, tofile bool) (q, nr int) {
 // inserted is a callback invoked by File on Insert* to update each Text
 // that is using a given File.
 func (t *Text) inserted(q0 int, r []rune) {
+	if t.eq0 == ^0 {
+		t.eq0 = q0
+	}
 	if t.what == Body {
 		t.w.utflastqid = -1
 	}

--- a/text.go
+++ b/text.go
@@ -419,7 +419,7 @@ func (t *Text) BsInsert(q0 int, r []rune, tofile bool) (q, nr int) {
 // inserted is a callback invoked by File on Insert* to update each Text
 // that is using a given File.
 func (t *Text) inserted(q0 int, r []rune) {
-	if t.eq0 == ^0 {
+	if t.eq0 == -1 {
 		t.eq0 = q0
 	}
 	if t.what == Body {


### PR DESCRIPTION
After typing text in Acme, one can press ESC to select the previously typed text and press ESC again to delete it. This is possible because `eq0` [is set when typing begins](https://github.com/9fans/plan9port/blob/70cc6e5ba7798b315c3fb3aae19620a01604a459/src/cmd/acme/text.c#L910) and is checked for [when ESC is pressed](https://github.com/9fans/plan9port/blob/70cc6e5ba7798b315c3fb3aae19620a01604a459/src/cmd/acme/text.c#L836). This PR adds support for this feature by setting `eq0` to the first address (0) when text is typed in a similar manner as is done in Acme.