### PR TITLE
Don't pollute edwood's environment when calling out.

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -936,6 +936,7 @@ func runproc(win *Window, s string, dir string, newns bool, argaddr string, arg 
 	}
 	c.iseditcommand = iseditcmd
 	c.text = s
+	env := os.Environ()
 	if newns {
 		if win != nil {
 			// Access possibly mutable Window state inside a lock.
@@ -953,11 +954,11 @@ func runproc(win *Window, s string, dir string, newns bool, argaddr string, arg 
 		}
 		// 	rfork(RFNAMEG|RFENVG|RFFDG|RFNOTEG); TODO(flux): I'm sure these settings are important
 
-		os.Setenv("winid", fmt.Sprintf("%d", winid))
+		env = append(env, fmt.Sprintf("winid=%d", winid))
 
 		if filename != "" {
-			os.Setenv("%", filename)
-			os.Setenv("samfile", filename)
+			env = append(env, fmt.Sprint("%%=%v", filename))
+			env = append(env, fmt.Sprint("samfile=%v", filename))
 		}
 		var fs *client.Fsys
 		var err error
@@ -1002,7 +1003,7 @@ func runproc(win *Window, s string, dir string, newns bool, argaddr string, arg 
 	}
 
 	if argaddr != "" {
-		os.Setenv("acmeaddr", argaddr)
+		env = append(env, fmt.Sprint("acmeaddr=%v", argaddr))
 	}
 	if global.acmeshell != "" {
 		return Hard()
@@ -1032,6 +1033,7 @@ func runproc(win *Window, s string, dir string, newns bool, argaddr string, arg 
 	cmd.Stdin = sin
 	cmd.Stdout = sout
 	cmd.Stderr = serr
+	cmd.Env = env
 	err := cmd.Start()
 	if err != nil {
 		Fail()

--- a/exec.go
+++ b/exec.go
@@ -957,8 +957,8 @@ func runproc(win *Window, s string, dir string, newns bool, argaddr string, arg 
 		env = append(env, fmt.Sprintf("winid=%d", winid))
 
 		if filename != "" {
-			env = append(env, fmt.Sprint("%%=%v", filename))
-			env = append(env, fmt.Sprint("samfile=%v", filename))
+			env = append(env, fmt.Sprintf("%%=%v", filename))
+			env = append(env, fmt.Sprintf("samfile=%v", filename))
 		}
 		var fs *client.Fsys
 		var err error
@@ -1003,7 +1003,7 @@ func runproc(win *Window, s string, dir string, newns bool, argaddr string, arg 
 	}
 
 	if argaddr != "" {
-		env = append(env, fmt.Sprint("acmeaddr=%v", argaddr))
+		env = append(env, fmt.Sprintf("acmeaddr=%v", argaddr))
 	}
 	if global.acmeshell != "" {
 		return Hard()

--- a/exec_test.go
+++ b/exec_test.go
@@ -31,30 +31,34 @@ func TestRunproc(t *testing.T) {
 	}
 	tt := []struct {
 		hard      bool
+		newns  bool
 		startfail bool
 		waitfail  bool
 		s, arg    string
 	}{
-		{false, true, true, "", ""},
-		{false, true, true, " ", ""},
-		{false, true, true, "   ", "   "},
-		{false, false, false, "ls", ""},
-		{false, false, false, "ls .", ""},
-		{false, false, false, " ls . ", ""},
-		{false, false, false, "	 ls	 .	 ", ""},
-		{false, false, false, "ls", "."},
-		{false, false, false, "|ls", "."},
-		{false, false, false, "<ls", "."},
-		{false, false, false, ">ls", "."},
-		{false, true, true, "nonexistentcommand", ""},
+		{false, false, true, true, "", ""},
+		{false, false, true, true, " ", ""},
+		{false, false, true, true, "   ", "   "},
+		{false, false, false, false, "ls", ""},
+		{false, false, false, false, "ls .", ""},
+		{false, false, false, false, " ls . ", ""},
+		{false, false, false, false, "	 ls	 .	 ", ""},
+		{false, false, false, false, "ls", "."},
+		{false, false, false, false, "|ls", "."},
+		{false, false, false, false, "<ls", "."},
+		{false, false, false, false, ">ls", "."},
+		{false, false, true, true, "nonexistentcommand", ""},
+
+		// Execute the newns path
+		{false, true, false, false, "echo", "$winid"},
 
 		// Hard: must be executed using a shell
-		{true, false, false, "ls '.'", ""},
-		{true, false, false, " ls '.' ", ""},
-		{true, false, false, "	 ls	 '.'	 ", ""},
-		{true, false, false, "ls '.'", "."},
-		{true, false, true, "dat\x08\x08ate", ""},
-		{true, false, true, "/non-existent-command", ""},
+		{true, false, false, false, "ls '.'", ""},
+		{true, false, false, false, " ls '.' ", ""},
+		{true, false, false, false, "	 ls	 '.'	 ", ""},
+		{true, false, false, false, "ls '.'", "."},
+		{true, false, false, true, "dat\x08\x08ate", ""},
+		{true, false, false, true, "/non-existent-command", ""},
 	}
 	acmeTestingMain()
 
@@ -70,7 +74,7 @@ func TestRunproc(t *testing.T) {
 		cpid := make(chan *os.Process)
 		done := make(chan struct{})
 		go func() {
-			err := runproc(nil, tc.s, "", false, "", tc.arg, &Command{}, cpid, false)
+			err := runproc(nil, tc.s, "", tc.newns, "", tc.arg, &Command{}, cpid, false)
 			if tc.startfail && err == nil {
 				t.Errorf("expected command %q to fail", tc.s)
 			}

--- a/exec_test.go
+++ b/exec_test.go
@@ -49,9 +49,6 @@ func TestRunproc(t *testing.T) {
 		{false, false, false, false, ">ls", "."},
 		{false, false, true, true, "nonexistentcommand", ""},
 
-		// Execute the newns path
-		{false, true, false, false, "ls", "$winid"},
-
 		// Hard: must be executed using a shell
 		{true, false, false, false, "ls '.'", ""},
 		{true, false, false, false, " ls '.' ", ""},
@@ -59,6 +56,9 @@ func TestRunproc(t *testing.T) {
 		{true, false, false, false, "ls '.'", "."},
 		{true, false, false, true, "dat\x08\x08ate", ""},
 		{true, false, false, true, "/non-existent-command", ""},
+
+		// Execute the newns path
+		{true, true, false, false, "ls", ""},
 	}
 	acmeTestingMain()
 

--- a/exec_test.go
+++ b/exec_test.go
@@ -58,7 +58,7 @@ func TestRunproc(t *testing.T) {
 		{true, false, false, true, "/non-existent-command", ""},
 
 		// Execute the newns path
-		{true, true, false, false, "ls", ""},
+		{true, true, false, false, "ls '.'", ""},
 	}
 	acmeTestingMain()
 

--- a/exec_test.go
+++ b/exec_test.go
@@ -50,7 +50,7 @@ func TestRunproc(t *testing.T) {
 		{false, false, true, true, "nonexistentcommand", ""},
 
 		// Execute the newns path
-		{false, true, false, false, "echo", "$winid"},
+		{false, true, false, false, "ls", "$winid"},
 
 		// Hard: must be executed using a shell
 		{true, false, false, false, "ls '.'", ""},


### PR DESCRIPTION
Both Acme and Edwood pollute the environment by setting environment variable directly before calling external tools.  In the case of $acmeaddr this isn't undone and leads to false detection of chording in scripts.
This fix builds a correct environment to call out with, replicating the parent environment and addeing winid, %, samfile, and acmeaddr only to the child process.
