### PR TITLE
Simplify TagStatusObserver

### DIFF
--- a/file/file.go
+++ b/file/file.go
@@ -300,16 +300,12 @@ func (f *File) Undo(isundo bool, seq int) (int, int, bool, int) {
 			q1 = u.P0 + u.N
 			ok = true
 		case sam.Filename:
-			// TODO(rjk): Fix Undo on Filename once the code has matured, removing broken code in the meantime.
-			// TODO(rjk): If I have a zerox, how does Undo work?
+			// If I have a zerox, Undo works via Undo calling
+			// TagStatusObserver.UpdateTag on the appropriate observers.
 			seq = u.seq
 			f.UnsetName(epsilon, seq)
 			newfname := string(u.Buf)
-			f.oeb.setnameandisscratch(newfname)
-
-			// New callback scheme
-			f.oeb.observersMemoizedUndone(isundo)
-			// TODO(rjk): Plumb the remaining observer logic for undo/redo actions.
+			f.oeb.setfilename(newfname)
 		}
 		*delta = (*delta)[0 : len(*delta)-1]
 	}

--- a/file/tag_status_observer.go
+++ b/file/tag_status_observer.go
@@ -13,12 +13,6 @@ type TagStatus struct {
 // changes to the ObservableEditableBuffer that would prompt changing the
 // contents of an Edwood tag.
 type TagStatusObserver interface {
-
-	// MemoizedUndone is called inside of an Undo when a previously memoized
-	// action is undone. This is used to propagate notice of finding a memoized
-	// point in the Undo history to the owning observer (typically a Window.)
-	MemoizedUndone(undo bool)
-
 	// UpdateTag is invoked on the implementation by the
 	// ObservableEditableBuffer when oeb state has changed in a way that
 	// requires altering the pre-bar tag contents.

--- a/wind.go
+++ b/wind.go
@@ -558,11 +558,6 @@ func (w *Window) ClampAddr() {
 	}
 }
 
-// Watch for filename undo actions.
-func (w *Window) MemoizedUndone(undo bool) {
-	// log.Println("Window.MemoizedUndone")
-}
-
 func (w *Window) UpdateTag(newtagstatus file.TagStatus) {
 	// log.Printf("Window.UpdateTag, status %+v", newtagstatus)
 	w.setTag1()


### PR DESCRIPTION
Remove some unnecessary code added as part of fixing #400. Makes
TagStatusObserver simpler.
