### PR TITLE
Improved TestRowLoad tolerance for alternate pathing

### DIFF
--- a/row_test.go
+++ b/row_test.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"9fans.net/go/plan9"
 	"9fans.net/go/plan9/client"
@@ -176,6 +177,7 @@ func TestRowLoad(t *testing.T) {
 
 // checkDump checks Edwood's current state (got) matches loaded dump file content (want).
 func checkDump(t *testing.T, got, want *dumpfile.Content) {
+	t.Helper()
 	// Ignore some mismatch. Positions may not match exactly.
 	// Window tags may get "Put" added or "Undo" removed, and
 	// because of the change in the tag, selection within the tag may not match.
@@ -188,6 +190,7 @@ func checkDump(t *testing.T, got, want *dumpfile.Content) {
 	}
 	for i, w := range want.Windows {
 		g := got.Windows[i]
+		t.Logf("[%d], %+v", i, g)
 		if math.Abs(g.Position-w.Position) < 10 {
 			g.Position = w.Position
 		}
@@ -208,6 +211,16 @@ func checkDump(t *testing.T, got, want *dumpfile.Content) {
 		if w := strings.Fields(g.Tag.Buffer); len(w) > 0 {
 			name = w[0]
 		}
+
+		// setTag1 (executed inside of Load) will (correctly) adjust the text
+		// selection to be within a valid range for the buffer.
+		if nr := utf8.RuneCountInString(g.Tag.Buffer); w.Tag.Q0 > nr {
+			w.Tag.Q0 = nr
+		}
+		if nr := utf8.RuneCountInString(g.Tag.Buffer); w.Tag.Q1 > nr {
+			w.Tag.Q1 = nr
+		}
+
 		if n := len(name); n > 0 && name[n-1] == filepath.Separator { // is directory
 			g.Tag.Q0 = w.Tag.Q0
 			g.Tag.Q1 = w.Tag.Q1

--- a/wind.go
+++ b/wind.go
@@ -123,7 +123,7 @@ func (w *Window) Init(clone *Window, r image.Rectangle, dis draw.Display) {
 		clonebuff := []rune(clone.tag.file.String())
 		w.tag.Insert(0, clonebuff, true)
 		w.tag.file.Reset()
-		w.tag.SetSelect(w.tag.file.Nbyte(), w.tag.file.Nbyte())
+		w.tag.SetSelect(w.tag.Nc(), w.tag.Nc())
 	}
 	r1 = r
 	r1.Min.Y += w.taglines*fontget(global.tagfont, w.display).Height() + 1
@@ -519,20 +519,20 @@ func (w *Window) setTag1() {
 		sb.WriteString(" ")
 	}
 
-	new := []rune(sb.String())
+	newtag := []rune(sb.String())
 
 	// replace tag if the new one is different
 	resize := false
-	if !runes.Equal(new, []rune(w.tag.file.String())) {
+	if !runes.Equal(newtag, []rune(w.tag.file.String())) {
 		resize = true // Might need to resize the tag
 		// try to preserve user selection
-		newbarIndex := runes.IndexRune(new, '|') // New always has '|'
+		newbarIndex := runes.IndexRune(newtag, '|') // New always has '|'
 		q0 := w.tag.q0
 		q1 := w.tag.q1
 
 		// These alter the Text's selection values.
 		w.tag.Delete(0, w.tag.Nc(), true)
-		w.tag.Insert(0, new, true)
+		w.tag.Insert(0, newtag, true)
 
 		// Rationalize the selection as best as possible
 		w.tag.q0 = util.Min(q0, w.tag.Nc())


### PR DESCRIPTION
TestRowLoad is fragile to pathing differences between the local
directory and test data when the local directory paths are shorter (in
runes). Fix this and a few other issues seen along the way.
