### PR TITLE
Revert "Use nested file.Bytes"

### DIFF
--- a/file/bytes.go
+++ b/file/bytes.go
@@ -55,6 +55,12 @@ func (bytes *Bytes) Init(contents []byte) *Bytes {
 	return bytes
 }
 
+// Bytes returns the contents of the Bytes.  This method also means the
+// Bytes is directly printable by fmt.Print.
+func (bytes *Bytes) Byte() []byte {
+	return bytes.b
+}
+
 // RuneCount returns the number of runes (Unicode code points) in the Bytes.
 func (bytes *Bytes) RuneCount() int {
 	return bytes.numRunes
@@ -204,13 +210,8 @@ func (b *Bytes) HasNull() bool {
 
 // Read implements the io.Reader interface.
 func (b *Bytes) Read(buf []byte) (n int, err error) {
-	n = copy(buf, b.b)
+	n = copy(buf, b.Byte())
 	return n, nil
-}
-
-// Size returns the length of the underlying buffer in bytes.
-func (b *Bytes) Size() int {
-	return len(b.b)
 }
 
 var errOutOfRange = errors.New("utf8Bytes: index out of range")

--- a/file/undo_test.go
+++ b/file/undo_test.go
@@ -345,7 +345,7 @@ func (t *Buffer) printPieces() {
 		if p.next != nil {
 			next = p.next.id
 		}
-		fmt.Printf("%d, p:%d, n:%d = %s\n", p.id, prev, next, string(p.data.b))
+		fmt.Printf("%d, p:%d, n:%d = %s\n", p.id, prev, next, string(p.data))
 	}
 	fmt.Println()
 }
@@ -364,8 +364,9 @@ func (t *Buffer) allContent() string {
 	var data []byte
 	p := t.begin.next
 	for p != t.end {
-		data = append(data, p.data.b...)
+		data = append(data, p.data...)
 		p = p.next
+
 	}
 	return string(data)
 }


### PR DESCRIPTION
This reverts commit f82a8ea5 as it's no longer needed for the direction that undo.Buffer is going in. 