### PR TITLE
Update the Go version used in the CI

### DIFF
--- a/.github/workflows/edwood.yml
+++ b/.github/workflows/edwood.yml
@@ -7,7 +7,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.14.x, 1.15.x]
+        go-version: [1.16.x, 1.17.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/acme_debug.go
+++ b/acme_debug.go
@@ -1,3 +1,4 @@
+//go:build debug
 // +build debug
 
 package main

--- a/acme_nodebug.go
+++ b/acme_nodebug.go
@@ -1,3 +1,4 @@
+//go:build !debug
 // +build !debug
 
 // We get a smaller binary by not importing net/http/pprof.

--- a/acme_p9p.go
+++ b/acme_p9p.go
@@ -1,3 +1,4 @@
+//go:build (darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris) && !duitdraw
 // +build darwin dragonfly freebsd linux netbsd openbsd solaris
 // +build !duitdraw
 

--- a/acme_plan9.go
+++ b/acme_plan9.go
@@ -1,3 +1,4 @@
+//go:build plan9
 // +build plan9
 
 package main

--- a/acme_unix.go
+++ b/acme_unix.go
@@ -1,3 +1,4 @@
+//go:build (darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris) && duitdraw
 // +build darwin dragonfly freebsd linux netbsd openbsd solaris
 // +build duitdraw
 

--- a/acme_windows.go
+++ b/acme_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package main

--- a/draw/9fans.go
+++ b/draw/9fans.go
@@ -1,3 +1,4 @@
+//go:build !duitdraw && !windows
 // +build !duitdraw,!windows
 
 package draw

--- a/draw/duitdraw.go
+++ b/draw/duitdraw.go
@@ -1,3 +1,4 @@
+//go:build duitdraw || windows
 // +build duitdraw windows
 
 package draw

--- a/dumpfile/legacy_parse_cases_test.go
+++ b/dumpfile/legacy_parse_cases_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package dumpfile

--- a/fsys_p9p.go
+++ b/fsys_p9p.go
@@ -1,3 +1,4 @@
+//go:build (darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris) && !mux9p
 // +build darwin dragonfly freebsd linux netbsd openbsd solaris
 // +build !mux9p
 

--- a/fsys_unix.go
+++ b/fsys_unix.go
@@ -1,3 +1,4 @@
+//go:build (darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris) && mux9p
 // +build darwin dragonfly freebsd linux netbsd openbsd solaris
 // +build mux9p
 

--- a/look_posix.go
+++ b/look_posix.go
@@ -1,3 +1,4 @@
+//go:build !plan9
 // +build !plan9
 
 package main


### PR DESCRIPTION
We can use a newer Go than 1.14. Support current and last version.
