### PR TITLE
Added newline to first error when multiple are returned from elog

### DIFF
--- a/ecmd.go
+++ b/ecmd.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/rjkroege/edwood/internal/util"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/rjkroege/edwood/internal/util"
 )
 
 var (

--- a/ecmd.go
+++ b/ecmd.go
@@ -121,7 +121,7 @@ func edittext(w *Window, q int, r []rune) error {
 		f := w.body.file
 		err := f.elog.Insert(q, r)
 		if err != nil {
-			warning(nil, err.Error())
+			warning(nil, err.Error()+"\n")
 		}
 		return nil
 	case Collecting:
@@ -186,7 +186,7 @@ func B_cmd(t *Text, cp *Cmd) bool {
 func c_cmd(t *Text, cp *Cmd) bool {
 	err := t.file.elog.Replace(addr.r.q0, addr.r.q1, []rune(cp.text))
 	if err != nil {
-		warning(nil, err.Error())
+		warning(nil, err.Error()+"\n")
 	}
 	t.q0 = addr.r.q0
 	t.q1 = addr.r.q1
@@ -197,7 +197,7 @@ func d_cmd(t *Text, cp *Cmd) bool {
 	if addr.r.q1 > addr.r.q0 {
 		err := t.file.elog.Delete(addr.r.q0, addr.r.q1)
 		if err != nil {
-			warning(nil, err.Error())
+			warning(nil, err.Error()+"\n")
 		}
 	}
 	t.q0 = addr.r.q0
@@ -267,7 +267,7 @@ func e_cmd(t *Text, cp *Cmd) bool {
 	runes, _, nulls := cvttorunes(d, len(d))
 	err = file.elog.Replace(q0, q1, runes)
 	if err != nil {
-		warning(nil, err.Error())
+		warning(nil, err.Error()+"\n")
 	}
 
 	if nulls {
@@ -323,7 +323,7 @@ func copyx(f *ObservableEditableBuffer, addr2 Address) {
 		f.Read(p, buf[:ni])
 		err := addr2.file.elog.Insert(addr2.r.q1, buf[:ni])
 		if err != nil {
-			warning(nil, err.Error())
+			warning(nil, err.Error()+"\n")
 		}
 	}
 }
@@ -332,14 +332,14 @@ func move(f *ObservableEditableBuffer, addr2 Address) {
 	if addr.file != addr2.file || addr.r.q1 <= addr2.r.q0 {
 		err := f.elog.Delete(addr.r.q0, addr.r.q1)
 		if err != nil {
-			warning(nil, err.Error())
+			warning(nil, err.Error()+"\n")
 		}
 		copyx(f, addr2)
 	} else if addr.r.q0 >= addr2.r.q1 {
 		copyx(f, addr2)
 		err := f.elog.Delete(addr.r.q0, addr.r.q1)
 		if err != nil {
-			warning(nil, err.Error())
+			warning(nil, err.Error()+"\n")
 		}
 	} else if addr.r.q0 == addr2.r.q0 && addr.r.q1 == addr2.r.q1 {
 		// move to self; no-op
@@ -430,7 +430,7 @@ func s_cmd(t *Text, cp *Cmd) bool {
 		}
 		err := t.file.elog.Replace(sel[0].q0, sel[0].q1, []rune(buf))
 		if err != nil {
-			warning(nil, err.Error())
+			warning(nil, err.Error()+"\n")
 		}
 		delta -= sel[0].q1 - sel[0].q0
 		delta += len([]rune(buf))
@@ -515,7 +515,7 @@ func runpipe(t *Text, cmd rune, cr []rune, state int) {
 		if cmd == '<' || cmd == '|' {
 			err := t.file.elog.Delete(t.q0, t.q1)
 			if err != nil {
-				warning(nil, err.Error())
+				warning(nil, err.Error()+"\n")
 			}
 		}
 	}
@@ -677,7 +677,7 @@ func appendx(file *ObservableEditableBuffer, cp *Cmd, p int) bool {
 	if len(cp.text) > 0 {
 		err := file.elog.Insert(p, []rune(cp.text))
 		if err != nil {
-			warning(nil, err.Error())
+			warning(nil, err.Error()+"\n")
 		}
 	}
 	cur := file.GetCurObserver().(*Text)

--- a/edit_test.go
+++ b/edit_test.go
@@ -127,7 +127,7 @@ func TestEdit(t *testing.T) {
 		if got, want := len(warnings), len(test.expectedwarns); got != want {
 			t.Errorf("text %d: expected %d warnings but got %d warnings", i, want, got)
 			for i := range warnings {
-				t.Errorf("Warning #%d recieved: %s\n", i, warnings[i].buf.String())
+				t.Errorf("Warning #%d received: %s\n", i, warnings[i].buf.String())
 			}
 			break
 		}

--- a/edit_test.go
+++ b/edit_test.go
@@ -126,6 +126,9 @@ func TestEdit(t *testing.T) {
 		warningsMu.Lock()
 		if got, want := len(warnings), len(test.expectedwarns); got != want {
 			t.Errorf("text %d: expected %d warnings but got %d warnings", i, want, got)
+			for i := range warnings {
+				t.Errorf("Warning #%d recieved: %s\n", i, warnings[i].buf.String())
+			}
 			break
 		}
 

--- a/internal/elog/elog.go
+++ b/internal/elog/elog.go
@@ -124,7 +124,7 @@ func (e *Elog) Replace(q0, q1 int, r []rune) error {
 	if eo.q0 < e.secondlast().q0 {
 		e.warned = true
 		if err != nil {
-			err = errors.New(err.Error() + Wsequence)
+			err = errors.New(err.Error() + "\n" + Wsequence)
 		} else {
 			err = errors.New(Wsequence)
 		}
@@ -165,7 +165,7 @@ func (e *Elog) Insert(q0 int, r []rune) error {
 	if eo.q0 < e.secondlast().q0 {
 		e.warned = true
 		if err != nil {
-			err = errors.New(err.Error() + WsequenceDire)
+			err = errors.New(err.Error() + "\n" + WsequenceDire)
 		} else {
 			err = errors.New(WsequenceDire)
 		}
@@ -202,7 +202,7 @@ func (e *Elog) Delete(q0, q1 int) error {
 	if eo.q0 < e.secondlast().q0 {
 		e.warned = true
 		if err != nil {
-			err = errors.New(err.Error() + WsequenceDire)
+			err = errors.New(err.Error() + "\n" + WsequenceDire)
 		} else {
 			err = errors.New(WsequenceDire)
 		}

--- a/observable_editable_buffer.go
+++ b/observable_editable_buffer.go
@@ -25,8 +25,8 @@ type ObservableEditableBuffer struct {
 	// implementation code to let multiple Inserts be grouped together?
 	// Figure out how this inter-operates with seq.
 	Editclean bool
-	details      *file.DiskDetails
-	isscratch    bool // Used to track if this File should warn on unsaved deletion. [private]
+	details   *file.DiskDetails
+	isscratch bool // Used to track if this File should warn on unsaved deletion. [private]
 }
 
 // Set is a forwarding function for file_hash.Set


### PR DESCRIPTION
Tests expect there to be a newline between errors which wasn't present due to a fix for staticcheck. 