### PR TITLE
More sensibly update tag selections

### DIFF
--- a/filename_undo_test.go
+++ b/filename_undo_test.go
@@ -137,7 +137,7 @@ func TestFilenameChangeUndo(t *testing.T) {
 			name: "undoFileNameChange",
 			fn:   undoFileNameChange,
 			// Currently failing. Requires some non-trivial coding adjustments.
-			passing: false,
+			passing: true,
 			want: &dumpfile.Content{
 				CurrentDir: cwd,
 				VarFont:    defaultVarFont,
@@ -160,7 +160,7 @@ func TestFilenameChangeUndo(t *testing.T) {
 						Type:   dumpfile.Saved,
 						Column: 0,
 						Tag: dumpfile.Text{
-							Buffer: secondfilename,
+							Buffer: secondfilename + " Del Snarf | Look Edit ",
 						},
 						Body: dumpfile.Text{},
 					},

--- a/testdata/example.dump
+++ b/testdata/example.dump
@@ -34,8 +34,8 @@
 			"Font": "/lib/font/bit/lucsans/euro.8.font",
 			"Tag": {
 				"Buffer": "glass Del Snarf | Look Edit ",
-				"Q0": 10,
-				"Q1": 15
+				"Q0": 5,
+				"Q1": 5
 			},
 			"Body": {
 				"Buffer": "I can eat glass and it doesn't hurt me.\nJe peux manger du verre, ça ne me fait pas mal.\n私はガラスを食べられます。それは私を傷つけません。\nআমি কাঁচ খেতে পারি, তাতে আমার কোনো ক্ষতি হয় না।\n",


### PR DESCRIPTION
Improve the updating of the selection in Window tags across various
actions (e.g. Undo of a file name change) where Edwood
programmatically updates the contents of the tag. Fixes #400.
