### PR TITLE
Better tag typing fix

### DIFF
--- a/col.go
+++ b/col.go
@@ -8,6 +8,8 @@ import (
 	"github.com/rjkroege/edwood/file"
 	"github.com/rjkroege/edwood/frame"
 	"github.com/rjkroege/edwood/util"
+
+	"log"
 )
 
 var (
@@ -342,6 +344,8 @@ func (c *Column) Grow(w *Window, but int) {
 	//var nl, ny *int
 
 	var windex int
+
+log.Println(c)
 
 	for windex = 0; windex < len(c.w); windex++ {
 		if c.w[windex] == w {

--- a/col.go
+++ b/col.go
@@ -8,8 +8,6 @@ import (
 	"github.com/rjkroege/edwood/file"
 	"github.com/rjkroege/edwood/frame"
 	"github.com/rjkroege/edwood/util"
-
-	"log"
 )
 
 var (
@@ -344,8 +342,6 @@ func (c *Column) Grow(w *Window, but int) {
 	//var nl, ny *int
 
 	var windex int
-
-log.Println(c)
 
 	for windex = 0; windex < len(c.w); windex++ {
 		if c.w[windex] == w {

--- a/rowmock_test.go
+++ b/rowmock_test.go
@@ -43,7 +43,7 @@ func updateText(t *Text, sertext *dumpfile.Text, display draw.Display) *Text {
 // row/col/window hierarchy sufficient to run sam commands. It is
 // configured from the intermediate model used by the Edwood JSON dump
 // file.
-// 
+//
 // TODO(rjk): create the global object and return.
 func MakeWindowScaffold(content *dumpfile.Content) {
 	display := edwoodtest.NewDisplay()

--- a/rowmock_test.go
+++ b/rowmock_test.go
@@ -43,6 +43,8 @@ func updateText(t *Text, sertext *dumpfile.Text, display draw.Display) *Text {
 // row/col/window hierarchy sufficient to run sam commands. It is
 // configured from the intermediate model used by the Edwood JSON dump
 // file.
+// 
+// TODO(rjk): create the global object and return.
 func MakeWindowScaffold(content *dumpfile.Content) {
 	display := edwoodtest.NewDisplay()
 	global.seq = 0

--- a/text.go
+++ b/text.go
@@ -452,7 +452,6 @@ func (t *Text) Inserted(q0 int, r []rune) {
 	if t.fr != nil && t.display != nil {
 		t.ScrDraw(t.fr.GetFrameFillStatus().Nchars)
 	}
-
 }
 
 // writeEventLog emits an event log for an insertion.
@@ -1025,9 +1024,15 @@ func (t *Text) Type(r rune) {
 	t.file.InsertAtWithoutCommit(t.q0, rp[:nr])
 	t.SetSelect(t.q0+nr, t.q0+nr)
 
-	// TODO(rjk): Do we always want to commit if editing a
-	// a tag?
-	if r == '\n' && t.w != nil {
+	// Always commit if the typing is into a tag. The reason to do this is to
+	// be sure to invoke the special logic in Window.Commit() that creates an
+	// undo point for a file name change and updates the file details.
+	//
+	// This doesn't seem ideal. We have subtle logic that spans layers. Can
+	// we clean this up in some fashion so that it's easier to have Text
+	// instances that are editable but have partial auto-generated semantics
+	// (e.g. directories, tags)
+	if r == '\n' && t.w != nil || t.what != Body {
 		t.w.Commit(t)
 	}
 	t.iq1 = t.q0

--- a/text_test.go
+++ b/text_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/rjkroege/edwood/file"
 	"github.com/rjkroege/edwood/frame"
+	"github.com/rjkroege/edwood/dumpfile"
 )
 
 func emptyText() *Text {
@@ -439,27 +440,60 @@ func checkTabexpand(t *testing.T, getText func(tabexpand bool, tabstop int) *Tex
 	}
 }
 
+
+func makeTestTextTabexpandState() *Window {
+		MakeWindowScaffold(&dumpfile.Content{
+		Columns: []dumpfile.Column{
+			{},
+		},
+		Windows: []*dumpfile.Window{
+			{
+				Column: 0,
+				Tag: dumpfile.Text{
+					Buffer: "",
+				},
+				Body: dumpfile.Text{
+					Buffer: "",
+					Q0:     0,
+					Q1:     0,
+				},
+			},
+		},
+	})
+	return global.row.col[0].w[0]
+}
+
+
 func TestTextTypeTabInBody(t *testing.T) {
 	checkTabexpand(t, func(tabexpand bool, tabstop int) *Text {
-		w := &Window{
-			body: Text{
-				file:      file.MakeObservableEditableBufferTag([]rune{}),
-				tabexpand: tabexpand,
-				tabstop:   tabstop,
-			},
-		}
-		text := &w.body
-		text.w = w
+
+	w := makeTestTextTabexpandState()
+	text := &w.body
+	text.tabexpand = tabexpand
+	text.tabstop = tabstop
+
 		return text
 	})
 }
 
 func TestTextTypeTabInTag(t *testing.T) {
 	checkTabexpand(t, func(tabexpand bool, tabstop int) *Text {
+	w := makeTestTextTabexpandState()
+	text := &w.tag
+	text.tabexpand = tabexpand
+	text.tabstop = tabstop
+
+	return text
+
+/*
 		return &Text{
 			file:      file.MakeObservableEditableBufferTag([]rune{}),
 			tabexpand: tabexpand,
 			tabstop:   tabstop,
+			what: Tag,
+			fr: &MockFrame{},
 		}
+
+*/
 	})
 }

--- a/text_test.go
+++ b/text_test.go
@@ -11,9 +11,9 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/rjkroege/edwood/dumpfile"
 	"github.com/rjkroege/edwood/file"
 	"github.com/rjkroege/edwood/frame"
-	"github.com/rjkroege/edwood/dumpfile"
 )
 
 func emptyText() *Text {
@@ -440,9 +440,8 @@ func checkTabexpand(t *testing.T, getText func(tabexpand bool, tabstop int) *Tex
 	}
 }
 
-
 func makeTestTextTabexpandState() *Window {
-		MakeWindowScaffold(&dumpfile.Content{
+	MakeWindowScaffold(&dumpfile.Content{
 		Columns: []dumpfile.Column{
 			{},
 		},
@@ -463,14 +462,13 @@ func makeTestTextTabexpandState() *Window {
 	return global.row.col[0].w[0]
 }
 
-
 func TestTextTypeTabInBody(t *testing.T) {
 	checkTabexpand(t, func(tabexpand bool, tabstop int) *Text {
 
-	w := makeTestTextTabexpandState()
-	text := &w.body
-	text.tabexpand = tabexpand
-	text.tabstop = tabstop
+		w := makeTestTextTabexpandState()
+		text := &w.body
+		text.tabexpand = tabexpand
+		text.tabstop = tabstop
 
 		return text
 	})
@@ -478,22 +476,22 @@ func TestTextTypeTabInBody(t *testing.T) {
 
 func TestTextTypeTabInTag(t *testing.T) {
 	checkTabexpand(t, func(tabexpand bool, tabstop int) *Text {
-	w := makeTestTextTabexpandState()
-	text := &w.tag
-	text.tabexpand = tabexpand
-	text.tabstop = tabstop
+		w := makeTestTextTabexpandState()
+		text := &w.tag
+		text.tabexpand = tabexpand
+		text.tabstop = tabstop
 
-	return text
+		return text
 
-/*
-		return &Text{
-			file:      file.MakeObservableEditableBufferTag([]rune{}),
-			tabexpand: tabexpand,
-			tabstop:   tabstop,
-			what: Tag,
-			fr: &MockFrame{},
-		}
+		/*
+			return &Text{
+				file:      file.MakeObservableEditableBufferTag([]rune{}),
+				tabexpand: tabexpand,
+				tabstop:   tabstop,
+				what: Tag,
+				fr: &MockFrame{},
+			}
 
-*/
+		*/
 	})
 }

--- a/text_test.go
+++ b/text_test.go
@@ -482,16 +482,5 @@ func TestTextTypeTabInTag(t *testing.T) {
 		text.tabstop = tabstop
 
 		return text
-
-		/*
-			return &Text{
-				file:      file.MakeObservableEditableBufferTag([]rune{}),
-				tabexpand: tabexpand,
-				tabstop:   tabstop,
-				what: Tag,
-				fr: &MockFrame{},
-			}
-
-		*/
 	})
 }

--- a/wind.go
+++ b/wind.go
@@ -505,7 +505,6 @@ func (w *Window) setTag1() {
 	if w.body.file.IsDir() {
 		sb.WriteString(Lget)
 	}
-	w.tag.file.Commit()
 	oldbarIndex := w.tag.file.IndexRune('|')
 	if oldbarIndex >= 0 {
 		// TODO(rjk): Update for file.Buffer representation.


### PR DESCRIPTION
Previous fix b859964fa27ed22a5c9fc81b5c46e467ed611a8c for bug that I
introduced in #371 failed to correctly handle text insertion in all
parts of the tag. Fix it more comprehensively. Also improve fidelity
of some tests by building a better model for tab insertion tests.
