### PR TITLE
Pull seq up out of file

### DIFF
--- a/file/file.go
+++ b/file/file.go
@@ -25,7 +25,7 @@ import (
 // TODO(rjk): ObservableEditableBuffer will be a facade pattern wrapping
 // a file.Buffer. This file.go is the legacy implementation and will be
 // removed.
-// 
+//
 // TODO(rjk): The Edwood version of file.Buffer will implement Reader,
 // Writer, RuneReader, Seeker. Observe: Character motion routines in Text
 // can be written in terms of any object that is Seeker and RuneReader.

--- a/file/file.go
+++ b/file/file.go
@@ -38,8 +38,8 @@ type File struct {
 
 	oeb *ObservableEditableBuffer
 
-	mod          bool // true if the file has been changed. [private]
-//	treatasclean bool // Window Clean tests should succeed if set. [private]
+	mod bool // true if the file has been changed. [private]
+	//	treatasclean bool // Window Clean tests should succeed if set. [private]
 
 	// cache holds  that are not yet part of an undo record.
 	cache []rune // [private]
@@ -126,7 +126,7 @@ func (f *File) saveableAndDirtyImpl() bool {
 // keeping them in the cache. Does not map to undo.RuneArray.Commit (that
 // method is Mark). Remove this method.
 func (f *File) Commit(seq int) {
-//	f.treatasclean = false
+	//	f.treatasclean = false
 	if !f.HasUncommitedChanges() {
 		return
 	}
@@ -181,7 +181,7 @@ func (f *File) Load(q0 int, d []byte, seq int) (n int, hasNulls bool) {
 // to file.Buffer.Insert.
 // NB: At suffix is to correspond to utf8string.String.At().
 func (f *File) InsertAt(p0 int, s []rune, seq int) {
-//	f.treatasclean = false
+	//	f.treatasclean = false
 	if p0 > f.b.Nc() {
 		panic("internal error: fileinsert")
 	}
@@ -198,9 +198,9 @@ func (f *File) InsertAt(p0 int, s []rune, seq int) {
 // InsertAtWithoutCommit inserts s at p0 without creating
 // an undo record.
 // TODO(rjk): Remove this as a prelude to converting to file.Buffer
-// undo.Buffer 
+// undo.Buffer
 func (f *File) InsertAtWithoutCommit(p0 int, s []rune) {
-//	f.treatasclean = false
+	//	f.treatasclean = false
 	if p0 > f.b.Nc()+len(f.cache) {
 		panic("File.InsertAtWithoutCommit insertion off the end")
 	}
@@ -237,7 +237,7 @@ func (f *File) Uninsert(delta *[]*Undo, q0, ns, seq int) {
 // TODO(rjk): DeleteAt has an implied Commit operation
 // that makes it not match with file.Buffer.Delete
 func (f *File) DeleteAt(p0, p1, seq int) {
-//	f.treatasclean = false
+	//	f.treatasclean = false
 	if !(p0 <= p1 && p0 <= f.b.Nc() && p1 <= f.b.Nc()) {
 		util.AcmeError("internal error: DeleteAt", nil)
 	}
@@ -297,7 +297,7 @@ func NewFile() *File {
 		b:       NewRuneArray(),
 		delta:   []*Undo{},
 		epsilon: []*Undo{},
-		mod: false,
+		mod:     false,
 		//	ntext   int
 	}
 }
@@ -344,13 +344,13 @@ func (f *File) RedoSeq() int {
 // This does not align with the semantics of undo.RuneArray.
 // Each "Mark" needs to have a seq value provided.
 // Returns new q0, q1, ok, new seq
-func (f *File) Undo(isundo bool, seq int) (int, int,  bool,  int)  {
+func (f *File) Undo(isundo bool, seq int) (int, int, bool, int) {
 	var (
 		stop           int
 		delta, epsilon *[]*Undo
-		q0 int
-		q1 int
-		ok bool
+		q0             int
+		q1             int
+		ok             bool
 	)
 	if isundo {
 		// undo; reverse delta onto epsilon, seq decreases
@@ -427,7 +427,7 @@ func (f *File) Undo(isundo bool, seq int) (int, int,  bool,  int)  {
 func (f *File) Reset() {
 	f.delta = f.delta[0:0]
 	f.epsilon = f.epsilon[0:0]
-//	f.seq = 0
+	//	f.seq = 0
 }
 
 // Mark sets an Undo point and
@@ -440,7 +440,7 @@ func (f *File) Reset() {
 // TODO(rjk): Consider renaming to SetUndoPoint
 func (f *File) Mark() {
 	f.epsilon = f.epsilon[0:0]
-//	f.seq = seq
+	//	f.seq = seq
 }
 
 // Modded marks the File if we know that its backing is different from

--- a/file/file_test.go
+++ b/file/file_test.go
@@ -76,7 +76,7 @@ func TestFileInsertAt(t *testing.T) {
 	f := MakeObservableEditableBuffer("edwood", nil)
 
 	// Force Undo.
-	f.f.seq = 1
+	f.seq = 1
 
 	f.InsertAtWithoutCommit(0, []rune(s1))
 
@@ -170,7 +170,7 @@ func check(t *testing.T, testname string, oeb *ObservableEditableBuffer, fss *fi
 	if got, want := f.HasRedoableChanges(), fss.HasRedoableChanges; got != want {
 		t.Errorf("%s: HasUndoableChanges failed. got %v want %v", testname, got, want)
 	}
-	if got, want := f.SaveableAndDirty(), fss.SaveableAndDirty; got != want {
+	if got, want := oeb.SaveableAndDirty(), fss.SaveableAndDirty; got != want {
 		t.Errorf("%s: SaveableAndDirty failed. got %v want %v", testname, got, want)
 	}
 	if got, want := readwholefile(t, f), fss.filecontents; got != want {

--- a/file/observable_editable_buffer.go
+++ b/file/observable_editable_buffer.go
@@ -37,6 +37,15 @@ type ObservableEditableBuffer struct {
 	treatasclean bool // Toggle to override the Dirty check on closing a buffer with unsaved changes.
 }
 
+// A ObservableEditableBuffer can have a specific file-backing name that
+// permits it to be persisted to disk but typically would not be. These
+// two constants are suffixes of disk-file names that have this property.
+// TODO(rjk): Consider making this a detail of file.Details.
+const (
+	slashguide = "/guide"
+	plusErrors = "+Errors"
+)
+
 // Set is a forwarding function for file_hash.Set
 func (e *ObservableEditableBuffer) Set(hash []byte) {
 	e.details.Hash.Set(hash)
@@ -200,8 +209,6 @@ func (e *ObservableEditableBuffer) ReadC(q int) rune {
 // as clean and is this File writable to a backing. They are combined in this
 // this method.
 func (e *ObservableEditableBuffer) SaveableAndDirty() bool {
-	//	return e.details.Name != "" && e.f.SaveableAndDirty()
-
 	sad := (e.f.saveableAndDirtyImpl() || e.Dirty()) && !e.IsDirOrScratch()
 	return e.details.Name != "" && sad
 }
@@ -222,7 +229,6 @@ func (e *ObservableEditableBuffer) Load(q0 int, fd io.Reader, sethash bool) (n i
 // Dirty returns true when the ObservableEditableBuffer differs from its disk
 // backing as tracked by the undo system.
 func (e *ObservableEditableBuffer) Dirty() bool {
-	//	return e.f.Dirty()
 	return e.seq != e.putseq
 }
 
@@ -265,7 +271,7 @@ func (e *ObservableEditableBuffer) TreatAsClean() {
 
 // Modded marks the File if we know that its backing is different from
 // its contents. This is needed to track when Edwood has modified the
-// backing without changing the File (e.g. via the Edit w command.
+// backing without changing the File (e.g. via the Edit w command.)
 func (e *ObservableEditableBuffer) Modded() {
 	e.f.Modded()
 	e.treatasclean = false
@@ -420,8 +426,6 @@ func (e *ObservableEditableBuffer) SetDelta(delta []*Undo) {
 func (e *ObservableEditableBuffer) SetEpsilon(epsilon []*Undo) {
 	e.f.epsilon = epsilon
 }
-
-// ------------
 
 // SnapshotSeq saves the current seq to putseq. Call this on Put actions.
 // TODO(rjk): adjust as needed for file.Buffer.

--- a/file/observable_editable_buffer.go
+++ b/file/observable_editable_buffer.go
@@ -28,6 +28,10 @@ type ObservableEditableBuffer struct {
 	EditClean bool
 	details   *DiskDetails
 	isscratch bool // Used to track if this File should warn on unsaved deletion. [private]
+
+	// Tracks the editing sequence.
+	seq          int  // undo sequencing [private]
+	putseq       int  // seq on last put [private]
 }
 
 // Set is a forwarding function for file_hash.Set
@@ -377,4 +381,23 @@ func (e *ObservableEditableBuffer) SetDelta(delta []*Undo) {
 // SetEpsilon is a setter for file.epsilon for use in tests.
 func (e *ObservableEditableBuffer) SetEpsilon(epsilon []*Undo) {
 	e.f.epsilon = epsilon
+}
+
+
+// ------------
+
+
+// SnapshotSeq saves the current seq to putseq. Call this on Put actions.
+// TODO(rjk): adjust as needed for file.Buffer.
+func (f *ObservableEditableBuffer) SnapshotSeq() {
+	f.putseq = f.seq
+}
+
+// Dirty reports whether the current state of the File is different from
+// the initial state or from the one at the time of calling Clean.
+//
+// TODO(rjk): switching to file.Buffer will require adjusting how we
+// use seq.
+func (f *ObservableEditableBuffer) Dirty() bool {
+	return f.seq != f.putseq
 }

--- a/file/observable_editable_buffer.go
+++ b/file/observable_editable_buffer.go
@@ -29,12 +29,12 @@ type ObservableEditableBuffer struct {
 	details   *DiskDetails
 
 	// Tracks the editing sequence.
-	seq          int  // undo sequencing
-	putseq       int  // seq on last put
+	seq    int // undo sequencing
+	putseq int // seq on last put
 
-	// TODO(rjk): 
-	isscratch bool // Used to track if this File should warn on unsaved deletion.
-	treatasclean bool  // Toggle to override the Dirty check on closing a buffer with unsaved changes.
+	// TODO(rjk):
+	isscratch    bool // Used to track if this File should warn on unsaved deletion.
+	treatasclean bool // Toggle to override the Dirty check on closing a buffer with unsaved changes.
 }
 
 // Set is a forwarding function for file_hash.Set
@@ -200,7 +200,7 @@ func (e *ObservableEditableBuffer) ReadC(q int) rune {
 // as clean and is this File writable to a backing. They are combined in this
 // this method.
 func (e *ObservableEditableBuffer) SaveableAndDirty() bool {
-//	return e.details.Name != "" && e.f.SaveableAndDirty()
+	//	return e.details.Name != "" && e.f.SaveableAndDirty()
 
 	sad := (e.f.saveableAndDirtyImpl() || e.Dirty()) && !e.IsDirOrScratch()
 	return e.details.Name != "" && sad
@@ -222,7 +222,7 @@ func (e *ObservableEditableBuffer) Load(q0 int, fd io.Reader, sethash bool) (n i
 // Dirty returns true when the ObservableEditableBuffer differs from its disk
 // backing as tracked by the undo system.
 func (e *ObservableEditableBuffer) Dirty() bool {
-//	return e.f.Dirty()
+	//	return e.f.Dirty()
 	return e.seq != e.putseq
 }
 
@@ -392,7 +392,7 @@ func (e *ObservableEditableBuffer) Nbyte() int {
 // TODO(rjk): This is a callback from file.go. How to handle file name
 // changes requires attention when forwarding to file.Buffer.
 func (e *ObservableEditableBuffer) Setnameandisscratch(name string) {
-	e.treatasclean = false	
+	e.treatasclean = false
 	e.details.Name = name
 	if strings.HasSuffix(name, slashguide) || strings.HasSuffix(name, plusErrors) {
 		e.isscratch = true
@@ -421,13 +421,10 @@ func (e *ObservableEditableBuffer) SetEpsilon(epsilon []*Undo) {
 	e.f.epsilon = epsilon
 }
 
-
 // ------------
-
 
 // SnapshotSeq saves the current seq to putseq. Call this on Put actions.
 // TODO(rjk): adjust as needed for file.Buffer.
 func (f *ObservableEditableBuffer) SnapshotSeq() {
 	f.putseq = f.seq
 }
-


### PR DESCRIPTION
Pull seq up out of file.Fiel into file.ObservableEditableBuffer. This
helps with #97 by reducing the work needed to implement
ObservableEditableBuffer functions in terms of file.Buffer functions.
