### PR TITLE
Fix for #385

### DIFF
--- a/col.go
+++ b/col.go
@@ -207,6 +207,8 @@ func (c *Column) Add(w, clone *Window, y int) *Window {
 	return w
 }
 
+// Close called to remove w from Column c. Set dofree to true to actually
+// delete window w. Otherwise, w will be moved to another Column.
 func (c *Column) Close(w *Window, dofree bool) {
 	var (
 		r            image.Rectangle
@@ -225,12 +227,17 @@ func (c *Column) Close(w *Window, dofree bool) {
 	util.AcmeError("can't find window", nil)
 Found:
 	r = w.r
+	// Crash noted in #385 happens when closing windows with the
+	// Edit command. Col.Close is invoked to remove the windows by ecmd.go/D1.
+	// When we place the Window in the new column, we'll set this. Or we'll
+	// delete the Window in the dofree block.
 	w.tag.col = nil
 	w.body.col = nil
 	w.col = nil
 	didmouse = restoremouse(w)
 	if dofree {
 		w.Delete()
+		// This Close call will decrement the w's reference count.
 		w.Close()
 	}
 	c.w = append(c.w[:i], c.w[i+1:]...)

--- a/file/observable_editable_buffer.go
+++ b/file/observable_editable_buffer.go
@@ -83,6 +83,7 @@ func (e *ObservableEditableBuffer) DelObserver(observer BufferObserver) error {
 		}
 		return nil
 	}
+	// This never happens right?
 	return fmt.Errorf("can't find editor in File.DelObserver")
 }
 
@@ -92,7 +93,7 @@ func (e *ObservableEditableBuffer) SetCurObserver(observer BufferObserver) {
 }
 
 // GetCurObserver gets the current observer and returns it as a interface type.
-func (e *ObservableEditableBuffer) GetCurObserver() interface{} {
+func (e *ObservableEditableBuffer) GetCurObserver() BufferObserver {
 	return e.currobserver
 }
 


### PR DESCRIPTION
When a Text has multiple observers, the Window ref count is
incremented as part of creating the Zerox. Add one additional
decrement operation to compensate.
