### PR TITLE
fs_plan9.go: plan9.MREPL -> MREPL

### DIFF
--- a/acme_test.go
+++ b/acme_test.go
@@ -3,11 +3,12 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/rjkroege/edwood/file"
 	"os/exec"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/rjkroege/edwood/file"
 
 	"github.com/rjkroege/edwood/edwoodtest"
 )

--- a/dat.go
+++ b/dat.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"github.com/rjkroege/edwood/file"
 	"math"
 	"os"
 	"unicode/utf8"
+
+	"github.com/rjkroege/edwood/file"
 
 	"9fans.net/go/plan9"
 	"9fans.net/go/plumb"

--- a/ecmd_test.go
+++ b/ecmd_test.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"github.com/rjkroege/edwood/file"
 	"testing"
+
+	"github.com/rjkroege/edwood/file"
 )
 
 // Test for https://github.com/rjkroege/edwood/issues/291

--- a/exec_test.go
+++ b/exec_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	file2 "github.com/rjkroege/edwood/file"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -9,6 +8,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	file2 "github.com/rjkroege/edwood/file"
 )
 
 func acmeTestingMain() {

--- a/fsys_plan9.go
+++ b/fsys_plan9.go
@@ -7,7 +7,6 @@ import (
 	"path"
 	"syscall"
 
-	"9fans.net/go/plan9"
 	"9fans.net/go/plan9/client"
 	"github.com/rjkroege/edwood/util"
 )
@@ -49,7 +48,7 @@ func post9pservice(conn net.Conn, name string, mtpt string) error {
 	go func() {
 		// We need to do this within a new goroutine because the file server
 		// hasn't been started yet.
-		err := syscall.Mount(cfd, -1, mtpt, plan9.MREPL, "")
+		err := syscall.Mount(cfd, -1, mtpt, MREPL, "")
 		if err != nil {
 			util.AcmeError("mount failed", err)
 		}

--- a/look_test.go
+++ b/look_test.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"fmt"
-	"github.com/rjkroege/edwood/file"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"github.com/rjkroege/edwood/file"
 
 	"9fans.net/go/plumb"
 	"github.com/google/go-cmp/cmp"

--- a/rowmock_test.go
+++ b/rowmock_test.go
@@ -4,9 +4,10 @@ package main
 // row/column/window model.
 
 import (
-	"github.com/rjkroege/edwood/file"
 	"image"
 	"strings"
+
+	"github.com/rjkroege/edwood/file"
 
 	"github.com/rjkroege/edwood/draw"
 	"github.com/rjkroege/edwood/dumpfile"

--- a/util_test.go
+++ b/util_test.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"github.com/rjkroege/edwood/util"
 	"path/filepath"
 	"reflect"
 	"testing"
+
+	"github.com/rjkroege/edwood/util"
 )
 
 func TestCvttorunes(t *testing.T) {

--- a/xfid_test.go
+++ b/xfid_test.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/rjkroege/edwood/file"
 	"image"
 	"io/ioutil"
 	"os"
@@ -14,6 +13,8 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/rjkroege/edwood/file"
 
 	"9fans.net/go/plan9"
 	"github.com/google/go-cmp/cmp"


### PR DESCRIPTION
plan9.MREPL was only used once, but that usage
broke plan9 compilation.

While we're at it, run goimports.

Fixes plan9 builds.

Signed-off-by: Ronald G. Minnich <rminnich@gmail.com>