### PR TITLE
Fix bug in observer-driven tag updates

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -528,6 +528,7 @@ func putfile(oeb *file.ObservableEditableBuffer, q0 int, q1 int, name string) er
 		if !os.SameFile(oeb.Info(), d) || d.ModTime().Sub(oeb.Info().ModTime()) > time.Millisecond {
 			oeb.UpdateInfo(name, d)
 		}
+
 		if !os.SameFile(oeb.Info(), d) || d.ModTime().Sub(oeb.Info().ModTime()) > time.Millisecond {
 			// By setting File.info here, a subsequent Put will ignore that
 			// the disk file was mutated and will write File to the disk file.
@@ -583,6 +584,8 @@ func putfile(oeb *file.ObservableEditableBuffer, q0 int, q1 int, name string) er
 	return nil
 }
 
+// TODO(rjk): Why doesn't this handle its arguments the same as some of
+// the other commands?
 func put(et *Text, _0 *Text, argt *Text, _1 bool, _2 bool, arg string) {
 	if et == nil || et.w == nil || et.w.body.file.IsDir() {
 		return

--- a/file/file_test.go
+++ b/file/file_test.go
@@ -542,8 +542,17 @@ func TestTagObserversFireCorrectly(t *testing.T) {
 		t.Errorf("got %+v, want %+v", got, want)
 	}
 
+	// Previous Clean makes the next observer fire so this one will invoke
+	// but since seq has not changed, it will not cause the last Clean to
+	// invoke the tag observers.
 	oeb.Clean()
-	if got, want := *counts, (observercount{0, 7}); got != want {
+	if got, want := *counts, (observercount{0, 8}); got != want {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+
+	// Last Clean
+	oeb.Clean()
+	if got, want := *counts, (observercount{0, 8}); got != want {
 		t.Errorf("got %+v, want %+v", got, want)
 	}
 }

--- a/file/observable_editable_buffer.go
+++ b/file/observable_editable_buffer.go
@@ -162,10 +162,16 @@ func MakeObservableEditableBuffer(filename string, b []rune) *ObservableEditable
 // TODO(rjk): Verify that this is invoked on a Put op.
 func (e *ObservableEditableBuffer) Clean() {
 	before := e.getTagStatus()
-	defer e.notifyTagObservers(before)
 
 	e.treatasclean = false
+	op := e.putseq
 	e.putseq = e.seq
+
+	e.notifyTagObservers(before)
+
+	if op != e.seq {
+		e.filtertagobservers = false
+	}
 }
 
 // getTagState returns the current tag state. Assumption: this method needs to be cheap to
@@ -334,6 +340,7 @@ func (e *ObservableEditableBuffer) SetName(name string) {
 	// SetName always forces an update of the tag let the default tag update
 	// filter skip the name string comparison on the default case of editing
 	// a body.
+	// TODO(rjk): This reset of filtertagobservers might be unnecessary.
 	e.filtertagobservers = false
 	before := e.getTagStatus()
 	defer e.notifyTagObservers(before)

--- a/wind.go
+++ b/wind.go
@@ -559,8 +559,7 @@ func (w *Window) MemoizedUndone(undo bool) {
 	// log.Println("Window.MemoizedUndone")
 }
 
-// TODO(rjk): This should only get invokved when the tag needs to change
-// do not double-invoke
 func (w *Window) UpdateTag(newtagstatus file.TagStatus) {
+	// log.Printf("Window.UpdateTag, status %+v", newtagstatus)
 	w.setTag1()
 }


### PR DESCRIPTION
My change to introduce observer-driven tag updates failed to correctly
propagate tag updates after doing a Put operation. Corrected this.
Helps eventually with #400.
