### PR TITLE
Changed all callers of file.Size() to file.Nr()

### DIFF
--- a/acme.go
+++ b/acme.go
@@ -215,7 +215,7 @@ func readfile(c *Column, filename string) {
 	w.SetTag()
 	w.Resize(w.r, false, true)
 	w.body.ScrDraw(w.body.fr.GetFrameFillStatus().Nchars)
-	w.tag.SetSelect(w.tag.file.Size(), w.tag.file.Size())
+	w.tag.SetSelect(w.tag.file.Nr(), w.tag.file.Nr())
 	xfidlog(w, "new")
 }
 

--- a/col.go
+++ b/col.go
@@ -63,7 +63,7 @@ func (c *Column) Init(r image.Rectangle, dis draw.Display) *Column {
 		c.display.ScreenImage().Draw(r1, c.display.Black(), nil, image.Point{})
 	}
 	c.tag.Insert(0, Lheader, true)
-	c.tag.SetSelect(c.tag.file.Size(), c.tag.file.Size())
+	c.tag.SetSelect(c.tag.file.Nr(), c.tag.file.Nr())
 	if c.display != nil {
 		c.display.ScreenImage().Draw(c.tag.scrollr, colbutton, nil, colbutton.R().Min)
 		// As a general practice, Edwood is very over-eager to Flush. Flushes hurt

--- a/ecmd.go
+++ b/ecmd.go
@@ -1184,7 +1184,7 @@ func lineaddr(l int, addr Address, sign int) Address {
 			}
 			for n < l {
 				// TODO(rjk) utf8 buffer issue p
-				if p >= file.Size() {
+				if p >= file.Nr() {
 					editerror("address out of range")
 				}
 				if f.ReadC(p) == '\n' {
@@ -1194,7 +1194,7 @@ func lineaddr(l int, addr Address, sign int) Address {
 			}
 			a.r.q0 = p
 		}
-		for p < f.Size() && f.ReadC(p) != '\n' {
+		for p < f.Nr() && f.ReadC(p) != '\n' {
 			p++
 		}
 		a.r.q1 = p

--- a/exec.go
+++ b/exec.go
@@ -132,7 +132,7 @@ func execute(t *Text, aq0 int, aq1 int, external bool, argt *Text) {
 			q0 = t.q0
 			q1 = t.q1
 		} else {
-			for q1 < t.file.Size() {
+			for q1 < t.file.Nr() {
 				c := t.file.ReadC(q1)
 				if isexecc(c) && c != ':' {
 					q1++
@@ -438,7 +438,7 @@ func get(et *Text, _ *Text, argt *Text, flag1 bool, _ bool, arg string) {
 	}
 
 	isclean := et.w.Clean(true)
-	if et.w.body.file.Size() > 0 && !isclean {
+	if et.w.body.file.Nr() > 0 && !isclean {
 		return
 	}
 	w := et.w
@@ -538,7 +538,7 @@ func putfile(oeb *file.ObservableEditableBuffer, q0 int, q1 int, name string) er
 
 	// Putting to the same file as the one that we originally read from.
 	if name == oeb.Name() {
-		if q0 != 0 || q1 != oeb.Size() {
+		if q0 != 0 || q1 != oeb.Nr() {
 			// The backing disk file contents now differ from File because
 			// we've over-written the disk file with part of File.
 			oeb.Modded()
@@ -568,7 +568,7 @@ func put(et *Text, _0 *Text, argt *Text, _1 bool, _2 bool, arg string) {
 		warning(nil, "no file name\n")
 		return
 	}
-	putfile(w.body.file, 0, f.Size(), name)
+	putfile(w.body.file, 0, f.Nr(), name)
 	xfidlog(w, "put")
 }
 
@@ -661,11 +661,11 @@ func sendx(et, _, _ *Text, _, _ bool, _ string) {
 	if t.q0 != t.q1 {
 		cut(t, t, nil, true, false, "")
 	}
-	t.SetSelect(t.file.Size(), t.file.Size())
+	t.SetSelect(t.file.Nr(), t.file.Nr())
 	paste(t, t, nil, true, true, "")
-	if t.ReadC(t.file.Size()-1) != '\n' {
-		t.Insert(t.file.Size(), []rune("\n"), true)
-		t.SetSelect(t.file.Size(), t.file.Size())
+	if t.ReadC(t.file.Nr()-1) != '\n' {
+		t.Insert(t.file.Nr(), []rune("\n"), true)
+		t.SetSelect(t.file.Nr(), t.file.Nr())
 	}
 	t.iq1 = t.q1
 	t.Show(t.q1, t.q1, true)

--- a/exec_test.go
+++ b/exec_test.go
@@ -134,11 +134,11 @@ func TestPutfile(t *testing.T) {
 		}
 	}
 
-	err = putfile(file, 0, f.Size(), filename)
+	err = putfile(file, 0, f.Nr(), filename)
 	if err == nil || !strings.Contains(err.Error(), "file already exists") {
 		t.Fatalf("putfile returned error %v; expected 'file already exists'", err)
 	}
-	err = putfile(file, 0, f.Size(), filename)
+	err = putfile(file, 0, f.Nr(), filename)
 	if err != nil {
 		t.Fatalf("putfile failed: %v", err)
 	}
@@ -146,7 +146,7 @@ func TestPutfile(t *testing.T) {
 
 	// mtime increased but hash is the same
 	increaseMtime(t, time.Second)
-	err = putfile(file, 0, f.Size(), filename)
+	err = putfile(file, 0, f.Nr(), filename)
 	if err != nil {
 		t.Fatalf("putfile failed: %v", err)
 	}
@@ -159,7 +159,7 @@ func TestPutfile(t *testing.T) {
 		t.Fatalf("WriteFile failed: %v", err)
 	}
 	increaseMtime(t, time.Second)
-	err = putfile(file, 0, f.Size(), filename)
+	err = putfile(file, 0, f.Nr(), filename)
 	if err == nil || !strings.Contains(err.Error(), "modified since last read") {
 		t.Fatalf("putfile returned error %v; expected 'modified since last read'", err)
 	}

--- a/file/file.go
+++ b/file/file.go
@@ -91,7 +91,6 @@ func (f *File) HasRedoableChanges() bool {
 // Size returns the complete size of the buffer including both committed
 // and uncommitted runes.
 // NB: naturally forwards to undo.RuneArray.Size()
-// bytes when backed by undo.RuneArray.
 func (f *File) Size() int {
 	return int(f.b.Nc()) + len(f.cache)
 }

--- a/file/file.go
+++ b/file/file.go
@@ -91,7 +91,6 @@ func (f *File) HasRedoableChanges() bool {
 // Size returns the complete size of the buffer including both committed
 // and uncommitted runes.
 // NB: naturally forwards to undo.RuneArray.Size()
-// TODO(rjk): Switch all callers to Nr() as would be the number of
 // bytes when backed by undo.RuneArray.
 func (f *File) Size() int {
 	return int(f.b.Nc()) + len(f.cache)

--- a/look.go
+++ b/look.go
@@ -189,7 +189,7 @@ func look3Message(t *Text, q0, q1 int) (*plumb.Message, error) {
 				}
 				q0--
 			}
-			for q1 < t.file.Size() {
+			for q1 < t.file.Nr() {
 				// TODO(rjk): utf8 conversion change point.
 				c := t.ReadC(q1)
 				if !(c != ' ' && c != '\t' && c != '\n') {
@@ -357,7 +357,7 @@ func expandfile(t *Text, q0 int, q1 int, e *Expand) (success bool) {
 	if q1 == q0 {
 		colon := int(-1)
 		// TODO(rjk): utf8 conversion work.
-		for q1 < t.file.Size() {
+		for q1 < t.file.Nr() {
 			c := t.ReadC(q1)
 			if !isfilec(c) {
 				break
@@ -382,11 +382,11 @@ func expandfile(t *Text, q0 int, q1 int, e *Expand) (success bool) {
 		// otherwise terminate expansion at :
 		if colon >= 0 {
 			q1 = colon
-			if colon < t.file.Size()-1 {
+			if colon < t.file.Nr()-1 {
 				c := t.ReadC(colon + 1)
 				if isaddrc(c) {
 					q1 = colon + 1
-					for q1 < t.file.Size() {
+					for q1 < t.file.Nr() {
 						c := t.ReadC(q1)
 						if !isaddrc(c) {
 							break
@@ -398,14 +398,14 @@ func expandfile(t *Text, q0 int, q1 int, e *Expand) (success bool) {
 		}
 		if q1 > q0 {
 			if colon >= 0 { // stop at white space
-				for amax = colon + 1; amax < t.file.Size(); amax++ {
+				for amax = colon + 1; amax < t.file.Nr(); amax++ {
 					c := t.ReadC(amax)
 					if c == ' ' || c == '\t' || c == '\n' {
 						break
 					}
 				}
 			} else {
-				amax = t.file.Size()
+				amax = t.file.Nr()
 			}
 		}
 	}
@@ -423,7 +423,7 @@ func expandfile(t *Text, q0 int, q1 int, e *Expand) (success bool) {
 	nname := -1
 	for i, c := range rb {
 		if c == ':' && nname < 0 {
-			if q0+i+1 >= t.file.Size() {
+			if q0+i+1 >= t.file.Nr() {
 				return false
 			}
 			if i != n-1 {
@@ -496,7 +496,7 @@ func expand(t *Text, q0 int, q1 int) (*Expand, bool) {
 	}
 
 	if q0 == q1 {
-		for q1 < t.file.Size() && isalnum(t.ReadC(q1)) {
+		for q1 < t.file.Nr() && isalnum(t.ReadC(q1)) {
 			q1++
 		}
 		for q0 > 0 && isalnum(t.ReadC(q0-1)) {
@@ -577,7 +577,7 @@ func openfile(t *Text, e *Expand) *Window {
 		t.Load(0, e.name, true)
 		t.file.Clean()
 		t.w.SetTag()
-		t.w.tag.SetSelect(t.w.tag.file.Size(), t.w.tag.file.Size())
+		t.w.tag.SetSelect(t.w.tag.file.Nr(), t.w.tag.file.Nr())
 		if ow != nil {
 			for _, inc := range ow.incl {
 				w.AddIncl(inc)

--- a/row.go
+++ b/row.go
@@ -48,7 +48,7 @@ func (row *Row) Init(r image.Rectangle, dis draw.Display) *Row {
 	r1.Max.Y += row.display.ScaleSize(Border)
 	row.display.ScreenImage().Draw(r1, row.display.Black(), nil, image.Point{})
 	t.Insert(0, []rune(RowTag+" "), true)
-	t.SetSelect(t.file.Size(), t.file.Size())
+	t.SetSelect(t.file.Nr(), t.file.Nr())
 	return row
 }
 
@@ -477,7 +477,7 @@ func (row *Row) loadhelper(win *dumpfile.Window) error {
 	}
 	w.ClearTag()
 
-	w.tag.Insert(w.tag.file.Size(), []rune(afterbar[1]), true)
+	w.tag.Insert(w.tag.file.Nr(), []rune(afterbar[1]), true)
 	w.tag.Show(win.Tag.Q0, win.Tag.Q1, true)
 
 	if win.Type == dumpfile.Unsaved {
@@ -497,7 +497,7 @@ func (row *Row) loadhelper(win *dumpfile.Window) error {
 
 	q0 := win.Body.Q0
 	q1 := win.Body.Q1
-	if q0 > w.body.file.Size() || q1 > w.body.file.Size() || q0 > q1 {
+	if q0 > w.body.file.Nr() || q1 > w.body.file.Nr() || q0 > q1 {
 		q0 = 0
 		q1 = 0
 	}
@@ -600,7 +600,7 @@ func (row *Row) loadimpl(dump *dumpfile.Content, initing bool) error {
 	}
 
 	// Set row tag
-	row.tag.Delete(0, row.tag.file.Size(), true)
+	row.tag.Delete(0, row.tag.file.Nr(), true)
 	row.tag.Insert(0, []rune(dump.RowTag.Buffer), true)
 	row.tag.Show(dump.RowTag.Q0, dump.RowTag.Q1, true)
 
@@ -609,7 +609,7 @@ func (row *Row) loadimpl(dump *dumpfile.Content, initing bool) error {
 		// Acme's handling of column headers is perplexing. It is conceivable
 		// that this code does not do the right thing even if it replicates Acme
 		// correctly.
-		row.col[i].tag.Delete(0, row.col[i].tag.file.Size(), true)
+		row.col[i].tag.Delete(0, row.col[i].tag.file.Nr(), true)
 		row.col[i].tag.Insert(0, []rune(col.Tag.Buffer), true)
 		row.col[i].tag.Show(col.Tag.Q0, col.Tag.Q1, true)
 	}

--- a/scrl.go
+++ b/scrl.go
@@ -80,7 +80,7 @@ func (t *Text) ScrDraw(nchars int) {
 	r1 = r
 	r1.Min.X = 0
 	r1.Max.X = r.Dx()
-	r2 = scrpos(r1, t.org, t.org+nchars, t.file.Size())
+	r2 = scrpos(r1, t.org, t.org+nchars, t.file.Nr())
 	if !r2.Eq(t.lastsr) {
 		t.lastsr = r2
 		// rjk is assuming that only body Text instances have scrollers.
@@ -120,7 +120,7 @@ func (t *Text) Scroll(but int) {
 		}
 		if but == 2 {
 			y = my
-			p0 = t.file.Size() * (y - s.Min.Y) / h
+			p0 = t.file.Nr() * (y - s.Min.Y) / h
 			if p0 >= t.q1 {
 				p0 = t.BackNL(p0, 2)
 			}

--- a/wind.go
+++ b/wind.go
@@ -218,8 +218,8 @@ func (w *Window) TagLines(r image.Rectangle) int {
 
 	// if tag ends with \n, include empty line at end for typing
 	n := w.tag.fr.GetFrameFillStatus().Nlines
-	if w.tag.file.Size() > 0 {
-		c := w.tag.file.ReadC(w.tag.file.Size() - 1)
+	if w.tag.file.Nr() > 0 {
+		c := w.tag.file.ReadC(w.tag.file.Nr() - 1)
 		if c == '\n' {
 			n++
 		}
@@ -542,7 +542,7 @@ func (w *Window) setTag1() {
 		}
 	}
 	w.tag.file.Clean()
-	n := w.tag.file.Size()
+	n := w.tag.file.Nr()
 	if w.tag.q0 > n {
 		w.tag.q0 = n
 	}


### PR DESCRIPTION
Changed all callers of file.Size() to file.Nr() as size will soon be in bytes and currently the size is in runes. Closes: "TODO(rjk): Switch all callers to Nr() as would be the number of bytes when backed by undo.RuneArray." #334 