### PR TITLE
Add test for multi-window Undo/Redo

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -638,7 +638,7 @@ func seqof(w *Window, isundo bool) int {
 	return w.body.file.RedoSeq()
 }
 
-// TODO(rjk): Test the logic of Undo across multiple buffers very carefully.
+// TODO(rjk): Test the logic of Undo across multiple buffers very carefully: #383
 func undo(et *Text, _ *Text, _ *Text, flag1, _ bool, _ string) {
 	if et == nil || et.w == nil {
 		return

--- a/exec_test.go
+++ b/exec_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/rjkroege/edwood/dumpfile"
 	"github.com/rjkroege/edwood/file"
 )
 
@@ -223,4 +225,469 @@ func TestCut(t *testing.T) {
 	if got, want := w.body.q1, 0; got != want {
 		t.Errorf("text q0 wrong after cut got %v, want %v", got, want)
 	}
+}
+
+func testSetupOnly(t *testing.T, g *globals) {
+	t.Helper()
+
+	// Mutate with Edit
+	firstwin := g.row.col[0].w[0]
+	secondwin := g.row.col[0].w[1]
+
+	t.Log("Before seq", global.seq)
+	t.Log("firstwin.body.file.Seq", g.row.col[0].w[0].body.file.Seq())
+	t.Log("firstwin.body.file.HasUndoableChanges", g.row.col[0].w[0].body.file.HasUndoableChanges())
+	t.Log("secondwin.body.file.Seq", g.row.col[0].w[1].body.file.Seq())
+	t.Log("secondwin.body.file.HasUndoableChanges", g.row.col[0].w[1].body.file.HasUndoableChanges())
+
+	// These should both do nothing.
+	undo(&firstwin.tag, nil, nil, true /* this is an undo */, false /* ignored */, "")
+	undo(&secondwin.tag, nil, nil, false /* this is a redo */, false /* ignored */, "")
+
+	t.Log("After seq", global.seq)
+	t.Log("firstwin.body.file.Seq", g.row.col[0].w[0].body.file.Seq())
+	t.Log("firstwin.body.file.HasUndoableChanges", g.row.col[0].w[0].body.file.HasUndoableChanges())
+	t.Log("secondwin.body.file.Seq", g.row.col[0].w[1].body.file.Seq())
+	t.Log("secondwin.body.file.HasUndoableChanges", g.row.col[0].w[1].body.file.HasUndoableChanges())
+}
+
+func mutateWithEdit(t *testing.T, g *globals) {
+	t.Helper()
+
+	// Mutate with Edit
+	firstwin := g.row.col[0].w[0]
+	// secondwin := g.row.col[0].w[1]
+
+	t.Log("Before seq", global.seq)
+	t.Log("firstwin.body.file.Seq", g.row.col[0].w[0].body.file.Seq())
+	t.Log("secondwin.body.file.Seq", g.row.col[0].w[1].body.file.Seq())
+
+	// Do I need to lock the warning?
+
+	// Lock discipline?
+	// TODO(rjk): figure out how to change this with less global dependency.
+	global.row.lk.Lock()
+	firstwin.Lock('M')
+	global.seq++
+
+	editcmd(&firstwin.body, []rune("X/.*file/ ,x/text/ c/TEXT/"))
+	firstwin.Unlock()
+	global.row.lk.Unlock()
+
+	t.Log("After seq", global.seq)
+	t.Log("firstwin.body.file.Seq", g.row.col[0].w[0].body.file.Seq())
+	t.Log("secondwin.body.file.Seq", g.row.col[0].w[1].body.file.Seq())
+}
+
+func undoRedoBothMutations(t *testing.T, g *globals) {
+	t.Helper()
+	mutateWithEdit(t, g)
+
+	firstwin := g.row.col[0].w[0]
+	secondwin := g.row.col[0].w[1]
+
+	// Run undo from one of the windows. (i.e. equivalent to clicking on the Undo action.)
+	undo(&firstwin.tag, nil, nil, true /* this is an undo */, false /* ignored */, "")
+
+	undo(&secondwin.tag, nil, nil, false /* this is a redo */, false /* ignored */, "")
+}
+
+func mutateBothOneUndo(t *testing.T, g *globals) {
+	t.Helper()
+	mutateWithEdit(t, g) // Changes both.
+
+	firstwin := g.row.col[0].w[0]
+
+	// Modify the firstwin.
+	firstwin.body.q0 = 3
+	firstwin.body.q1 = 10
+	global.seq++
+	firstwin.body.file.Mark(global.seq)
+	cut(&firstwin.tag, &firstwin.body, nil, false, true, "")
+
+	// Run undo from first window. (i.e. equivalent to clicking on the Undo action.)
+	// Should undo only the cut.
+	undo(&firstwin.tag, nil, nil, true /* this is an undo */, false /* ignored */, "")
+}
+
+func mutateBothOtherUndo(t *testing.T, g *globals) {
+	t.Helper()
+	mutateWithEdit(t, g)
+
+	// Mutate with Edit
+	firstwin := g.row.col[0].w[0]
+	secondwin := g.row.col[0].w[1]
+
+	// Modify the firstwin.
+	firstwin.body.q0 = 3
+	firstwin.body.q1 = 10
+	global.seq++
+	firstwin.body.file.Mark(global.seq)
+	cut(&firstwin.tag, &firstwin.body, nil, false, true, "")
+
+	// Run undo from one of the windows. (i.e. same as clicking on the Undo action.)
+	// Cut should remain, original global edit should get Undone only in secondwin.
+	undo(&secondwin.tag, nil, nil, true /* this is an undo */, false /* ignored */, "")
+}
+
+func mutateBranchedAndRejoined(t *testing.T, g *globals) {
+	t.Helper()
+
+	// Mutate firstwin, secondwin simultaneously.
+	mutateWithEdit(t, g)
+
+	firstwin := g.row.col[0].w[0]
+	secondwin := g.row.col[0].w[1]
+
+	// Mutate firstwin via cut.
+	firstwin.body.q0 = 3
+	firstwin.body.q1 = 10
+	global.seq++
+	firstwin.body.file.Mark(global.seq)
+	cut(&firstwin.tag, &firstwin.body, nil, false, true, "")
+
+	undo(&secondwin.tag, nil, nil, true /* this is an undo */, false /* ignored */, "")
+	undo(&firstwin.tag, nil, nil, true /* this is an undo */, false /* ignored */, "")
+
+	// Should do nothing.
+	undo(&secondwin.tag, nil, nil, true /* this is an undo */, false /* ignored */, "")
+
+	// Undoes the mutateWithEdit on firstwin
+	undo(&firstwin.tag, nil, nil, true /* this is an undo */, false /* ignored */, "")
+
+	// Redo on secondwin puts back the change on both firstwin and secondwind.
+	undo(&secondwin.tag, nil, nil, false /* this is not undo */, false /* ignored */, "")
+}
+
+func TestUndoRedo(t *testing.T) {
+	dir := t.TempDir()
+	firstfilename, secondfilename := makeTempBackingFiles(t, dir)
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current working directory: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		fn   func(t *testing.T, g *globals)
+		want *dumpfile.Content
+	}{
+		{
+			// Verify that test harness creates valid initial state.
+			name: "testSetupOnly",
+			fn:   testSetupOnly,
+			want: &dumpfile.Content{
+				CurrentDir: cwd,
+				VarFont:    defaultVarFont,
+				FixedFont:  defaultFixedFont,
+				Columns: []dumpfile.Column{
+					{},
+				},
+				Windows: []*dumpfile.Window{
+					{
+						Type:   dumpfile.Saved,
+						Column: 0,
+						Tag: dumpfile.Text{
+							Buffer: firstfilename,
+						},
+						// Recall that when the contents match the on-disk state,
+						// they are elided.
+						Body: dumpfile.Text{},
+					},
+					{
+						Type:   dumpfile.Saved,
+						Column: 0,
+						Tag: dumpfile.Text{
+							Buffer: secondfilename,
+						},
+						Body: dumpfile.Text{},
+					},
+				},
+			},
+		},
+		{
+			// Verify that the mutateWithEdit helper successfully applies a mutation
+			// to two buffers via an Edit X command.
+			name: "mutateWithEdit",
+			fn:   mutateWithEdit,
+			want: &dumpfile.Content{
+				CurrentDir: cwd,
+				VarFont:    defaultVarFont,
+				FixedFont:  defaultFixedFont,
+				Columns: []dumpfile.Column{
+					{},
+				},
+				Windows: []*dumpfile.Window{
+					{
+						Type:   dumpfile.Unsaved,
+						Column: 0,
+						Tag: dumpfile.Text{
+							Buffer: firstfilename,
+						},
+						Body: dumpfile.Text{
+							Buffer: "This is a\nshort TEXT\nto try addressing\n",
+							Q0:     16,
+							Q1:     20,
+						},
+					},
+					{
+						Type:   dumpfile.Unsaved,
+						Column: 0,
+						Tag: dumpfile.Text{
+							Buffer: secondfilename,
+						},
+						Body: dumpfile.Text{
+							Buffer: "A different TEXT\nWith other contents\nSo there!\n",
+							Q0:     12,
+							Q1:     16,
+						},
+					},
+				},
+			},
+		},
+		{
+			// Having mutated both buffers, Undo one and Redo the other to get back
+			// to the initial mutated state.
+			name: "undoRedoBothMutations",
+			fn:   undoRedoBothMutations,
+			want: &dumpfile.Content{
+				CurrentDir: cwd,
+				VarFont:    defaultVarFont,
+				FixedFont:  defaultFixedFont,
+				Columns: []dumpfile.Column{
+					{},
+				},
+				Windows: []*dumpfile.Window{
+					{
+						Type:   dumpfile.Unsaved,
+						Column: 0,
+						Tag: dumpfile.Text{
+							Buffer: firstfilename + " Del Snarf Undo Put | Look Edit ",
+						},
+						Body: dumpfile.Text{
+							Buffer: "This is a\nshort TEXT\nto try addressing\n",
+							Q0:     16,
+							Q1:     20,
+						},
+					},
+					{
+						Type:   dumpfile.Unsaved,
+						Column: 0,
+						Tag: dumpfile.Text{
+							Buffer: secondfilename + " Del Snarf Undo Put | Look Edit ",
+						},
+						Body: dumpfile.Text{
+							Buffer: "A different TEXT\nWith other contents\nSo there!\n",
+							Q0:     12,
+							Q1:     16,
+						},
+					},
+				},
+			},
+		},
+		{
+			// Having mutated both buffers, further modify the first buffer via Cut
+			// and then undo only the Cut action on the first buffer.
+			name: "mutateBothOneUndo",
+			fn:   mutateBothOneUndo,
+			want: &dumpfile.Content{
+				CurrentDir: cwd,
+				VarFont:    defaultVarFont,
+				FixedFont:  defaultFixedFont,
+				Columns: []dumpfile.Column{
+					{},
+				},
+				Windows: []*dumpfile.Window{
+					{
+						Type:   dumpfile.Unsaved,
+						Column: 0,
+						Tag: dumpfile.Text{
+							Buffer: firstfilename + " Del Snarf Undo Redo Put | Look Edit ",
+						},
+
+						Body: dumpfile.Text{
+							Buffer: "This is a\nshort TEXT\nto try addressing\n",
+							Q0:     3,
+							Q1:     10,
+						},
+					},
+					{
+						Type:   dumpfile.Unsaved,
+						Column: 0,
+						Tag: dumpfile.Text{
+							// TODO(rjk): Why does cut+undo remove the tag contents here? Somewhere
+							// the logic for updating the tags is being weird. This could be a bug in
+							// updating tag contents.
+							Buffer: secondfilename,
+						},
+						Body: dumpfile.Text{
+							Buffer: "A different TEXT\nWith other contents\nSo there!\n",
+							Q0:     12,
+							Q1:     16,
+						},
+					},
+				},
+			},
+		},
+		{
+			// Edit X mutate both buffers, further mutate the first via Cut. Undo on
+			// second buffer. Show that the second buffer returns to the original
+			// contents but that the first buffer's now divergent history is not
+			// affected.
+			name: "mutateBothOtherUndo",
+			fn:   mutateBothOtherUndo,
+			want: &dumpfile.Content{
+				CurrentDir: cwd,
+				VarFont:    defaultVarFont,
+				FixedFont:  defaultFixedFont,
+				Columns: []dumpfile.Column{
+					{},
+				},
+				Windows: []*dumpfile.Window{
+					{
+						Type:   dumpfile.Unsaved,
+						Column: 0,
+						Tag: dumpfile.Text{
+							Buffer: firstfilename,
+						},
+						Body: dumpfile.Text{
+							Buffer: "Thishort TEXT\nto try addressing\n",
+							Q0:     3,
+							Q1:     3,
+						},
+					},
+					{
+						Type:   dumpfile.Saved,
+						Column: 0,
+						Tag: dumpfile.Text{
+							Buffer: secondfilename + " Del Snarf Redo | Look Edit ",
+						},
+						Body: dumpfile.Text{
+							// Original content is elided.
+							Buffer: "",
+							Q0:     12,
+							Q1:     16,
+						},
+					},
+				},
+			},
+		},
+		{
+			// Edit X mutate both buffers and further mutate the first via Cut. Undo
+			// the Edit X on the second buffer and hence diverge the undo history.
+			// Undo Cut and Edit X on the first buffer to return to the same point in
+			// the global undo history in first and second. Redo Edit X on the second
+			// buffer also updates the first window.
+			name: "mutateBranchedAndRejoined",
+			fn:   mutateBranchedAndRejoined,
+			want: &dumpfile.Content{
+				CurrentDir: cwd,
+				VarFont:    defaultVarFont,
+				FixedFont:  defaultFixedFont,
+				Columns: []dumpfile.Column{
+					{},
+				},
+				Windows: []*dumpfile.Window{
+					{
+						Type:   dumpfile.Unsaved,
+						Column: 0,
+						Tag: dumpfile.Text{
+							Buffer: firstfilename + " Del Snarf Undo Redo Put | Look Edit ",
+						},
+						Body: dumpfile.Text{
+							Buffer: "This is a\nshort TEXT\nto try addressing\n",
+							Q0:     16,
+							Q1:     20,
+						},
+					},
+					{
+						Type:   dumpfile.Unsaved,
+						Column: 0,
+						Tag: dumpfile.Text{
+							Buffer: secondfilename + " Del Snarf Undo Put | Look Edit ",
+						},
+						Body: dumpfile.Text{
+							Buffer: "A different TEXT\nWith other contents\nSo there!\n",
+							Q0:     12,
+							Q1:     16,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			makeSkeletonWindowModelWithFiles(t, firstfilename, secondfilename)
+			// Probably there are other issues here...
+			t.Log("seq", global.seq)
+			t.Log("seq, w0", global.row.col[0].w[0].body.file.Seq())
+			t.Log("seq, w1", global.row.col[0].w[1].body.file.Seq())
+
+			tc.fn(t, global)
+
+			t.Log(*varfontflag, defaultVarFont)
+
+			got, err := global.row.dump()
+			if err != nil {
+				t.Fatalf("dump failed: %v", err)
+			}
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("dump mismatch (-want +got):\n%s", diff)
+			}
+
+		})
+	}
+}
+
+// TODO(rjk): consider how to merge this with makeSkeletonWindowModel
+// Use direct access to the global data to walk the datastructure.
+// TODO(rjk): pass in the global to modify.
+func makeSkeletonWindowModelWithFiles(t *testing.T, firstfilename, secondfilename string) {
+	t.Helper()
+	MakeWindowScaffold(&dumpfile.Content{
+		Columns: []dumpfile.Column{
+			{},
+		},
+		Windows: []*dumpfile.Window{
+			{
+				Column: 0,
+				Tag: dumpfile.Text{
+					Buffer: firstfilename,
+				},
+				Body: dumpfile.Text{
+					Buffer: contents,
+				},
+			},
+			{
+				Column: 0,
+				Tag: dumpfile.Text{
+					Buffer: secondfilename,
+				},
+				Body: dumpfile.Text{
+					Buffer: alt_contents,
+				},
+			},
+		},
+	})
+}
+
+func makeTempBackingFiles(t *testing.T, dir string) (string, string) {
+	t.Helper()
+
+	firstfilename := filepath.Join(dir, "firstfile")
+	secondfilename := filepath.Join(dir, "secondfile")
+
+	// Write contents to the files. Use the contents from
+	// makeSkeletonWindowModel to later simplify the task of merging these
+	// together.
+	if err := os.WriteFile(firstfilename, []byte(contents), 0644); err != nil {
+		t.Fatalf("%s can't make %q: %v", "makeTempBackingFiles", firstfilename, err)
+	}
+	if err := os.WriteFile(secondfilename, []byte(alt_contents), 0644); err != nil {
+		t.Fatalf("%s can't make %q: %v", "makeTempBackingFiles", secondfilename, err)
+	}
+	return firstfilename, secondfilename
 }

--- a/file/file.go
+++ b/file/file.go
@@ -13,7 +13,7 @@ import (
 // View-Controller.
 //
 // A File tracks several related concepts. First it is a text buffer with
-// undo/redo back to an initial state. Mark (undo.RuneArray.Commit) notes
+// undo/redo back to an initial state. Mark (file.Buffer.Commit) notes
 // an undo point.
 //
 // Lastly the text buffer might be clean/dirty. A clean buffer is possibly

--- a/file/observable_editable_buffer.go
+++ b/file/observable_editable_buffer.go
@@ -12,9 +12,10 @@ import (
 	"github.com/rjkroege/edwood/util"
 )
 
-// The ObservableEditableBuffer is used by the main program
-// to add, remove and check on the current observer(s) for a Text.
-// Text in turn, implements BufferObserver for the various required callback functions in BufferObserver.
+// The ObservableEditableBuffer is used by the main program to add,
+// remove and check on the current observer(s) for a Text. Text in turn,
+// implements BufferObserver for the various required callback functions
+// in BufferObserver.
 type ObservableEditableBuffer struct {
 	currobserver BufferObserver
 	observers    map[BufferObserver]struct{}
@@ -383,6 +384,8 @@ func (e *ObservableEditableBuffer) Read(q0 int, r []rune) (int, error) {
 
 // String is a forwarding function for rune_array.String.
 // Returns the entire buffer as a string.
+// TODO(rjk): Consider making this aware of the cache. (If test results depend
+// on this not
 func (e *ObservableEditableBuffer) String() string {
 	return e.f.b.String()
 }

--- a/row.go
+++ b/row.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"image"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -356,8 +357,12 @@ func (r *Row) dump() (*dumpfile.Content, error) {
 	dumpid := make(map[*file.ObservableEditableBuffer]int)
 
 	for i, c := range r.col {
+		pos := 100.0 * float64(c.r.Min.X-global.row.r.Min.X) / float64(r.r.Dx())
+		if math.IsNaN(pos) || math.IsInf(pos, 0) {
+			pos = 0.
+		}
 		dump.Columns[i] = dumpfile.Column{
-			Position: 100.0 * float64(c.r.Min.X-global.row.r.Min.X) / float64(r.r.Dx()),
+			Position: pos,
 			Tag: dumpfile.Text{
 				Buffer: c.tag.file.String(),
 				Q0:     c.tag.q0,
@@ -393,6 +398,10 @@ func (r *Row) dump() (*dumpfile.Content, error) {
 			// We always include the font name.
 			fontname := t.font
 
+			pos := 100.0 * float64(w.r.Min.Y-c.r.Min.Y) / float64(c.r.Dy())
+			if math.IsNaN(pos) || math.IsInf(pos, 0) {
+				pos = 0.
+			}
 			dump.Windows = append(dump.Windows, &dumpfile.Window{
 				Column: i,
 				Body: dumpfile.Text{
@@ -400,7 +409,7 @@ func (r *Row) dump() (*dumpfile.Content, error) {
 					Q0:     w.body.q0,
 					Q1:     w.body.q1,
 				},
-				Position: 100.0 * float64(w.r.Min.Y-c.r.Min.Y) / float64(c.r.Dy()),
+				Position: pos,
 				Font:     fontname,
 			})
 			dw := dump.Windows[len(dump.Windows)-1]

--- a/row_test.go
+++ b/row_test.go
@@ -457,6 +457,7 @@ func replacePathsForTesting(t *testing.T, b []byte, isJSON bool) []byte {
 		escape = func(s string) string { return s }
 	}
 
+	// TODO(rjk): Doesn't fix up the positions if the length of the path has changed.
 	b = bytes.Replace(b, []byte(gd+"/"),
 		[]byte(escape(d+string(filepath.Separator))), -1)
 	b = bytes.Replace(b, []byte(gd),

--- a/rowmock_test.go
+++ b/rowmock_test.go
@@ -24,7 +24,6 @@ func configureGlobals() {
 
 	// Set up Undo to make sure that we see undoable results.
 	// By default, post-load, file.seq, file.putseq = 0, 0.
-	global.seq = 1
 }
 
 // updateText creates a minimal mock Text object from data embedded inside


### PR DESCRIPTION
Partially address #383 by adding a more comprehensive row, col, wind, text, oeb test fixture and demonstrate that Undo/Redo history sequences correctly diverge and rejoin across a pair of different Window instances.
