### PR TITLE
Improved documentation for exec functions

### DIFF
--- a/exec_test.go
+++ b/exec_test.go
@@ -224,5 +224,3 @@ func TestCut(t *testing.T) {
 		t.Errorf("text q0 wrong after cut got %v, want %v", got, want)
 	}
 }
-
-// TODO(rjk): test undo.

--- a/globals.go
+++ b/globals.go
@@ -15,9 +15,10 @@ import (
 // TODO(rjk): Document what each of these are.
 type globals struct {
 	globalincref bool
-	seq          int
-	maxtab       uint // size of a tab, in units of the '0' character
-	tabexpand    bool // defines whether to expand tab to spaces
+
+	seq       int  // undo/redo sequence across all file.OEBs
+	maxtab    uint // size of a tab, in units of the '0' character
+	tabexpand bool // defines whether to expand tab to spaces
 
 	tagfont     string
 	mouse       *draw.Mouse

--- a/text.go
+++ b/text.go
@@ -1637,3 +1637,9 @@ func (t *Text) AbsDirName(name string) string {
 	}
 	return filepath.Clean(d)
 }
+
+// DebugString provides a Text representation convenient for logging for
+// debugging.
+func (t *Text) DebugString() string {
+	return fmt.Sprintf("t.what (kind): %s contents: %q", t.what, t.file.String())
+}


### PR DESCRIPTION
exec.go contains functions for most of the built-in commands
recognized by Edwood. Document the format and calling conventions for
these functions more precisely before writing additional unit tests
for them.
