### PR TITLE
Moved external imports to the bottom of the imports.

### DIFF
--- a/col.go
+++ b/col.go
@@ -1,12 +1,12 @@
 package main
 
 import (
-	"github.com/rjkroege/edwood/internal/util"
 	"image"
 	"sort"
 
 	"github.com/rjkroege/edwood/internal/draw"
 	"github.com/rjkroege/edwood/internal/frame"
+	"github.com/rjkroege/edwood/internal/util"
 )
 
 var (

--- a/fsys.go
+++ b/fsys.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/rjkroege/edwood/internal/util"
 	"io"
 	"log"
 	"os"
@@ -14,6 +13,7 @@ import (
 
 	"9fans.net/go/plan9"
 	"github.com/rjkroege/edwood/internal/ninep"
+	"github.com/rjkroege/edwood/internal/util"
 )
 
 type fileServer struct {

--- a/fsys_plan9.go
+++ b/fsys_plan9.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/rjkroege/edwood/internal/util"
 	"net"
 	"os"
 	"path"
@@ -10,6 +9,7 @@ import (
 
 	"9fans.net/go/plan9"
 	"9fans.net/go/plan9/client"
+	"github.com/rjkroege/edwood/internal/util"
 )
 
 // These constants are from /sys/include/libc.h

--- a/fsys_unix.go
+++ b/fsys_unix.go
@@ -5,13 +5,13 @@ package main
 
 import (
 	"fmt"
-	"github.com/rjkroege/edwood/internal/util"
 	"net"
 	"os"
 	"path/filepath"
 
 	"9fans.net/go/plan9/client"
 	"github.com/fhs/mux9p"
+	"github.com/rjkroege/edwood/internal/util"
 )
 
 func newPipe() (net.Conn, net.Conn, error) {

--- a/fsys_windows.go
+++ b/fsys_windows.go
@@ -3,11 +3,11 @@ package main
 import (
 	"flag"
 	"fmt"
-	"github.com/rjkroege/edwood/internal/util"
 	"net"
 
 	"9fans.net/go/plan9/client"
 	"github.com/fhs/mux9p"
+	"github.com/rjkroege/edwood/internal/util"
 )
 
 var (

--- a/look.go
+++ b/look.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bufio"
 	"fmt"
-	"github.com/rjkroege/edwood/internal/util"
 	"image"
 	"os"
 	"path/filepath"
@@ -14,6 +13,7 @@ import (
 	"9fans.net/go/plan9/client"
 	"9fans.net/go/plumb"
 	"github.com/rjkroege/edwood/internal/runes"
+	"github.com/rjkroege/edwood/internal/util"
 )
 
 var (

--- a/observable_editable_buffer.go
+++ b/observable_editable_buffer.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/rjkroege/edwood/internal/file"
 	"io"
 	"io/ioutil"
 	"os"
 	"strings"
 
+	"github.com/rjkroege/edwood/internal/file"
 	"github.com/rjkroege/edwood/internal/sam"
 )
 

--- a/row.go
+++ b/row.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/rjkroege/edwood/internal/util"
 	"image"
 	"os"
 	"path/filepath"
@@ -12,6 +11,7 @@ import (
 
 	"github.com/rjkroege/edwood/internal/draw"
 	"github.com/rjkroege/edwood/internal/dumpfile"
+	"github.com/rjkroege/edwood/internal/util"
 )
 
 const RowTag = "Newcol Kill Putall Dump Exit"

--- a/text.go
+++ b/text.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"github.com/rjkroege/edwood/internal/util"
 	"image"
 	"io"
 	"log"
@@ -18,6 +17,7 @@ import (
 	"github.com/rjkroege/edwood/internal/draw/drawutil"
 	"github.com/rjkroege/edwood/internal/frame"
 	"github.com/rjkroege/edwood/internal/runes"
+	"github.com/rjkroege/edwood/internal/util"
 )
 
 const (

--- a/util.go
+++ b/util.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/rjkroege/edwood/internal/util"
 	"image"
 	"path/filepath"
 	"strings"
@@ -10,6 +9,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/rjkroege/edwood/internal/runes"
+	"github.com/rjkroege/edwood/internal/util"
 )
 
 var (

--- a/wind.go
+++ b/wind.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/rjkroege/edwood/internal/runes"
-	"github.com/rjkroege/edwood/internal/util"
 	"image"
 	"os"
 	"path/filepath"
@@ -12,6 +10,8 @@ import (
 
 	"github.com/rjkroege/edwood/internal/draw"
 	"github.com/rjkroege/edwood/internal/frame"
+	"github.com/rjkroege/edwood/internal/runes"
+	"github.com/rjkroege/edwood/internal/util"
 )
 
 type Window struct {

--- a/xfid.go
+++ b/xfid.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/rjkroege/edwood/internal/util"
 	"io"
 	"io/ioutil"
 	"log"
@@ -15,6 +14,7 @@ import (
 	"github.com/rjkroege/edwood/internal/draw"
 	"github.com/rjkroege/edwood/internal/ninep"
 	"github.com/rjkroege/edwood/internal/runes"
+	"github.com/rjkroege/edwood/internal/util"
 )
 
 const Ctlsize = 5 * 12


### PR DESCRIPTION
Fixed imports that were previously not following convention by being mixed in with go language imports.