### PR TITLE
Fix no-typing-in-tags bug

### DIFF
--- a/wind.go
+++ b/wind.go
@@ -505,6 +505,7 @@ func (w *Window) setTag1() {
 	if w.body.file.IsDir() {
 		sb.WriteString(Lget)
 	}
+	w.tag.file.Commit()
 	oldbarIndex := w.tag.file.IndexRune('|')
 	if oldbarIndex >= 0 {
 		// TODO(rjk): Update for file.Buffer representation.


### PR DESCRIPTION
My recent change #371 broke tag reconstruction. Oops. Fix that.
