### PR TITLE
Remove redundant Tag-specific file creation

### DIFF
--- a/addr_test.go
+++ b/addr_test.go
@@ -95,7 +95,7 @@ func TestAcmeregexp(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			warnings = nil
 			text := &Text{
-				file: file.MakeObservableEditableBufferTag([]rune("abcd αβξδ\n")),
+				file: file.MakeObservableEditableBuffer("", []rune("abcd αβξδ\n")),
 			}
 			lim := Range{
 				0,

--- a/file/file.go
+++ b/file/file.go
@@ -243,14 +243,6 @@ func NewFile() *File {
 	}
 }
 
-func NewTagFile() *File {
-	return &File{
-		b:       NewRuneArray(),
-		delta:   []*Undo{},
-		epsilon: []*Undo{},
-	}
-}
-
 // RedoSeq finds the seq of the last redo record. TODO(rjk): This has no
 // analog in file.Buffer. The value of seq is used to track intra and
 // inter File edit actions so that cross-File changes via Edit X can be

--- a/file/file_test.go
+++ b/file/file_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestDelObserver(t *testing.T) {
-	f := MakeObservableEditableBufferTag(RuneArray{})
+	f := MakeObservableEditableBuffer("", RuneArray{})
 
 	testData := []*testText{{file: MakeObservableEditableBuffer("World sourdoughs from antiquity", nil)},
 		{file: MakeObservableEditableBuffer("Willowbrook Association Handbook: 2011", nil)},

--- a/file/observable_editable_buffer.go
+++ b/file/observable_editable_buffer.go
@@ -123,22 +123,6 @@ func MakeObservableEditableBuffer(filename string, b []rune) *ObservableEditable
 	return oeb
 }
 
-// MakeObservableEditableBufferTag is a constructor wrapper for NewTagFile() to abstract File from the main program.
-func MakeObservableEditableBufferTag(b []rune) *ObservableEditableBuffer {
-	f := NewTagFile()
-	f.b = b
-	oeb := &ObservableEditableBuffer{
-		currobserver: nil,
-		observers:    nil,
-		f:            f,
-		Elog:         sam.MakeElog(),
-		details:      &DiskDetails{Hash: Hash{}},
-		EditClean:    true,
-	}
-	oeb.f.oeb = oeb
-	return oeb
-}
-
 // Clean marks the ObservableEditableBuffer as being non-dirty: the
 // backing is the same as File.
 //

--- a/look_test.go
+++ b/look_test.go
@@ -60,7 +60,7 @@ func TestExpand(t *testing.T) {
 		t.Run(fmt.Sprintf("test-%02d", i), func(t *testing.T) {
 			r := []rune(tc.s)
 			text := &Text{
-				file: file.MakeObservableEditableBufferTag(r),
+				file: file.MakeObservableEditableBuffer("", r),
 				q0:   0,
 				q1:   tc.sel1,
 			}
@@ -98,7 +98,7 @@ func TestExpandJump(t *testing.T) {
 
 	for _, tc := range tt {
 		text := &Text{
-			file: file.MakeObservableEditableBufferTag([]rune("chicken")),
+			file: file.MakeObservableEditableBuffer("", []rune("chicken")),
 			q0:   0,
 			q1:   5,
 			what: tc.kind,

--- a/rowmock_test.go
+++ b/rowmock_test.go
@@ -56,7 +56,7 @@ func MakeWindowScaffold(content *dumpfile.Content) {
 		display: display,
 		tag: *updateText(&Text{
 			what: Rowtag,
-			file: file.MakeObservableEditableBufferTag(nil),
+			file: file.MakeObservableEditableBuffer("", nil),
 		}, &content.RowTag, display),
 	}
 
@@ -65,7 +65,7 @@ func MakeWindowScaffold(content *dumpfile.Content) {
 		col := &Column{
 			tag: *updateText(&Text{
 				what: Columntag,
-				file: file.MakeObservableEditableBufferTag(nil),
+				file: file.MakeObservableEditableBuffer("", nil),
 			}, &sercol.Tag, display),
 			display: display,
 			fortest: true,

--- a/text_test.go
+++ b/text_test.go
@@ -135,7 +135,7 @@ func TestClickHTMLMatch(t *testing.T) {
 		t.Run(fmt.Sprintf("test-%02d", i), func(t *testing.T) {
 			r := []rune(tc.s)
 			text := &Text{
-				file: file.MakeObservableEditableBufferTag(r),
+				file: file.MakeObservableEditableBuffer("", r),
 			}
 			q0, q1, ok := text.ClickHTMLMatch(tc.inq0)
 			switch {
@@ -256,7 +256,7 @@ func (fr *textFillMockFrame) GetFrameFillStatus() frame.FrameFillStatus {
 
 func TestTextFill(t *testing.T) {
 	text := &Text{
-		file: file.MakeObservableEditableBufferTag([]rune{}),
+		file: file.MakeObservableEditableBuffer("", []rune{}),
 	}
 	err := text.fill(&textFillMockFrame{})
 	wantErr := "fill: negative slice length -100"
@@ -338,7 +338,7 @@ func TestTextAbsDirName(t *testing.T) {
 func windowWithTag(tag string) *Window {
 	return &Window{
 		tag: Text{
-			file: file.MakeObservableEditableBufferTag([]rune(tag)),
+			file: file.MakeObservableEditableBuffer("", []rune(tag)),
 		},
 	}
 }
@@ -366,7 +366,7 @@ func TestBackNL(t *testing.T) {
 
 	for _, tc := range tt {
 		text := &Text{
-			file: file.MakeObservableEditableBufferTag([]rune(tc.buf)),
+			file: file.MakeObservableEditableBuffer("", []rune(tc.buf)),
 		}
 		q := text.BackNL(tc.p, tc.n)
 		if got, want := q, tc.q; got != want {
@@ -397,7 +397,7 @@ func TestTextBsInsert(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			text := &Text{
 				what: tc.what,
-				file: file.MakeObservableEditableBufferTag([]rune(tc.buf)),
+				file: file.MakeObservableEditableBuffer("", []rune(tc.buf)),
 			}
 			q, nr := text.BsInsert(tc.q0, []rune(tc.inbuf), true)
 			if nr != tc.nr {

--- a/wind.go
+++ b/wind.go
@@ -82,7 +82,7 @@ func (w *Window) initHeadless(clone *Window) *Window {
 	w.ctlfid = MaxFid
 	w.utflastqid = -1
 
-	f := file.MakeObservableEditableBufferTag(nil)
+	f := file.MakeObservableEditableBuffer("", nil)
 	f.AddObserver(&w.tag)
 	w.tag.file = f
 

--- a/wind_test.go
+++ b/wind_test.go
@@ -39,7 +39,7 @@ func TestWindowUndoSelection(t *testing.T) {
 			body: Text{
 				q0:   tc.q0,
 				q1:   tc.q1,
-				file: file.MakeObservableEditableBufferTag([]rune("This is an example sentence.\n")),
+				file: file.MakeObservableEditableBuffer("", []rune("This is an example sentence.\n")),
 			},
 		}
 		w.body.file.SetDelta(tc.delta)
@@ -108,7 +108,7 @@ func TestWindowClampAddr(t *testing.T) {
 		w := &Window{
 			addr: tc.addr,
 			body: Text{
-				file: file.MakeObservableEditableBufferTag(buf),
+				file: file.MakeObservableEditableBuffer("", buf),
 			},
 		}
 		w.ClampAddr()
@@ -131,7 +131,7 @@ func TestWindowParseTag(t *testing.T) {
 	} {
 		w := &Window{
 			tag: Text{
-				file: file.MakeObservableEditableBufferTag([]rune(tc.tag)),
+				file: file.MakeObservableEditableBuffer("", []rune(tc.tag)),
 			},
 		}
 		if got, want := w.ParseTag(), tc.filename; got != want {
@@ -145,7 +145,7 @@ func TestWindowClearTag(t *testing.T) {
 	want := "/foo bar/test.txt Del Snarf Undo Put |"
 	w := &Window{
 		tag: Text{
-			file: file.MakeObservableEditableBufferTag([]rune(tag)),
+			file: file.MakeObservableEditableBuffer("", []rune(tag)),
 		},
 	}
 	w.ClearTag()

--- a/xfid_test.go
+++ b/xfid_test.go
@@ -220,7 +220,7 @@ func TestXfidwriteQWaddr(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			mr := new(mockResponder)
 			w := NewWindow().initHeadless(nil)
-			w.body.file = file.MakeObservableEditableBufferTag([]rune("abcαβξ\n"))
+			w.body.file = file.MakeObservableEditableBuffer("", []rune("abcαβξ\n"))
 			w.col = new(Column)
 			w.limit = Range{0, w.body.file.Nr()}
 			x := &Xfid{
@@ -758,7 +758,7 @@ func TestXfidwriteQWerrors(t *testing.T) {
 	mr := new(mockResponder)
 	w := NewWindow().initHeadless(nil)
 	w.col = new(Column)
-	w.tag.file = file.MakeObservableEditableBufferTag([]rune("/home/gopher/edwood/row.go Del Snarf | Look "))
+	w.tag.file = file.MakeObservableEditableBuffer("", []rune("/home/gopher/edwood/row.go Del Snarf | Look "))
 	w.tag.fr = &MockFrame{}
 	w.body.fr = &MockFrame{}
 	x := &Xfid{
@@ -1080,9 +1080,9 @@ func TestXfidreadQWbodyQWtag(t *testing.T) {
 			w.body.fr = &MockFrame{}
 			switch tc.q {
 			case QWbody:
-				w.body.file = file.MakeObservableEditableBufferTag([]rune(data))
+				w.body.file = file.MakeObservableEditableBuffer("", []rune(data))
 			case QWtag:
-				w.tag.file = file.MakeObservableEditableBufferTag([]rune(data))
+				w.tag.file = file.MakeObservableEditableBuffer("", []rune(data))
 			}
 
 			x := &Xfid{
@@ -1141,7 +1141,7 @@ func TestXfidruneread(t *testing.T) {
 			fs: mr,
 		}
 		w := NewWindow().initHeadless(nil)
-		w.body.file = file.MakeObservableEditableBufferTag(tc.body)
+		w.body.file = file.MakeObservableEditableBuffer("", tc.body)
 		nr := xfidruneread(x, &w.body, tc.q0, tc.q1)
 		if got, want := nr, tc.nr; got != want {
 			t.Errorf("read %v runes from %q (q0=%v, q1=%v); should read %v runes",
@@ -1183,7 +1183,7 @@ func TestXfidreadQWxdataQWdata(t *testing.T) {
 			mr := new(mockResponder)
 			w := NewWindow().initHeadless(nil)
 			w.col = new(Column)
-			w.body.file = file.MakeObservableEditableBufferTag([]rune(body))
+			w.body.file = file.MakeObservableEditableBuffer("", []rune(body))
 			w.addr = tc.inAddr
 			xfidread(&Xfid{
 				f: &Fid{
@@ -1217,7 +1217,7 @@ func TestXfidreadQWaddr(t *testing.T) {
 	)
 	w := NewWindow().initHeadless(nil)
 	w.col = new(Column)
-	w.body.file = file.MakeObservableEditableBufferTag([]rune(body))
+	w.body.file = file.MakeObservableEditableBuffer("", []rune(body))
 	w.addr.q0 = 5
 	w.addr.q1 = 12
 
@@ -1246,8 +1246,8 @@ func TestXfidreadQWctl(t *testing.T) {
 	w.col = new(Column)
 	w.display = edwoodtest.NewDisplay()
 	w.body.fr = &MockFrame{}
-	w.tag.file = file.MakeObservableEditableBufferTag([]rune(("/etc/hosts Del Snarf | Look Get ")))
-	w.body.file = file.MakeObservableEditableBufferTag([]rune("Hello, world!\n"))
+	w.tag.file = file.MakeObservableEditableBuffer("", []rune(("/etc/hosts Del Snarf | Look Get ")))
+	w.body.file = file.MakeObservableEditableBuffer("", []rune("Hello, world!\n"))
 
 	mr := new(mockResponder)
 	xfidread(&Xfid{


### PR DESCRIPTION
file.MakeObservableEditableBufferTag is redundant. Remove this to
simplify the file implementation to help with #97.
