### PR TITLE
Observer-driven tag updates

### DIFF
--- a/exec_test.go
+++ b/exec_test.go
@@ -236,9 +236,12 @@ func testSetupOnly(t *testing.T, g *globals) {
 
 	t.Log("Before seq", global.seq)
 	t.Log("firstwin.body.file.Seq", g.row.col[0].w[0].body.file.Seq())
+	t.Log("firstwin.tag", firstwin.tag.DebugString())
 	t.Log("firstwin.body.file.HasUndoableChanges", g.row.col[0].w[0].body.file.HasUndoableChanges())
 	t.Log("secondwin.body.file.Seq", g.row.col[0].w[1].body.file.Seq())
+	t.Log("secondwin.tag", secondwin.tag.DebugString())
 	t.Log("secondwin.body.file.HasUndoableChanges", g.row.col[0].w[1].body.file.HasUndoableChanges())
+	t.Log("firstwin.tag", firstwin.tag.DebugString())
 
 	// These should both do nothing.
 	undo(&firstwin.tag, nil, nil, true /* this is an undo */, false /* ignored */, "")
@@ -246,8 +249,10 @@ func testSetupOnly(t *testing.T, g *globals) {
 
 	t.Log("After seq", global.seq)
 	t.Log("firstwin.body.file.Seq", g.row.col[0].w[0].body.file.Seq())
+	t.Log("firstwin.tag", firstwin.tag.DebugString())
 	t.Log("firstwin.body.file.HasUndoableChanges", g.row.col[0].w[0].body.file.HasUndoableChanges())
 	t.Log("secondwin.body.file.Seq", g.row.col[0].w[1].body.file.Seq())
+	t.Log("secondwin.tag", secondwin.tag.DebugString())
 	t.Log("secondwin.body.file.HasUndoableChanges", g.row.col[0].w[1].body.file.HasUndoableChanges())
 }
 
@@ -388,7 +393,7 @@ func TestUndoRedo(t *testing.T) {
 						Type:   dumpfile.Saved,
 						Column: 0,
 						Tag: dumpfile.Text{
-							Buffer: firstfilename,
+							Buffer: firstfilename + " Del Snarf | Look Edit ",
 						},
 						// Recall that when the contents match the on-disk state,
 						// they are elided.
@@ -398,7 +403,7 @@ func TestUndoRedo(t *testing.T) {
 						Type:   dumpfile.Saved,
 						Column: 0,
 						Tag: dumpfile.Text{
-							Buffer: secondfilename,
+							Buffer: secondfilename + " Del Snarf | Look Edit ",
 						},
 						Body: dumpfile.Text{},
 					},
@@ -422,7 +427,7 @@ func TestUndoRedo(t *testing.T) {
 						Type:   dumpfile.Unsaved,
 						Column: 0,
 						Tag: dumpfile.Text{
-							Buffer: firstfilename,
+							Buffer: firstfilename + " Del Snarf Undo Put | Look Edit ",
 						},
 						Body: dumpfile.Text{
 							Buffer: "This is a\nshort TEXT\nto try addressing\n",
@@ -434,7 +439,7 @@ func TestUndoRedo(t *testing.T) {
 						Type:   dumpfile.Unsaved,
 						Column: 0,
 						Tag: dumpfile.Text{
-							Buffer: secondfilename,
+							Buffer: secondfilename + " Del Snarf Undo Put | Look Edit ",
 						},
 						Body: dumpfile.Text{
 							Buffer: "A different TEXT\nWith other contents\nSo there!\n",
@@ -515,10 +520,7 @@ func TestUndoRedo(t *testing.T) {
 						Type:   dumpfile.Unsaved,
 						Column: 0,
 						Tag: dumpfile.Text{
-							// TODO(rjk): Why does cut+undo remove the tag contents here? Somewhere
-							// the logic for updating the tags is being weird. This could be a bug in
-							// updating tag contents.
-							Buffer: secondfilename,
+							Buffer: secondfilename + " Del Snarf Undo Put | Look Edit ",
 						},
 						Body: dumpfile.Text{
 							Buffer: "A different TEXT\nWith other contents\nSo there!\n",
@@ -548,7 +550,7 @@ func TestUndoRedo(t *testing.T) {
 						Type:   dumpfile.Unsaved,
 						Column: 0,
 						Tag: dumpfile.Text{
-							Buffer: firstfilename,
+							Buffer: firstfilename + " Del Snarf Undo Put | Look Edit ",
 						},
 						Body: dumpfile.Text{
 							Buffer: "Thishort TEXT\nto try addressing\n",

--- a/file/file.go
+++ b/file/file.go
@@ -97,7 +97,7 @@ func (f *File) ReadAtRune(r []rune, off int) (n int, err error) {
 }
 
 // Commit writes the in-progress edits to the real buffer instead of
-// keeping them in the cache. Does not map to undo.RuneArray.Commit (that
+// keeping them in the cache. Does not map to file.Buffer.Commit (that
 // method is Mark). Remove this method.
 func (f *File) Commit(seq int) {
 	if !f.HasUncommitedChanges() {
@@ -305,7 +305,11 @@ func (f *File) Undo(isundo bool, seq int) (int, int, bool, int) {
 			seq = u.seq
 			f.UnsetName(epsilon, seq)
 			newfname := string(u.Buf)
-			f.oeb.Setnameandisscratch(newfname)
+			f.oeb.setnameandisscratch(newfname)
+
+			// New callback scheme
+			f.oeb.observersMemoizedUndone(isundo)
+			// TODO(rjk): Plumb the remaining observer logic for undo/redo actions.
 		}
 		*delta = (*delta)[0 : len(*delta)-1]
 	}

--- a/file/tag_status_observer.go
+++ b/file/tag_status_observer.go
@@ -1,0 +1,26 @@
+package file
+
+// This is passed by value. I'm assuming that it's small.
+// TODO(rjk): decide if I want to pack these together.
+type TagStatus struct {
+	UndoableChanges  bool
+	RedoableChanges  bool
+	SaveableAndDirty bool
+}
+
+// TagStatusObserver implementations can register themselves with an
+// ObservableEditableBuffer so the observers can be notified of all
+// changes to the ObservableEditableBuffer that would prompt changing the
+// contents of an Edwood tag.
+type TagStatusObserver interface {
+
+	// MemoizedUndone is called inside of an Undo when a previously memoized
+	// action is undone. This is used to propagate notice of finding a memoized
+	// point in the Undo history to the owning observer (typically a Window.)
+	MemoizedUndone(undo bool)
+
+	// UpdateTag is invoked on the implementation by the
+	// ObservableEditableBuffer when oeb state has changed in a way that
+	// requires altering the pre-bar tag contents.
+	UpdateTag(newtagstatus TagStatus)
+}

--- a/filename_undo_test.go
+++ b/filename_undo_test.go
@@ -16,6 +16,7 @@ func changeFileName(t *testing.T, g *globals, ffn, _ string) {
 	// Mutate
 	fwt := &g.row.col[0].w[0].tag
 
+	// TODO(rjk): WRONG WITH THE UNICODE
 	fwt.q0 = len(ffn)
 	fwt.q1 = len(ffn)
 
@@ -33,6 +34,7 @@ func undoFileNameChange(t *testing.T, g *globals, ffn, _ string) {
 	changeFileName(t, g, ffn, "")
 
 	// TODO(rjk): Move the text position
+	// to the end?
 
 	firstwin := g.row.col[0].w[0]
 	undo(&firstwin.tag, nil, nil, true /* this is an undo */, false /* ignored */, "")
@@ -107,7 +109,7 @@ func TestFilenameChangeUndo(t *testing.T) {
 						Type:   dumpfile.Unsaved,
 						Column: 0,
 						Tag: dumpfile.Text{
-							Buffer: firstfilename + "suffix",
+							Buffer: firstfilename + "suffix" + " Del Snarf Undo Put | Look Edit ",
 							Q0:     len(firstfilename),
 							Q1:     len(firstfilename) + len("suffix"),
 						},
@@ -123,7 +125,7 @@ func TestFilenameChangeUndo(t *testing.T) {
 						Type:   dumpfile.Saved,
 						Column: 0,
 						Tag: dumpfile.Text{
-							Buffer: secondfilename,
+							Buffer: secondfilename + " Del Snarf | Look Edit ",
 						},
 						Body: dumpfile.Text{},
 					},
@@ -132,10 +134,10 @@ func TestFilenameChangeUndo(t *testing.T) {
 		},
 		{
 			// Verify that we can edit a file name and then undo the change.
-			name:    "undoFileNameChange",
-			fn:      undoFileNameChange,
+			name: "undoFileNameChange",
+			fn:   undoFileNameChange,
+			// Currently failing. Requires some non-trivial coding adjustments.
 			passing: false,
-			// Q1 is not correctly updated.
 			want: &dumpfile.Content{
 				CurrentDir: cwd,
 				VarFont:    defaultVarFont,
@@ -227,7 +229,7 @@ func TestFilenameChangeUndo(t *testing.T) {
 						Type:   dumpfile.Unsaved,
 						Column: 0,
 						Tag: dumpfile.Text{
-							Buffer: firstfilename + "suffix",
+							Buffer: firstfilename + "suffix" + " Del Snarf Undo Put | Look Edit ",
 							Q0:     len(firstfilename),
 							Q1:     len(firstfilename) + len("suffix"),
 						},

--- a/look.go
+++ b/look.go
@@ -628,7 +628,8 @@ func newx(et *Text, t *Text, argt *Text, flag1 bool, flag2 bool, arg string) {
 	filenames := strings.Split(s, " ")
 	if len(filenames) == 1 && filenames[0] == "" && et.col != nil {
 		w := et.col.Add(nil, nil, -1)
-		w.SetTag()
+		// Note special case for empty windows.
+		w.ForceSetWindowTag()
 		xfidlog(w, "new")
 		return
 	}

--- a/row_test.go
+++ b/row_test.go
@@ -198,6 +198,7 @@ func checkDump(t *testing.T, got, want *dumpfile.Content) {
 			put  = " Put "
 			undo = " Undo "
 		)
+
 		if strings.Contains(g.Tag.Buffer, put) && !strings.Contains(w.Tag.Buffer, put) {
 			g.Tag.Buffer = w.Tag.Buffer
 		}

--- a/rowmock_test.go
+++ b/rowmock_test.go
@@ -58,7 +58,9 @@ func MakeWindowScaffold(content *dumpfile.Content) {
 			file: file.MakeObservableEditableBuffer("", nil),
 		}, &content.RowTag, display),
 	}
+	global.row.tag.Insert(0, []rune(content.RowTag.Buffer), true)
 
+	// TODO(rjk): Consider calling Column.Init?
 	cols := make([]*Column, 0, len(content.Columns))
 	for _, sercol := range content.Columns {
 		col := &Column{
@@ -70,15 +72,19 @@ func MakeWindowScaffold(content *dumpfile.Content) {
 			fortest: true,
 			w:       make([]*Window, 0),
 		}
+		col.safe = true
 		cols = append(cols, col)
 	}
+
+	// This has to be done first.
+	global.row.col = cols
+	configureGlobals()
 
 	for _, serwin := range content.Windows {
 		w := NewWindow().initHeadless(nil)
 		w.display = display
-		updateText(&w.body, &serwin.Body, display)
-		updateText(&w.tag, &serwin.Tag, display)
-		w.body.file.SetName(strings.SplitN(serwin.Tag.Buffer, " ", 2)[0])
+		w.tag.display = display
+		w.body.display = display
 		w.body.w = w
 		w.body.what = Body
 		w.tag.w = w
@@ -89,10 +95,10 @@ func MakeWindowScaffold(content *dumpfile.Content) {
 		w.col = wincol
 		w.body.col = wincol
 		w.tag.col = wincol
+		updateText(&w.tag, &serwin.Tag, display)
+		updateText(&w.body, &serwin.Body, display)
+		w.SetName(strings.SplitN(serwin.Tag.Buffer, " ", 2)[0])
 	}
-
-	global.row.col = cols
-	configureGlobals()
 }
 
 // InsertString inserts a string at the beginning of a buffer. It doesn't

--- a/wind_test.go
+++ b/wind_test.go
@@ -35,6 +35,10 @@ func TestSetTag1(t *testing.T) {
 			file:    file.MakeObservableEditableBuffer("", nil),
 		}
 
+		w.col = &Column{
+			safe: true,
+		}
+
 		w.setTag1()
 		got := w.tag.file.String()
 		want := name + defaultSuffix


### PR DESCRIPTION
Use an observer scheme to invoke `Window.setTag` instead of the manual
calls to `Window.SetTag`. This significantly reduces the number of
calls to `SetTag`: e.g. in editing this commit message, we reduced the
number of `setTag` invocations by ~99%.

This change also contributes to #400 by setting up the start of an
observer structure for plumbing together Undo actions *in the tag*
into filename changes.
