### PR TITLE
More validation of file.BufferObserver callbacks

### DIFF
--- a/file/file_test.go
+++ b/file/file_test.go
@@ -224,12 +224,12 @@ func TestFileLoadUndoHash(t *testing.T) {
 	if got, want := f.Name(), "edwood"; got != want {
 		t.Errorf("TestFileLoadUndoHash failed to set name. got %v want %v", got, want)
 	}
-	to.Check([]*observation{		{
-			callback: "Inserted",
-			q0: 0,
-			payload: "byebye",
-		},
-})
+	to.Check([]*observation{{
+		callback: "Inserted",
+		q0:       0,
+		payload:  "byebye",
+	},
+	})
 }
 
 // Multiple interleaved actions do the right thing.
@@ -271,33 +271,33 @@ func TestFileInsertDeleteUndo(t *testing.T) {
 	to.Check([]*observation{
 		{
 			callback: "Inserted",
-			q0: 0,
-			payload: "hi 海老麺",
+			q0:       0,
+			payload:  "hi 海老麺",
 		},
 		{
 			callback: "Inserted",
-			q0: 0,
-			payload: "bye",
+			q0:       0,
+			payload:  "bye",
 		},
 		{
 			callback: "Deleted",
-			q0: 0,
-			q1: 1,
+			q0:       0,
+			q1:       1,
 		},
 		{
 			callback: "Deleted",
-			q0: 1,
-			q1: 3,
+			q0:       1,
+			q1:       3,
 		},
 		{
 			callback: "Inserted",
-			q0: f.Nr()-1,
-			payload: s1,
+			q0:       f.Nr() - 1,
+			payload:  s1,
 		},
 		{
 			callback: "Deleted",
-			q0: 5,
-			q1: 5 + len([]rune(s1)),
+			q0:       5,
+			q1:       5 + len([]rune(s1)),
 		},
 	})
 
@@ -313,23 +313,23 @@ func TestFileInsertDeleteUndo(t *testing.T) {
 	to.Check([]*observation{
 		{
 			callback: "Inserted",
-			q0: 1,
-			payload: "eh",
+			q0:       1,
+			payload:  "eh",
 		},
 		{
 			callback: "Inserted",
-			q0: 0,
-			payload: "b",
+			q0:       0,
+			payload:  "b",
 		},
 		{
 			callback: "Deleted",
-			q0: 0,
-			q1: 1,
+			q0:       0,
+			q1:       1,
 		},
 		{
 			callback: "Deleted",
-			q0: 1,
-			q1: 3,
+			q0:       1,
+			q1:       3,
 		},
 	})
 }

--- a/file/helpers_test.go
+++ b/file/helpers_test.go
@@ -90,9 +90,9 @@ func check(t *testing.T, testname string, oeb *ObservableEditableBuffer, fss *st
 
 type observation struct {
 	callback string
-	q0 int
-	q1 int
-	payload string
+	q0       int
+	q1       int
+	payload  string
 }
 
 func (o *observation) String() string {
@@ -103,7 +103,7 @@ func (o *observation) String() string {
 }
 
 type testObserver struct {
-	t *testing.T
+	t    *testing.T
 	tape []*observation
 }
 
@@ -116,8 +116,8 @@ func MakeTestObserver(t *testing.T) *testObserver {
 func (to *testObserver) Inserted(q0 int, r []rune) {
 	o := &observation{
 		callback: "Inserted",
-		q0: q0,
-		payload: string(r),
+		q0:       q0,
+		payload:  string(r),
 	}
 	to.t.Log(o)
 	to.tape = append(to.tape, o)
@@ -126,8 +126,8 @@ func (to *testObserver) Inserted(q0 int, r []rune) {
 func (to *testObserver) Deleted(q0, q1 int) {
 	o := &observation{
 		callback: "Deleted",
-		q0: q0,
-		q1: q1,
+		q0:       q0,
+		q1:       q1,
 	}
 	to.t.Log(o)
 	to.tape = append(to.tape, o)
@@ -135,9 +135,9 @@ func (to *testObserver) Deleted(q0, q1 int) {
 
 func (to *testObserver) Check(expected []*observation) {
 	to.t.Helper()
-	defer func() {to.tape = nil}()
-	
-	if got, want := len(to.tape),  len(expected); got != want {
+	defer func() { to.tape = nil }()
+
+	if got, want := len(to.tape), len(expected); got != want {
 		to.t.Errorf("testObserver: tape length: got %d, want %d", got, want)
 		return
 	}

--- a/file/observable_editable_buffer.go
+++ b/file/observable_editable_buffer.go
@@ -250,7 +250,7 @@ func (e *ObservableEditableBuffer) InsertAt(p0 int, s []rune) {
 // SetName sets the name of the backing for this file. Some backings that
 // opt them out of typically being persisted. Resetting a file name to a
 // new value does not have any effect.
-// 
+//
 // TODO(rjk): This implementation is a layering violation for the
 // conversion to file.Buffer.
 func (e *ObservableEditableBuffer) SetName(name string) {


### PR DESCRIPTION
Increase validation that file.ObservableEditableBuffer correctly calls
its observers. Reduces the chances of regression when backing OEB with
a file.Buffer. Helps with #97.
