### PR TITLE
Reduce binary size by hiding profiler under a build tag

### DIFF
--- a/acme.go
+++ b/acme.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"image"
 	"log"
-	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
 	"path"
@@ -27,7 +25,6 @@ import (
 var (
 	command []*Command
 
-	debugAddr         = flag.String("debug", "", "Serve debug information on the supplied address")
 	globalAutoIndent  = flag.Bool("a", false, "Start each window in autoindent mode")
 	barflag           = flag.Bool("b", false, "Click to focus window instead of focus follows mouse (Bart's flag)")
 	varfontflag       = flag.String("f", defaultVarFont, "Variable-width font")
@@ -51,11 +48,7 @@ func main() {
 	flag.StringVar(&loadfile, "l", "", "Load state from file generated with Dump command")
 	flag.Parse()
 
-	if *debugAddr != "" {
-		go func() {
-			log.Println(http.ListenAndServe(*debugAddr, nil))
-		}()
-	}
+	startProfiler()
 
 	var err error
 	home, err = os.UserHomeDir()

--- a/acme_debug.go
+++ b/acme_debug.go
@@ -1,0 +1,20 @@
+// +build debug
+
+package main
+
+import (
+	"flag"
+	"log"
+	"net/http"
+	_ "net/http/pprof"
+)
+
+var debugAddr = flag.String("debug", "", "Serve debug information on the supplied address")
+
+func startProfiler() {
+	if *debugAddr != "" {
+		go func() {
+			log.Println(http.ListenAndServe(*debugAddr, nil))
+		}()
+	}
+}

--- a/acme_nodebug.go
+++ b/acme_nodebug.go
@@ -1,0 +1,7 @@
+// +build !debug
+
+// We get a smaller binary by not importing net/http/pprof.
+
+package main
+
+func startProfiler() {}


### PR DESCRIPTION
```
; go build -tags debug
; ls -l edwood
-rwxr-xr-x 1 fhs fhs 8941213 Sep  4 12:05 edwood
; go build
; ls -l edwood
-rwxr-xr-x 1 fhs fhs 5098257 Sep  4 12:06 edwood
```