### PR TITLE
robhacks on cam

### DIFF
--- a/dumpfile/legacy_parse_test.go
+++ b/dumpfile/legacy_parse_test.go
@@ -261,7 +261,7 @@ func TestLegacyLoad(t *testing.T) {
 			parseerror: "",
 		},
 
-		// TODO(rjk): Insert some error handling test cases.
+		// TODO(rjk): InsertWithNr some error handling test cases.
 
 	}...)
 

--- a/file/file_test.go
+++ b/file/file_test.go
@@ -153,7 +153,7 @@ func TestFileUndoRedoWithMark(t *testing.T) {
 func TestFileLoadNoUndo(t *testing.T) {
 	f := MakeObservableEditableBuffer("edwood", nil)
 
-	// Insert some pre-existing content.
+	// InsertWithNr some pre-existing content.
 	f.InsertAt(0, []rune(s1))
 
 	buffy := bytes.NewBuffer([]byte(s2 + s2))

--- a/file/offset_tuple.go
+++ b/file/offset_tuple.go
@@ -2,5 +2,5 @@ package file
 
 type OffSetTuple struct {
 	b int64
-	r int32
+	r int64
 }

--- a/file/offset_tuple.go
+++ b/file/offset_tuple.go
@@ -1,0 +1,6 @@
+package file
+
+type OffSetTuple struct {
+	b int64
+	r int32
+}

--- a/file/offset_tuple.go
+++ b/file/offset_tuple.go
@@ -1,6 +1,22 @@
 package file
 
+import (
+	"fmt"
+)
+
 type OffSetTuple struct {
 	b int64
 	r int64
+}
+
+// can work this api to be a little better...
+func (o OffSetTuple) add(b, r int64) OffSetTuple {
+	return OffSetTuple {
+		b: o.b + b,
+		r: o.r + r,
+	}
+}
+
+func (o OffSetTuple) String() string {
+	return fmt.Sprintf("offsettuple b: %d r: %d", o.b, o.r)
 }

--- a/file/rune_array.go
+++ b/file/rune_array.go
@@ -15,7 +15,7 @@ func NewRuneArray() RuneArray { return []rune{} }
 
 func (b *RuneArray) Insert(q0 int, r []rune) {
 	if q0 > len(*b) {
-		panic("internal error: buffer.Insert: Out of range insertion")
+		panic("internal error: buffer.InsertWithNr: Out of range insertion")
 	}
 	*b = append((*b)[:q0], append(r, (*b)[q0:]...)...)
 }

--- a/file/rune_array_test.go
+++ b/file/rune_array_test.go
@@ -42,7 +42,7 @@ func TestBufferInsert(t *testing.T) {
 		tb := test.tb
 		tb.Insert(test.q0, []rune(test.insert))
 		if string(tb) != test.expected {
-			t.Errorf("Insert Failed.  Expected %v, got %v", test.expected, string(tb))
+			t.Errorf("InsertWithNr Failed.  Expected %v, got %v", test.expected, string(tb))
 		}
 	}
 }

--- a/file/undo.go
+++ b/file/undo.go
@@ -459,6 +459,15 @@ func (b *Buffer) Size() int64 {
 	return size
 }
 
+// Nr returns the sum of the Nr for each piece in the buffer.
+func (b *Buffer) Nr() int64 {
+	var nr int
+	for p := b.begin; p != nil; p = p.next {
+		nr += p.nr
+	}
+	return int64(nr)
+}
+
 // action is a list of changes which are used to undo/redo all modifications.
 type action struct {
 	changes []*change

--- a/file/undo.go
+++ b/file/undo.go
@@ -259,6 +259,7 @@ func (b *Buffer) Delete(off, length int64) error {
 		copy(newBuf, start.data[:offset])
 		before.data = newBuf
 		before.prev, before.next = start.prev, after
+		before.nr = utf8.RuneCount(start.data[:offset])
 
 		newStart = before
 		if !midwayEnd {

--- a/file/undo.go
+++ b/file/undo.go
@@ -138,9 +138,9 @@ func NewBufferNoNr(content []byte) *Buffer {
 	return NewBuffer(content, utf8.RuneCount(content))
 }
 
-// Insert inserts the data at the given offset in the buffer. An error is return when the
+// InsertWithNr inserts the data at the given offset in the buffer. An error is return when the
 // given offset is invalid.
-func (b *Buffer) Insert(off int64, data []byte, nr int) error {
+func (b *Buffer) InsertWithNr(off int64, data []byte, nr int) error {
 	b.treatasclean = false
 	if len(data) == 0 {
 		return nil
@@ -158,13 +158,13 @@ func (b *Buffer) Insert(off int64, data []byte, nr int) error {
 	c := b.newChange(off)
 	var pnew *piece
 	if offset == p.len() {
-		// Insert between two existing pieces, hence there is nothing to
+		// InsertWithNr between two existing pieces, hence there is nothing to
 		// remove, just add a new piece holding the extra text.
 		pnew = b.newPiece(data, p, p.next, nr)
 		c.new = newSpan(pnew, pnew)
 		c.old = newSpan(nil, nil)
 	} else {
-		// Insert into middle of an existing piece, therefore split the old
+		// InsertWithNr into middle of an existing piece, therefore split the old
 		// piece. That is we have 3 new pieces one containing the content
 		// before the insertion point then one holding the newly inserted
 		// text and one holding the content after the insertion point.
@@ -184,8 +184,8 @@ func (b *Buffer) Insert(off int64, data []byte, nr int) error {
 	return nil
 }
 
-func (b *Buffer) InsertNoNr(off int64, data []byte) error {
-	return b.Insert(off, data, utf8.RuneCount(data))
+func (b *Buffer) Insert(off int64, data []byte) error {
+	return b.InsertWithNr(off, data, utf8.RuneCount(data))
 }
 
 // Delete deletes the portion of the length at the given offset. An error is returned

--- a/file/undo.go
+++ b/file/undo.go
@@ -339,11 +339,11 @@ func (b *Buffer) findPiece(off int64) (p *piece, offset int) {
 // at which the first change of the action occurred and the number of bytes
 // the change added at off. If there is no action to undo, Undo returns -1
 // as the offset.
-func (b *Buffer) Undo() ChangeInfo {
+func (b *Buffer) Undo() (int64, int64) {
 	b.Commit()
 	a := b.unshiftAction()
 	if a == nil {
-		return ChangeInfo{Off: -1, Size: 0}
+		return -1, 0
 	}
 
 	var off, size int64
@@ -356,8 +356,7 @@ func (b *Buffer) Undo() ChangeInfo {
 		size = c.old.len - c.new.len
 		nR -= c.new.Nr() - c.old.Nr()
 	}
-	nonAscii, width := b.FindNewNonAscii()
-	return ChangeInfo{Off: off, Size: int(size), Nr: nR, NonAscii: nonAscii, Width: width}
+	return off, size
 }
 
 func (b *Buffer) unshiftAction() *action {
@@ -372,11 +371,11 @@ func (b *Buffer) unshiftAction() *action {
 // at which the last change of the action occurred and the number of bytes
 // the change added at off. If there is no action to redo, Redo returns -1
 // as the offset.
-func (b *Buffer) Redo() ChangeInfo {
+func (b *Buffer) Redo() (int64, int64) {
 	b.Commit()
 	a := b.shiftAction()
 	if a == nil {
-		return ChangeInfo{Off: -1, Size: 0}
+		return -1, 0
 	}
 
 	var nR int
@@ -388,8 +387,7 @@ func (b *Buffer) Redo() ChangeInfo {
 		nR -= c.new.Nr() - c.old.Nr()
 		size = c.new.len - c.old.len
 	}
-	nonAscii, width := b.FindNewNonAscii()
-	return ChangeInfo{Off: off, Size: int(size), Nr: nR, NonAscii: nonAscii, Width: width}
+	return off, size
 }
 
 func (b *Buffer) shiftAction() *action {

--- a/file/undo.go
+++ b/file/undo.go
@@ -233,8 +233,6 @@ func (b *Buffer) Delete(off, length int64) error {
 			break
 		}
 		p = p.next
-		if p == nil {
-		}
 		cur += int64(p.len())
 	}
 

--- a/file/undo.go
+++ b/file/undo.go
@@ -255,7 +255,7 @@ func (b *Buffer) Delete(startOff, endOff OffSetTuple) error {
 		copy(newBuf, start.data[:offset])
 		before.data = newBuf
 		before.prev, before.next = start.prev, after
-		before.nr = utf8.RuneCount(start.data[:offset])
+		before.nr = utf8.RuneCount(newBuf)
 
 		newStart = before
 		if !midwayEnd {
@@ -602,7 +602,7 @@ func (s *span) Nr() int {
 	var nr int
 
 	for p := s.start; p != nil; p = p.next {
-		nr += utf8.RuneCount(p.data)
+		nr += p.nr
 		if p == s.end {
 			break
 		}

--- a/file/undo.go
+++ b/file/undo.go
@@ -86,7 +86,6 @@ import (
 	"errors"
 	"io"
 	"time"
-	"unicode"
 	"unicode/utf8"
 )
 
@@ -578,25 +577,4 @@ func (s *span) Nr() int {
 		}
 	}
 	return nr
-}
-
-func (b *Buffer) FindNewNonAscii() (int, int) {
-	for p := b.begin; p != nil; p = p.next {
-		if p.len() > p.nr {
-			return p.FirstNonAscii()
-		}
-	}
-	return -1, 1
-}
-
-func (p *piece) FirstNonAscii() (int, int) {
-	var nonAscii, width int
-	for i := range p.data {
-		if p.data[i] > unicode.MaxASCII {
-			_, width = utf8.DecodeRune(p.data[i:])
-			nonAscii = i
-			return nonAscii, width
-		}
-	}
-	return -1, 1
 }

--- a/file/undo.go
+++ b/file/undo.go
@@ -131,10 +131,6 @@ func NewBuffer(content []byte, nr int) *Buffer {
 	return t
 }
 
-func NewBufferNoNr(content []byte) *Buffer {
-	return NewBuffer(content, utf8.RuneCount(content))
-}
-
 // InsertWithNr inserts the data at the given offset in the buffer. An error is return when the
 // given offset is invalid.
 func (b *Buffer) InsertWithNr(off int64, data []byte, nr int) error {

--- a/file/undo_test.go
+++ b/file/undo_test.go
@@ -271,7 +271,7 @@ func TestUndoRedoReturnedOffsets(t *testing.T) {
 
 	undo, redo := (*Buffer).Undo, (*Buffer).Redo
 	tests := []struct {
-		op      func(*Buffer) ChangeInfo
+		op      func(*Buffer) (int64, int64)
 		wantOff int64
 		wantN   int64
 	}{
@@ -293,8 +293,7 @@ func TestUndoRedoReturnedOffsets(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		info := tt.op(b)
-		off, n := info.Off, int64(info.Size)
+		off, n := tt.op(b)
 		if off != tt.wantOff {
 			t.Errorf("%d: got offset %d, want %d", i, off, tt.wantOff)
 		}
@@ -321,7 +320,7 @@ func TestPieceNr(t *testing.T) {
 
 	undo, redo := (*Buffer).Undo, (*Buffer).Redo
 	tests := []struct {
-		op func(*Buffer) ChangeInfo
+		op func(*Buffer) (int64, int64)
 	}{
 		0:  {redo},
 		1:  {undo},

--- a/file/undo_test.go
+++ b/file/undo_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func TestOverall(t *testing.T) {

--- a/file/undo_test.go
+++ b/file/undo_test.go
@@ -312,11 +312,22 @@ func TestPieceNr(t *testing.T) {
 	eng3 := []byte("In the midst")
 
 	b.Insert(0, manderianBytes)
+	b.checkContent("TestPieceNr: First insert", t, string(manderianBytes))
+
 	b.Insert(b.Nr(), eng1)
+	b.checkContent("TestPieceNr: Second insert", t, string(eng1)+string(manderianBytes))
+
 	b.Insert(0, eng2)
+	buffAfterInserts := string(eng2) + string(eng1) + string(manderianBytes)
+	b.checkContent("TestPieceNr: third insert", t, buffAfterInserts)
 
 	b.Delete(13, 10)
+	buffAfterDelete := buffAfterInserts[:13] + buffAfterInserts[23:]
+	b.checkContent("TestPieceNr: after 1 delete", t, buffAfterDelete)
+
 	b.Insert(8, eng3)
+	buffAfterDelete = buffAfterDelete[:8] + string(eng3) + buffAfterDelete[8:]
+	b.checkContent("TestPieceNr: after everything", t, buffAfterDelete)
 
 	undo, redo := (*Buffer).Undo, (*Buffer).Redo
 	tests := []struct {
@@ -420,4 +431,8 @@ func (t *Buffer) allContent() string {
 
 func countRunes(b *Buffer) int64 {
 	return int64(utf8.RuneCount(b.Bytes()))
+}
+
+func NewBufferNoNr(content []byte) *Buffer {
+	return NewBuffer(content, utf8.RuneCount(content))
 }

--- a/file/undo_test.go
+++ b/file/undo_test.go
@@ -315,19 +315,20 @@ func TestPieceNr(t *testing.T) {
 	b.checkContent("TestPieceNr: First insert", t, string(manderianBytes))
 
 	b.Insert(b.Nr(), eng1)
-	b.checkContent("TestPieceNr: Second insert", t, string(eng1)+string(manderianBytes))
+	b.checkContent("TestPieceNr: Second insert", t, string(manderianBytes)+string(eng1))
 
 	b.Insert(0, eng2)
-	buffAfterInserts := string(eng2) + string(eng1) + string(manderianBytes)
-	b.checkContent("TestPieceNr: third insert", t, buffAfterInserts)
+	buffAfterInserts := string(eng2) + string(manderianBytes) + string(eng1)
+	b.checkContent("TestPieceNr: third insert", t, buffAfterInserts+"extra")
 
 	b.Delete(13, 10)
-	buffAfterDelete := buffAfterInserts[:13] + buffAfterInserts[23:]
-	b.checkContent("TestPieceNr: after 1 delete", t, buffAfterDelete)
+	buffAfterDelete := []rune(buffAfterInserts)
+	buffAfterDelete = append(buffAfterDelete[:13], buffAfterDelete[23:]...)
+	b.checkContent("TestPieceNr: after 1 delete", t, string(buffAfterDelete))
 
 	b.Insert(8, eng3)
-	buffAfterDelete = buffAfterDelete[:8] + string(eng3) + buffAfterDelete[8:]
-	b.checkContent("TestPieceNr: after everything", t, buffAfterDelete)
+	buffAfterDelete = append(buffAfterDelete[:8], append([]rune(string(eng3)), buffAfterDelete[8:]...)...)
+	b.checkContent("TestPieceNr: after everything", t, string(buffAfterDelete))
 
 	undo, redo := (*Buffer).Undo, (*Buffer).Redo
 	tests := []struct {

--- a/file/undo_test.go
+++ b/file/undo_test.go
@@ -324,6 +324,7 @@ func TestPieceNr(t *testing.T) {
 	b.Delete(13, 10)
 	buffAfterDelete := []rune(buffAfterInserts)
 	buffAfterDelete = append(buffAfterDelete[:13], buffAfterDelete[23:]...)
+	fmt.Printf("Len of buff before: %v, Length of buff after: %v\n", len([]byte(string(buffAfterDelete))), len(buffAfterInserts)) // Should be a difference of 10
 	b.checkContent("TestPieceNr: after 1 delete", t, string(buffAfterDelete))
 
 	b.Insert(8, eng3)

--- a/file/undo_test.go
+++ b/file/undo_test.go
@@ -319,7 +319,7 @@ func TestPieceNr(t *testing.T) {
 
 	b.Insert(0, eng2)
 	buffAfterInserts := string(eng2) + string(manderianBytes) + string(eng1)
-	b.checkContent("TestPieceNr: third insert", t, buffAfterInserts+"extra")
+	b.checkContent("TestPieceNr: third insert", t, buffAfterInserts)
 
 	b.Delete(13, 10)
 	buffAfterDelete := []rune(buffAfterInserts)

--- a/frame/insert.go
+++ b/frame/insert.go
@@ -132,9 +132,9 @@ func (f *frameimpl) insertimpl(r []rune, p0 int) bool {
 	// log.Printf("frame.Insert. Start: %s", string(r))
 	// defer log.Println("frame.Insert end")
 	//	f.Logboxes("at very start of insert")
-	f.validateboxmodel("Frame.Insert Start p0=%d, «%s»", p0, string(r))
-	defer f.validateboxmodel("Frame.Insert End p0=%d, «%s»", p0, string(r))
-	f.validateinputs(r, "Frame.Insert Start")
+	f.validateboxmodel("Frame.InsertWithNr Start p0=%d, «%s»", p0, string(r))
+	defer f.validateboxmodel("Frame.InsertWithNr End p0=%d, «%s»", p0, string(r))
+	f.validateinputs(r, "Frame.InsertWithNr Start")
 
 	if p0 > f.nchars || len(r) == 0 || f.background == nil {
 		return f.lastlinefull
@@ -189,7 +189,7 @@ func (f *frameimpl) insertimpl(r []rune, p0 int) bool {
 		pt1 = f.cklinewrap0(pt1, b)
 		if pt1.Y > f.rect.Max.Y {
 			f.Logboxes("-- pt1 violated invariant at box --")
-			panic(fmt.Sprint("frame.Insert pt1 too far", " pt1=", pt1, " box=", b))
+			panic(fmt.Sprint("frame.InsertWithNr pt1 too far", " pt1=", pt1, " box=", b))
 		}
 
 		if b.Nrune > 0 {
@@ -215,8 +215,8 @@ func (f *frameimpl) insertimpl(r []rune, p0 int) bool {
 	}
 
 	if pt1.Y > f.rect.Max.Y {
-		nframe.validateboxmodel("frame.Insert pt1 too far, nframe validation, %v", pt1)
-		panic("frame.Insert pt1 too far")
+		nframe.validateboxmodel("frame.InsertWithNr pt1 too far, nframe validation, %v", pt1)
+		panic("frame.InsertWithNr pt1 too far")
 	}
 	if pt1.Y == f.rect.Max.Y && n0 < len(f.box) {
 		f.nchars -= f.strlen(n0)
@@ -365,7 +365,7 @@ func (f *frameimpl) validateinputs(runes []rune, format string, args ...interfac
 		if r == 0x00 { // Nulls in input string are forbidden.
 			log.Printf(format, args...)
 			log.Printf("r[%d] null", i)
-			panic("-- invalid input to Frame.Insert --")
+			panic("-- invalid input to Frame.InsertWithNr --")
 		}
 	}
 }

--- a/sam/elog_test.go
+++ b/sam/elog_test.go
@@ -43,7 +43,7 @@ func TestInsert(t *testing.T) {
 		tb := test.tb
 		tb.Insert(test.q0, []rune(test.insert), true)
 		if string(tb.buf) != test.expected {
-			t.Errorf("Insert Failed.  Expected %v, got %v", test.expected, string(tb.buf))
+			t.Errorf("InsertWithNr Failed.  Expected %v, got %v", test.expected, string(tb.buf))
 		}
 	}
 }

--- a/text.go
+++ b/text.go
@@ -1070,7 +1070,7 @@ func (t *Text) FrameScroll(fr frame.SelectScrollUpdater, dl int) {
 		}
 		q0 = t.org + fr.Charofpt(image.Pt(fr.Rect().Min.X, fr.Rect().Min.Y+dl*fr.DefaultFontHeight()))
 	}
-	// Insert text into the frame.
+	// InsertWithNr text into the frame.
 	t.setorigin(fr, q0, true, true)
 }
 


### PR DESCRIPTION
- Pieces now have Nr that they store.
- Refactored the undo tests to use the Nr-less constructor
- Removed empty branch
- Refactored so that the original Nr-less Insert is called Insert.
- Added Nr function to get the total number of runes in the underlying buffer
- Fixed delete
- Added test for Nr
- Imported utf8
- Removed ChangeInfo
- Removed mod and treatasclean
- Added the OffsetTuple
- Added a decent test for the edge cases of undo with NR
- Updated the test to use runes
- Finalized test updates
- Moved test function
- Removed extra functions
- Got the OffsetTuple functions working
- Insert is working delete is not.
- [not to be landed] Making more tests work in file.Buffer
