### PR TITLE
Remove ObservableEditableBuffer.Reset()

### DIFF
--- a/file/file.go
+++ b/file/file.go
@@ -320,21 +320,12 @@ func (f *File) Undo(isundo bool, seq int) (int, int, bool, int) {
 	return q0, q1, ok, seq
 }
 
-// Reset removes all Undo records for this File.
-// TODO(rjk): This concept doesn't particularly exist in file.Buffer.
-// Why can't I just create a new File?
-func (f *File) Reset() {
-	f.delta = f.delta[0:0]
-	f.epsilon = f.epsilon[0:0]
-}
-
-// Mark sets an Undo point and
-// and discards Redo records. Call this at the beginning
-// of a set of edits that ought to be undo-able as a unit. This
-// is equivalent to file.Buffer.Commit()
-// NB: current implementation permits calling Mark on an empty
-// file to indicate that one can undo to the file state at the time of
-// calling Mark.
+// Mark sets an Undo point and and discards Redo records. Call this at
+// the beginning of a set of edits that ought to be undo-able as a unit.
+// This is equivalent to file.Buffer.Commit() NB: current implementation
+// permits calling Mark on an empty file to indicate that one can undo to
+// the file state at the time of calling Mark.
+//
 // TODO(rjk): Consider renaming to SetUndoPoint
 func (f *File) Mark() {
 	f.epsilon = f.epsilon[0:0]

--- a/file/observable_editable_buffer.go
+++ b/file/observable_editable_buffer.go
@@ -158,8 +158,8 @@ func MakeObservableEditableBuffer(filename string, b []rune) *ObservableEditable
 }
 
 // Clean marks the ObservableEditableBuffer as being non-dirty: the
-// backing is the same as File.
-// TODO(rjk): Verify that this is invoked on a Put op.
+// backing is the same as File. In particular, invoked in response to a
+// Put operation.
 func (e *ObservableEditableBuffer) Clean() {
 	before := e.getTagStatus()
 
@@ -207,15 +207,6 @@ func (e *ObservableEditableBuffer) notifyTagObservers(before TagStatus) {
 func (e *ObservableEditableBuffer) Mark(seq int) {
 	e.f.Mark()
 	e.seq = seq
-}
-
-// Reset is a forwarding function for file.Reset.
-// TODO(rjk): Do we even need this?
-// TODO(rjk): I believe that we don't need to invoke tag observers here.
-func (e *ObservableEditableBuffer) Reset() {
-	e.filtertagobservers = false
-	e.f.Reset()
-	e.seq = 0
 }
 
 // HasUncommitedChanges is a forwarding function for file.HasUncommitedChanges.
@@ -488,9 +479,13 @@ func (e *ObservableEditableBuffer) String() string {
 	return e.f.b.String()
 }
 
-// ResetBuffer is a forwarding function for rune_array.Reset.
+// ResetBuffer is a forwarding function for rune_array.Reset. Equivalent
+// to re-creating the buffer.
 func (e *ObservableEditableBuffer) ResetBuffer() {
-	e.f.b.Reset()
+	e.filtertagobservers = false
+	e.seq = 0
+	e.f = NewFile()
+	e.f.oeb = e
 }
 
 // Reader is a forwarding function for rune_array.Reader.

--- a/file/rune_array.go
+++ b/file/rune_array.go
@@ -47,7 +47,7 @@ func (b *RuneArray) ReadC(q int) rune { return (*b)[q] }
 func (b *RuneArray) String() string { return string(*b) }
 
 func (b *RuneArray) Reset() {
-	*b = (*b)[0:0]
+	*b = make([]rune, 0)
 }
 
 // nc returns the number of characters in the RuneArray.

--- a/text.go
+++ b/text.go
@@ -1603,7 +1603,6 @@ func (t *Text) Reset() {
 	t.org = 0
 	t.q0 = 0
 	t.q1 = 0
-	t.file.Reset()
 	t.file.ResetBuffer()
 }
 

--- a/wind.go
+++ b/wind.go
@@ -92,6 +92,14 @@ func (w *Window) initHeadless(clone *Window) *Window {
 
 	// Tag setup.
 	f := file.MakeObservableEditableBuffer("", nil)
+
+	if clone != nil {
+		// TODO(rjk): Support something nicer like initializing from a Reader.
+		// (Can refactor ObservableEditableBuffer.Load perhaps.
+		clonebuff := make([]rune, clone.tag.Nc())
+		clone.tag.file.Read(0, clonebuff)
+		f = file.MakeObservableEditableBuffer("", clonebuff)
+	}
 	f.AddObserver(&w.tag)
 	// w observes tag to update the tag index.
 	// TODO(rjk): Add the tag index facility.
@@ -130,13 +138,9 @@ func (w *Window) Init(clone *Window, r image.Rectangle, dis draw.Display) {
 	w.tag.Init(r1, global.tagfont, global.tagcolors, w.display)
 	w.tag.what = Tag
 
-	// tag is a copy of the contents, not a tracked image
+	// When cloning, we copy the tag so that the tag contents can evolve
+	// independently.
 	if clone != nil {
-		w.tag.Delete(0, w.tag.Nc(), true)
-		// TODO(sn0w): find a nicer way to do this.
-		clonebuff := []rune(clone.tag.file.String())
-		w.tag.Insert(0, clonebuff, true)
-		w.tag.file.Reset()
 		w.tag.SetSelect(w.tag.Nc(), w.tag.Nc())
 	}
 	r1 = r

--- a/xfid.go
+++ b/xfid.go
@@ -574,8 +574,6 @@ forloop:
 		case "clean": // mark window 'clean', seq=0
 			t := &w.body
 			t.eq0 = ^0
-			// TODO(rjk): Is this right?
-			t.file.Reset()
 			t.file.Clean()
 		case "dirty": // mark window 'dirty'
 			t := &w.body


### PR DESCRIPTION
Further simplify the ObservableEditableBuffer interface. This will
(slightly) reduce the work needed to complete #97. And seemed like a
nice cleanup. Also updated a number of comments to better specify API
surfaces.
