### PR TITLE
Added TODO in File to fix undo for disk filenames 

### DIFF
--- a/file.go
+++ b/file.go
@@ -498,6 +498,7 @@ func (f *File) Undo(isundo bool) (q0, q1 int, ok bool) {
 			q1 = u.p0 + u.n
 			ok = true
 		case Filename:
+			// TODO(rjk): Fix Undo on Filename once the code has matured, removing broken code in the meantime.
 			// TODO(rjk): If I have a zerox, does undo a filename change update?
 			f.seq = u.seq
 			f.UnsetName(epsilon)


### PR DESCRIPTION
Currently Undo is broken for disk filenames, a temporary fix wouldn't be worth it as it would need to be fixed again following the new undo structure, added a TODO for when that is ready.  #334 