### PR TITLE
OEB Simplifications

### DIFF
--- a/file/file.go
+++ b/file/file.go
@@ -357,10 +357,11 @@ func NewTagFile() *File {
 }
 
 // RedoSeq finds the seq of the last redo record. TODO(rjk): This has no
-// analog in undo.RuneArray. The value of seq is used to track intra and
+// analog in file.Buffer. The value of seq is used to track intra and
 // inter File edit actions so that cross-File changes via Edit X can be
-// undone with a single action. An implementation of File that wraps
-// undo.RuneArray will need to to preserve seq tracking.
+// undone with a single action. An implementation of
+// ObservableEditableBuffer that wraps file.Buffer will need to to
+// preserve seq tracking.
 func (f *File) RedoSeq() int {
 	delta := &f.epsilon
 	if len(*delta) == 0 {

--- a/file/observable_editable_buffer.go
+++ b/file/observable_editable_buffer.go
@@ -272,14 +272,18 @@ func (e *ObservableEditableBuffer) RedoSeq() int {
 	return e.f.RedoSeq()
 }
 
-// inserted is a forwarding function for text.inserted.
+// inserted is a package-only entry point from the underlying
+// buffer (file.Buffer or file.File) to run the registered observers
+// on a change in the buffer.
 func (e *ObservableEditableBuffer) inserted(q0 int, r []rune) {
 	for observer := range e.observers {
 		observer.Inserted(q0, r)
 	}
 }
 
-// deleted is a forwarding function for text.deleted.
+// deleted is a package-only entry point from the underlying
+// buffer (file.Buffer or file.File) to run the registered observers
+// on a change in the buffer.
 func (e *ObservableEditableBuffer) deleted(q0 int, q1 int) {
 	for observer := range e.observers {
 		observer.Deleted(q0, q1)
@@ -319,6 +323,7 @@ func (e *ObservableEditableBuffer) Read(q0 int, r []rune) (int, error) {
 }
 
 // String is a forwarding function for rune_array.String.
+// Returns the entire buffer as a string.
 func (e *ObservableEditableBuffer) String() string {
 	return e.f.b.String()
 }

--- a/file/observable_editable_buffer.go
+++ b/file/observable_editable_buffer.go
@@ -287,11 +287,13 @@ func (e *ObservableEditableBuffer) deleted(q0 int, q1 int) {
 }
 
 // Commit is a forwarding function for file.Commit.
+// nop with file.Buffer.
 func (e *ObservableEditableBuffer) Commit() {
 	e.f.Commit()
 }
 
 // InsertAtWithoutCommit is a forwarding function for file.InsertAtWithoutCommit.
+// forwards to InsertAt for file.Buffer.
 func (e *ObservableEditableBuffer) InsertAtWithoutCommit(p0 int, s []rune) {
 	e.f.InsertAtWithoutCommit(p0, s)
 }
@@ -314,11 +316,6 @@ func (e *ObservableEditableBuffer) TreatAsDirty() bool {
 // because the "cache" concept is not germane.
 func (e *ObservableEditableBuffer) Read(q0 int, r []rune) (int, error) {
 	return e.f.b.Read(q0, r)
-}
-
-// View is a forwarding function for rune_array.View.
-func (e *ObservableEditableBuffer) View(q0 int, q1 int) []rune {
-	return e.f.b.View(q0, q1)
 }
 
 // String is a forwarding function for rune_array.String.

--- a/file/observable_editable_buffer.go
+++ b/file/observable_editable_buffer.go
@@ -127,12 +127,6 @@ func (e *ObservableEditableBuffer) Clean() {
 	e.f.Clean()
 }
 
-// Size is a forwarding function for file.Size.
-// This is in runes.
-func (e *ObservableEditableBuffer) Size() int {
-	return e.f.Size()
-}
-
 // Mark is a forwarding function for file.Mark.
 func (e *ObservableEditableBuffer) Mark(seq int) {
 	e.f.Mark(seq)

--- a/file/observable_editable_buffer.go
+++ b/file/observable_editable_buffer.go
@@ -382,8 +382,3 @@ func (e *ObservableEditableBuffer) SetDelta(delta []*Undo) {
 func (e *ObservableEditableBuffer) SetEpsilon(epsilon []*Undo) {
 	e.f.epsilon = epsilon
 }
-
-// GetCache is a Getter for file.cache for use in tests.
-func (e *ObservableEditableBuffer) GetCache() []rune {
-	return e.f.cache
-}

--- a/file/rune_array.go
+++ b/file/rune_array.go
@@ -65,16 +65,6 @@ func (b *RuneArray) Nbyte() int {
 	return bc
 }
 
-// TODO(flux): This is another design constraint of RuneArray - we want to efficiently
-// present contiguous segments of bytes, possibly by merging/flattening our tree
-// when a view is requested. This should be a rare operation...
-func (b *RuneArray) View(q0, q1 int) []rune {
-	if q1 > len(*b) {
-		q1 = len(*b)
-	}
-	return (*b)[q0:q1]
-}
-
 func (b RuneArray) IndexRune(r rune) int {
 	return runes.IndexRune(b, r)
 }

--- a/regx.go
+++ b/regx.go
@@ -5,6 +5,8 @@ import (
 	"github.com/rjkroege/edwood/sam"
 )
 
+// TODO(rjk): Regexps should stream. We need a forward/back Rune streaming interface.
+
 // AcmeRegexp is the representation of a compiled regular expression for acme.
 type AcmeRegexp struct {
 	*regexp.Regexp
@@ -26,7 +28,9 @@ func rxcompile(r string) (*AcmeRegexp, error) {
 // and returns at most n matches. If r is nil, it is derived from t.
 func (re *AcmeRegexp) rxexecute(t sam.Texter, r []rune, start int, end int, n int) []RangeSet {
 	if r == nil {
-		r = t.View(0, t.Nc())
+		// TODO(rjk): This is horrible. Stream here instead.
+		r = make([]rune, t.Nc())
+		t.ReadB(0, r[:t.Nc()])
 	}
 	return matchesToRangeSets(re.FindForward(r, start, end, n))
 }
@@ -34,7 +38,9 @@ func (re *AcmeRegexp) rxexecute(t sam.Texter, r []rune, start int, end int, n in
 // rxbexecute derives the full rune slice r from t and searches backwards in r[:end]
 // (from end of the slice to the beginning) and returns at most n matches.
 func (re *AcmeRegexp) rxbexecute(t sam.Texter, end int, n int) RangeSet {
-	r := t.View(0, t.Nc())
+	// TODO(rjk): This is horrible. Stream here instead.
+	r := make([]rune, t.Nc())
+	t.ReadB(0, r[:t.Nc()])
 	matches := re.FindBackward(r, 0, end, n)
 	var rs RangeSet
 	for _, m := range matches {

--- a/sam/texter.go
+++ b/sam/texter.go
@@ -7,6 +7,7 @@ import (
 // Texter abstracts the buffering side of Text, allowing testing of Elog Apply
 // TODO(flux): This is probably lame and will get re-done when I understand
 // how Text stores its text.
+// TODO(rjk): Make this into a streaming interface.
 type Texter interface {
 	Constrain(q0, q1 int) (p0, p1 int)
 	Delete(q0, q1 int, tofile bool)
@@ -15,10 +16,11 @@ type Texter interface {
 	SetQ0(int)
 	Q1() int // End of selelection
 	SetQ1(int)
+	// TODO(rjk): Please call this Nr().
 	Nc() int
+	// TODO(rjk): Rename this to Read
 	ReadB(q int, r []rune) (n int, err error)
 	ReadC(q int) rune
-	View(q0, q1 int) []rune // Return a "read only" slice
 }
 
 // TextBuffer implements Texter around a buffer.
@@ -36,13 +38,6 @@ func (t TextBuffer) Constrain(q0, q1 int) (p0, p1 int) {
 	p0 = util.Min(q0, len(t.buf))
 	p1 = util.Min(q1, len(t.buf))
 	return p0, p1
-}
-
-func (t *TextBuffer) View(q0, q1 int) []rune {
-	if q1 > len(t.buf) {
-		q1 = len(t.buf)
-	}
-	return t.buf[q0:q1]
 }
 
 func (t *TextBuffer) Delete(q0, q1 int, tofile bool) {

--- a/text.go
+++ b/text.go
@@ -623,7 +623,6 @@ func (t *Text) logInsertDelete(q0, q1 int) {
 	}
 }
 
-func (t *Text) View(q0, q1 int) []rune                   { return t.file.View(q0, q1) }
 func (t *Text) ReadB(q int, r []rune) (n int, err error) { n, err = t.file.Read(q, r); return }
 func (t *Text) nc() int                                  { return t.file.Nr() }
 func (t *Text) Q0() int                                  { return t.q0 }

--- a/text_test.go
+++ b/text_test.go
@@ -428,7 +428,12 @@ func checkTabexpand(t *testing.T, getText func(tabexpand bool, tabstop int) *Tex
 		for _, r := range tc.input {
 			text.Type(r)
 		}
-		if got := string(text.file.GetCache()); got != tc.want {
+		text.file.Commit()
+
+		gr := make([]rune, text.file.Nr())
+		text.file.Read(0, gr[:text.file.Nr()])
+
+		if got := string(gr); got != tc.want {
 			t.Errorf("loaded editor %q; expected %q", got, tc.want)
 		}
 	}

--- a/wind.go
+++ b/wind.go
@@ -505,11 +505,13 @@ func (w *Window) setTag1() {
 	if w.body.file.IsDir() {
 		sb.WriteString(Lget)
 	}
-	old := w.tag.file.View(0, w.tag.file.Nbyte()) // TODO(sn0w) find another way to do this without using View.
 	oldbarIndex := w.tag.file.IndexRune('|')
 	if oldbarIndex >= 0 {
+		// TODO(rjk): Update for file.Buffer representation.
+		oldsuffix := make([]rune, w.tag.file.Nr()-oldbarIndex)
+		w.tag.file.Read(oldbarIndex, oldsuffix)
 		sb.WriteString(" ")
-		sb.WriteString(string(old[oldbarIndex:]))
+		sb.WriteString(string(oldsuffix))
 	} else {
 		sb.WriteString(Lpipe)
 		sb.WriteString(Llook)


### PR DESCRIPTION
Simplify the `ObservableEditableBuffer` API surface to reduce the work
needed in forthcoming CLs to adapte OEB to `file.Buffer`.
