### PR TITLE
s_cmd vs x_cmd benchmark

### DIFF
--- a/addr.go
+++ b/addr.go
@@ -43,7 +43,7 @@ func isregexc(r rune) bool {
 // being careful not to walk past the end of the text,
 // and then nr chars, being careful not to walk past
 // the end of the current line.
-// It returns the final position.
+// It returns the final position in runes.
 func nlcounttopos(t sam.Texter, q0 int, nl int, nr int) int {
 	for nl > 0 && q0 < t.Nc() {
 		if t.ReadC(q0) == '\n' {

--- a/ecmd_test.go
+++ b/ecmd_test.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/rjkroege/edwood/dumpfile"
 	"github.com/rjkroege/edwood/file"
 )
 
@@ -62,4 +66,141 @@ func DISABLED_TestXCmdPipeMultipleWindows(t *testing.T) {
 		t.Fatalf("failed to parse command: %v", err)
 	}
 	X_cmd(nil, cmd)
+}
+
+func edit_sPerf(t testing.TB, g *globals) {
+	t.Helper()
+
+	firstwin := g.row.col[0].w[0]
+
+	// Lock discipline?
+	// TODO(rjk): figure out how to change this with less global dependency.
+	global.row.lk.Lock()
+	firstwin.Lock('M')
+	global.seq++
+
+	action := ", s/fox/gopher/g"
+	editcmd(&firstwin.body, []rune(action))
+	firstwin.Unlock()
+	global.row.lk.Unlock()
+}
+
+func edit_xPerf(t testing.TB, g *globals) {
+	t.Helper()
+
+	firstwin := g.row.col[0].w[0]
+
+	// Lock discipline?
+	// TODO(rjk): figure out how to change this with less global dependency.
+	global.row.lk.Lock()
+	firstwin.Lock('M')
+	global.seq++
+
+	action := ",x/fox/ c/gopher/"
+	editcmd(&firstwin.body, []rune(action))
+	firstwin.Unlock()
+	global.row.lk.Unlock()
+}
+
+func BenchmarkLargeEditTargets10(t *testing.B)    { benchmarkLargeEditTargetsImpl(t, 10) }
+func BenchmarkLargeEditTargets109(t *testing.B)   { benchmarkLargeEditTargetsImpl(t, 100) }
+func BenchmarkLargeEditTargets1000(t *testing.B)  { benchmarkLargeEditTargetsImpl(t, 1000) }
+func BenchmarkLargeEditTargets10000(t *testing.B) { benchmarkLargeEditTargetsImpl(t, 10000) }
+
+func benchmarkLargeEditTargetsImpl(t *testing.B, nl int) {
+	dir := t.TempDir()
+	firstfilename := filepath.Join(dir, "bigfile")
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("failed to get current working directory: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		fn   func(t testing.TB, g *globals)
+		want *dumpfile.Content
+	}{
+		{
+			name: "edit_xPerf",
+			fn:   edit_xPerf,
+			want: &dumpfile.Content{
+				CurrentDir: cwd,
+				VarFont:    defaultVarFont,
+				FixedFont:  defaultFixedFont,
+				Columns: []dumpfile.Column{
+					{},
+				},
+				Windows: []*dumpfile.Window{
+					{
+						Type:   dumpfile.Unsaved,
+						Column: 0,
+						Tag: dumpfile.Text{
+							Buffer: firstfilename + " Del Snarf Undo Put | Look Edit ",
+						},
+						Body: dumpfile.Text{
+							Buffer: Repeating(nl, "the quick brown gopher"),
+							Q0:     nl*(len("the quick brown gopher")+1) - 7,
+							Q1:     nl*(len("the quick brown gopher")+1) - 1,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "edit_sPerf",
+			fn:   edit_sPerf,
+			want: &dumpfile.Content{
+				CurrentDir: cwd,
+				VarFont:    defaultVarFont,
+				FixedFont:  defaultFixedFont,
+				Columns: []dumpfile.Column{
+					{},
+				},
+				Windows: []*dumpfile.Window{
+					{
+						Type:   dumpfile.Unsaved,
+						Column: 0,
+						Tag: dumpfile.Text{
+							Buffer: firstfilename + " Del Snarf Undo Put | Look Edit ",
+						},
+						Body: dumpfile.Text{
+							Buffer: Repeating(nl, "the quick brown gopher"),
+							Q0:     0,
+							Q1:     nl * (len("the quick brown gopher") + 1),
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(b *testing.B) {
+			b.StopTimer()
+
+			for i := 0; i < b.N; i++ {
+
+				FlexiblyMakeWindowScaffold(
+					b,
+					ScWin("bigfile"),
+					ScDir(dir, "bigfile"),
+					ScBody("bigfile", Repeating(nl, "the quick brown fox")),
+				)
+
+				b.StartTimer()
+				tc.fn(b, global)
+				b.StopTimer()
+
+				got, err := global.row.dump()
+				if err != nil {
+					b.Fatalf("dump failed: %v", err)
+				}
+
+				if diff := cmp.Diff(tc.want, got); diff != "" {
+					b.Errorf("dump mismatch (-want +got):\n%s", diff)
+				}
+
+			}
+		})
+	}
 }

--- a/exec_test.go
+++ b/exec_test.go
@@ -770,6 +770,7 @@ func TestUndoRedo(t *testing.T) {
 // TODO(rjk): consider how to merge this with makeSkeletonWindowModel
 // Use direct access to the global data to walk the datastructure.
 // TODO(rjk): pass in the global to modify.
+// TODO(rjk): Make this more flexible for building test data. (See FlexiblyMakeWindowScaffold)
 func makeSkeletonWindowModelWithFiles(t *testing.T, firstfilename, secondfilename string) {
 	t.Helper()
 	MakeWindowScaffold(&dumpfile.Content{

--- a/guide
+++ b/guide
@@ -1,3 +1,18 @@
+// Basics
+Edit X:edwood/\+Errors: 1,$d
+X:edwood/.*\.go: w
+
+go build
+./testedwood.sh  /tmp/xxx.tex
+
+go test --run 'TestLargeEditTargets' -covermode=count -coverprofile=count.out
+go test --run XXX -bench 'BenchmarkLargeEditTargets' -cpuprofile cpu.prof
+go test
+go tool cover -html=count.out
+go test 
+
+// Edit commands for converting C to Go
+
 ",
 { x/->/c/./
 x/TRUE/c/true/

--- a/text.go
+++ b/text.go
@@ -422,6 +422,8 @@ func (t *Text) BsInsert(q0 int, r []rune, tofile bool) (q, nr int) {
 
 // inserted is a callback invoked by File on Insert* to update each Text
 // that is using a given File.
+// TODO(rjk): Carefully scrub this for opportunities to not do work if the
+// changes are not in the viewport. Also: minimize scrollbar redraws.
 func (t *Text) Inserted(q0 int, r []rune) {
 	if t.eq0 == -1 {
 		t.eq0 = q0
@@ -467,6 +469,8 @@ func (t *Text) logInsert(q0 int, r []rune) {
 			c = 'I'
 		}
 		if n <= EVENTSIZE {
+			// TODO(rjk): Does unnecessary work making a string from r if there's no
+			// event reader.
 			t.w.Eventf("%c%d %d 0 %d %v\n", c, q0, q0+n, n, string(r))
 		} else {
 			t.w.Eventf("%c%d %d 0 0 \n", c, q0, q0+n)


### PR DESCRIPTION
slower than `x`. Add a benchmark BenchmarkLargeEditTargets.* to
compare the performance of equivalent `s` and `x` edits on a range of
buffer sizes.
