### PR TITLE
Enhanced framework for frame.Frame tests

### DIFF
--- a/edwoodtest/colornames.go
+++ b/edwoodtest/colornames.go
@@ -1,0 +1,29 @@
+package edwoodtest
+
+import (
+	"fmt"
+
+	"github.com/rjkroege/edwood/draw"
+)
+
+func NiceColourName(num draw.Color) string {
+	lookuptable := make(map[draw.Color]string)
+
+	lookuptable[draw.Darkyellow] = "Darkyellow"
+	lookuptable[draw.Medblue] = "Medblue"
+	lookuptable[draw.Nofill] = "Nofill"
+	lookuptable[draw.Notacolor] = "Notacolor"
+	lookuptable[draw.Palebluegreen] = "Palebluegreen"
+	lookuptable[draw.Palegreygreen] = "Palegreygreen"
+	lookuptable[draw.Paleyellow] = "Paleyellow"
+	lookuptable[draw.Purpleblue] = "Purpleblue"
+	lookuptable[draw.Transparent] = "Transparent"
+	lookuptable[draw.White] = "White"
+	lookuptable[draw.Yellowgreen] = "Yellowgreen"
+
+	if s, ok := lookuptable[num]; ok {
+
+		return s
+	}
+	return fmt.Sprintf("color(%x)", num)
+}

--- a/edwoodtest/draw.go
+++ b/edwoodtest/draw.go
@@ -3,6 +3,7 @@ package edwoodtest
 
 import (
 	"errors"
+	"fmt"
 	"image"
 	"sync"
 	"unicode/utf8"
@@ -12,30 +13,62 @@ import (
 
 var _ = draw.Display((*mockDisplay)(nil))
 
+// GettableDrawOps display implementations can provide a list of the
+// executed draw ops.
+type GettableDrawOps interface {
+	DrawOps() []string
+	Clear()
+}
+
 // mockDisplay implements draw.Display.
 type mockDisplay struct {
 	snarfbuf []byte
 	mu       sync.Mutex
+	drawops  []string
 }
 
 // NewDisplay returns a mock draw.Display.
 func NewDisplay() draw.Display {
 	return &mockDisplay{}
 }
-func (d *mockDisplay) ScreenImage() draw.Image                 { return NewImage(image.Rect(0, 0, 800, 600)) }
-func (d *mockDisplay) White() draw.Image                       { return NewImage(image.Rectangle{}) }
-func (d *mockDisplay) Black() draw.Image                       { return NewImage(image.Rectangle{}) }
-func (d *mockDisplay) Opaque() draw.Image                      { return NewImage(image.Rectangle{}) }
-func (d *mockDisplay) Transparent() draw.Image                 { return NewImage(image.Rectangle{}) }
-func (d *mockDisplay) InitKeyboard() *draw.Keyboardctl         { return nil }
-func (d *mockDisplay) InitMouse() *draw.Mousectl               { return nil }
+
+func (d *mockDisplay) ScreenImage() draw.Image {
+	return newimageimpl(d, "screen-800x600", image.Rect(0, 0, 800, 600))
+}
+
+func (d *mockDisplay) White() draw.Image  { return newimageimpl(d, "white", image.Rectangle{}) }
+func (d *mockDisplay) Black() draw.Image  { return newimageimpl(d, "black", image.Rectangle{}) }
+func (d *mockDisplay) Opaque() draw.Image { return newimageimpl(d, "opaque", image.Rectangle{}) }
+func (d *mockDisplay) Transparent() draw.Image {
+	return newimageimpl(d, "transparent", image.Rectangle{})
+}
+func (d *mockDisplay) InitKeyboard() *draw.Keyboardctl { return nil }
+func (d *mockDisplay) InitMouse() *draw.Mousectl       { return nil }
+
+// TODO(rjk): Need to increase fidelity here.
 func (d *mockDisplay) OpenFont(name string) (draw.Font, error) { return NewFont(13, 10), nil }
+
 func (d *mockDisplay) AllocImage(r image.Rectangle, pix draw.Pix, repl bool, val draw.Color) (draw.Image, error) {
-	return &mockImage{r: r}, nil
+	name := NiceColourName(val)
+	if repl {
+		name += ",tiled"
+	}
+
+	return &mockImage{
+		d: d,
+		r: r,
+		n: name,
+	}, nil
 }
+
 func (d *mockDisplay) AllocImageMix(color1, color3 draw.Color) draw.Image {
-	return NewImage(image.Rectangle{})
+	name := fmt.Sprintf("mix(%s,%s)", NiceColourName(color1), NiceColourName(color3))
+	return &mockImage{
+		d: d,
+		n: name,
+	}
 }
+
 func (d *mockDisplay) Attach(ref int) error { return nil }
 func (d *mockDisplay) Flush() error         { return nil }
 func (d *mockDisplay) ScaleSize(n int) int  { return 0 }
@@ -67,31 +100,98 @@ func (d *mockDisplay) WriteSnarf(data []byte) error {
 
 func (d *mockDisplay) MoveTo(pt image.Point) error    { return nil }
 func (d *mockDisplay) SetCursor(c *draw.Cursor) error { return nil }
+func (d *mockDisplay) DrawOps() []string              { return d.drawops }
+func (d *mockDisplay) Clear()                         { d.drawops = nil }
 
 var _ = draw.Image((*mockImage)(nil))
 
 // mockImage implements draw.Image.
 type mockImage struct {
 	r image.Rectangle
+	d *mockDisplay
+	n string
+}
+
+func newimageimpl(d *mockDisplay, name string, r image.Rectangle) draw.Image {
+	return &mockImage{
+		r: r,
+		n: name,
+		d: d,
+	}
 }
 
 // NewImage returns a mock draw.Image with the given bounds.
-func NewImage(r image.Rectangle) draw.Image {
-	return &mockImage{r: r}
+func NewImage(display draw.Display, name string, r image.Rectangle) draw.Image {
+	d := display.(*mockDisplay)
+	return newimageimpl(d, name, r)
 }
-func (i *mockImage) Display() draw.Display                                             { return NewDisplay() }
-func (i *mockImage) Pix() draw.Pix                                                     { return 0 }
-func (i *mockImage) R() image.Rectangle                                                { return i.r }
-func (i *mockImage) Draw(r image.Rectangle, src, mask draw.Image, p1 image.Point)      {}
-func (i *mockImage) Border(r image.Rectangle, n int, color draw.Image, sp image.Point) {}
+
+func (i *mockImage) Display() draw.Display { return i.d }
+func (i *mockImage) Pix() draw.Pix         { return 0 }
+func (i *mockImage) R() image.Rectangle    { return i.r }
+
+func (i *mockImage) Draw(r image.Rectangle, src, mask draw.Image, p1 image.Point) {
+	srcname := "nil"
+	if msrc, ok := src.(*mockImage); ok {
+		srcname = msrc.n
+	}
+	maskname := "nil"
+	if mmask, ok := src.(*mockImage); ok {
+		maskname = mmask.n
+	}
+
+	op := fmt.Sprintf("%s <- draw r: %v src: %s mask %s p1: %v",
+		i.n,
+		r,
+		srcname,
+		maskname,
+		p1,
+	)
+	i.d.drawops = append(i.d.drawops, op)
+}
+
+func (i *mockImage) Border(r image.Rectangle, n int, color draw.Image, sp image.Point) {
+	colorname := "nil"
+	if mcolor, ok := color.(*mockImage); ok {
+		colorname = mcolor.n
+	}
+
+	op := fmt.Sprintf("%s <- border r: %v thick: %d color: %s sp: %v",
+		i.n,
+		r,
+		n,
+		colorname,
+		sp,
+	)
+	i.d.drawops = append(i.d.drawops, op)
+}
+
 func (i *mockImage) Bytes(pt image.Point, src draw.Image, sp image.Point, f draw.Font, b []byte) image.Point {
-	return image.Point{}
+	srcname := "nil"
+	if msrc, ok := src.(*mockImage); ok {
+		srcname = msrc.n
+	}
+
+	op := fmt.Sprintf("%s <- draw-chars %q atpoint: %v font: %s fill: %s sp: %v",
+		i.n,
+		string(b),
+		pt,
+		f.Name(),
+		srcname,
+		sp,
+	)
+	i.d.drawops = append(i.d.drawops, op)
+
+	// TODO(rjk): This assumes fixed width. Consider generalizing.
+	return pt.Add(image.Pt(f.BytesWidth(b), 0))
 }
+
 func (i *mockImage) Free() error { return nil }
 
 var _ = draw.Font((*mockFont)(nil))
 
 // mockFont implements draw.Font and mocks as a fixed width font.
+// TODO(rjk): Do we need to handle variable widths?
 type mockFont struct {
 	width, height int
 }

--- a/frame/frame.go
+++ b/frame/frame.go
@@ -91,11 +91,11 @@ type Frame interface {
 	// if the frame is to be redrawn with a different font; otherwise the
 	// frame will maintain some data structures associated with the font.
 	//
-	// /To resize a Frame, use Clear and Init and then Insert to recreate the
-	// /display. If a Frame is being moved but not resized, that is, if the
-	// /shape of its containing rectangle is unchanged, it is sufficient to
-	// /use Draw to copy the containing rectangle from the old to the new
-	// /location and then call SetRects to establish the new geometry.
+	// To resize a Frame, use Clear and Init and then Insert to recreate the
+	// display. If a Frame is being moved but not resized, that is, if the
+	// shape of its containing rectangle is unchanged, it is sufficient to
+	// use Draw to copy the containing rectangle from the old to the new
+	// location and then call SetRects to establish the new geometry.
 	Clear(bool)
 
 	// Ptofchar returns the location of the upper left corner of the p'th

--- a/frame/guide
+++ b/frame/guide
@@ -1,0 +1,11 @@
+// Basics
+Edit X:edwood/frame/\+Errors: 1,$d
+X:edwood/.*\.go: w
+
+go build -tags debug
+
+go test --run 'TestLargeEditTargets' -covermode=count -coverprofile=count.out
+go test --run XXX -bench 'BenchmarkLargeEditTargets' -cpuprofile cpu.prof
+go test -covermode=count -coverprofile=count.out
+go tool cover -html=count.out
+

--- a/frame/insert_test.go
+++ b/frame/insert_test.go
@@ -5,6 +5,10 @@ import (
 	"image"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/rjkroege/edwood/draw"
+	"github.com/rjkroege/edwood/edwoodtest"
 )
 
 type InsertTestResult struct {
@@ -142,4 +146,168 @@ func TestBxscan(t *testing.T) {
 			image.Pt(10+2*10, 15+13+13),
 		},
 	})
+}
+
+type invariants struct {
+	topcorner image.Point
+	textarea  image.Rectangle
+}
+
+func setupFrame(t *testing.T, iv *invariants) Frame {
+	t.Helper()
+	display := edwoodtest.NewDisplay()
+
+	var textcolors [NumColours]draw.Image
+
+	textcolors[ColBack] = display.AllocImageMix(draw.Paleyellow, draw.White)
+	textcolors[ColHigh], _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, draw.Darkyellow)
+	textcolors[ColBord], _ = display.AllocImage(image.Rect(0, 0, 1, 1), display.ScreenImage().Pix(), true, draw.Yellowgreen)
+	textcolors[ColText] = display.Black()
+	textcolors[ColHText] = display.Black()
+
+	// TODO(rjk) Needs to be something with valid metrics for the tests to be be useful.
+	name := "helvetica"
+
+	font, err := display.OpenFont(name)
+	if err != nil {
+		t.Fatalf("can't make mock font %q: %v", name, err)
+	}
+	fr := NewFrame(iv.textarea, font, display.ScreenImage(), textcolors)
+
+	return fr
+}
+
+func simpleInsertShortString(t *testing.T, fr Frame, iv *invariants) {
+	t.Helper()
+
+	gdo(t, fr).Clear()
+
+	s := fr.Insert([]rune("ab"), 0)
+
+	if got, want := s, false; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	if got, want := fr.Ptofchar(0), image.Pt(0, 0).Add(iv.topcorner); got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	if got, want := fr.Ptofchar(1), image.Pt(13, 0).Add(iv.topcorner); got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func multiInsertShortString(t *testing.T, fr Frame, iv *invariants) {
+	t.Helper()
+
+	gdo(t, fr).Clear()
+
+	s := fr.Insert([]rune("ab\ncd"), 0)
+
+	if got, want := s, false; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	if got, want := fr.Ptofchar(0), image.Pt(0, 0).Add(iv.topcorner); got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	if got, want := fr.Ptofchar(1), image.Pt(13, 0).Add(iv.topcorner); got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func gdo(t *testing.T, fr Frame) edwoodtest.GettableDrawOps {
+	t.Helper()
+	frimpl := fr.(*frameimpl)
+	gdo := frimpl.display.(edwoodtest.GettableDrawOps)
+	return gdo
+}
+
+func nop(t *testing.T, _ Frame, _ *invariants) {
+	t.Log("hi from nop")
+}
+
+// TODO(rjk): Conceivably the bxscan test can go away once I have written this
+// to my satisfaction?
+// TODO(rjk): This can be restructured to look like the edit tests: stim
+// function, list of ops, post condition.
+func TestInsert(t *testing.T) {
+	iv := &invariants{
+		topcorner: image.Pt(20, 10),
+		// Remember that the "screen image" is 800,600.
+		textarea: image.Rect(20, 10, 400, 500),
+	}
+
+	*validate = true
+
+	tests := []struct {
+		name string
+		fn   func(t *testing.T, fr Frame, iv *invariants)
+		want []string
+	}{
+		// TODO(rjk): Test cases
+		// 1. add a string that doesn't fit on one line
+		// 2. add a string that causes a line to spill over
+		// 3. add a newline
+		// 4. start a line with a tab, insert before the tab
+		// 5. split a line
+		// multiple boxes, few lines, insert line before, into multi-line,
+		// split a multiline
+		// join lines into a multiline (delete test)
+		// remove a line before a multiline
+		// remove enough of a multiline for it to become a single line
+		{
+			name: "setupFrame",
+			fn:   nop,
+			want: []string{
+				"White <- draw r: (0,0)-(0,10) src: mix(Paleyellow,White) mask mix(Paleyellow,White) p1: (0,0)",
+				"Transparent <- draw r: (0,0)-(0,10) src: transparent mask transparent p1: (0,0)",
+				"Transparent <- draw r: (0,0)-(0,10) src: opaque mask opaque p1: (0,0)",
+				"Transparent <- draw r: (0,0)-(0,0) src: opaque mask opaque p1: (0,0)",
+				"Transparent <- draw r: (0,10)-(0,10) src: opaque mask opaque p1: (0,0)",
+			},
+		},
+		{
+			// A short string that fits on one line without breaking.
+			name: "simpleInsertShortString",
+			fn:   simpleInsertShortString,
+			want: []string{
+				// TODO(rjk): Where do we draw a background for the text area.
+				"screen-800x600 <- draw r: (20,10)-(46,20) src: mix(Paleyellow,White) mask mix(Paleyellow,White) p1: (0,0)",
+				`screen-800x600 <- draw-chars "ab" atpoint: (20,10) font: /lib/font/edwood.font fill: black sp: (0,0)`,
+			},
+		},
+		{
+			// A multi-line string
+			name: "multiInsertShortString",
+			fn:   multiInsertShortString,
+			want: []string{
+				// TODO(rjk): Where do we draw a background for the text area.
+				"screen-800x600 <- draw r: (20,10)-(400,20) src: mix(Paleyellow,White) mask mix(Paleyellow,White) p1: (0,0)",
+				"screen-800x600 <- draw r: (20,20)-(46,30) src: mix(Paleyellow,White) mask mix(Paleyellow,White) p1: (0,0)",
+				`screen-800x600 <- draw-chars "ab" atpoint: (20,10) font: /lib/font/edwood.font fill: black sp: (0,0)`,
+				`screen-800x600 <- draw-chars "cd" atpoint: (20,20) font: /lib/font/edwood.font fill: black sp: (0,0)`,
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fr := setupFrame(t, iv)
+
+			// TODO(rjk): validate here
+
+			tc.fn(t, fr, iv)
+
+			// TODO(rjk): validate here
+
+			// Peek inside.
+			got := gdo(t, fr).DrawOps()
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("dump mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+
+	// TODO(rjk): how to document these things? I'd like little box diagrams
+	// how can I make little box diagrams? (HTML? OmniFocus?)
+	// HTML three-column: name, before, after (grid layout?)
+	// nb: can imagine generating the code from the diagrams? (that would be rsc-ian.)
 }

--- a/guide
+++ b/guide
@@ -2,8 +2,8 @@
 Edit X:edwood/\+Errors: 1,$d
 X:edwood/.*\.go: w
 
-go build
-./testedwood.sh  /tmp/xxx.tex
+go build -tags debug
+./testedwood.sh --debug=localhost:8000  
 
 go test --run 'TestLargeEditTargets' -covermode=count -coverprofile=count.out
 go test --run XXX -bench 'BenchmarkLargeEditTargets' -cpuprofile cpu.prof

--- a/row_test.go
+++ b/row_test.go
@@ -447,13 +447,14 @@ func jsonEscapePath(s string) string {
 
 func setGlobalsForLoadTesting() {
 	global.WinID = 0 // reset
-	global.colbutton = edwoodtest.NewImage(image.Rectangle{})
-	global.button = edwoodtest.NewImage(image.Rectangle{})
-	global.modbutton = edwoodtest.NewImage(image.Rectangle{})
+	display := edwoodtest.NewDisplay()
+
+	global.colbutton = edwoodtest.NewImage(display, "colbutton", image.Rectangle{})
+	global.button = edwoodtest.NewImage(display, "button", image.Rectangle{})
+	global.modbutton = edwoodtest.NewImage(display, "modbutton", image.Rectangle{})
 	global.mouse = &draw.Mouse{}
 	global.maxtab = 4
 
-	display := edwoodtest.NewDisplay()
 	global.row = Row{} // reset
 	global.row.Init(display.ScreenImage().R(), display)
 }

--- a/rowmock_test.go
+++ b/rowmock_test.go
@@ -18,12 +18,11 @@ import (
 
 // configureGlobals setups global variables so that Edwood can operate on
 // a scaffold model.
-func configureGlobals() {
-	// TODO(rjk): Make a proper mock draw.Mouse in edwoodtest.
-	global.mouse = new(draw.Mouse)
-	global.button = edwoodtest.NewImage(image.Rect(0, 0, 10, 10))
-	global.modbutton = edwoodtest.NewImage(image.Rect(0, 0, 10, 10))
-	global.colbutton = edwoodtest.NewImage(image.Rect(0, 0, 10, 10))
+func (g *globals) configureGlobals(d draw.Display) {
+	g.mouse = new(draw.Mouse)
+	g.button = edwoodtest.NewImage(d, "button", image.Rect(0, 0, 10, 10))
+	g.modbutton = edwoodtest.NewImage(d, "modbutton", image.Rect(0, 0, 10, 10))
+	g.colbutton = edwoodtest.NewImage(d, "colbutton", image.Rect(0, 0, 10, 10))
 
 	// Set up Undo to make sure that we see undoable results.
 	// By default, post-load, file.seq, file.putseq = 0, 0.
@@ -81,7 +80,7 @@ func MakeWindowScaffold(content *dumpfile.Content) {
 
 	// This has to be done first.
 	global.row.col = cols
-	configureGlobals()
+	global.configureGlobals(display)
 
 	for _, serwin := range content.Windows {
 		w := NewWindow().initHeadless(nil)

--- a/wind_test.go
+++ b/wind_test.go
@@ -19,9 +19,9 @@ func TestSetTag1(t *testing.T) {
 		"/home/ゴーファー/src/エドウード.txt",
 		"/home/ゴーファー/src/",
 	} {
-		configureGlobals()
-
 		display := edwoodtest.NewDisplay()
+		global.configureGlobals(display)
+
 		w := NewWindow().initHeadless(nil)
 		w.display = display
 		w.body = Text{

--- a/xfid_test.go
+++ b/xfid_test.go
@@ -256,7 +256,7 @@ func TestXfidwriteQWaddr(t *testing.T) {
 
 func TestXfidopen(t *testing.T) {
 	display := edwoodtest.NewDisplay()
-	configureGlobals()
+	global.configureGlobals(display)
 
 	for _, tc := range []struct {
 		name string
@@ -348,7 +348,7 @@ func TestXfidopenQeditout(t *testing.T) {
 }
 
 func TestXfidopenQWeditout(t *testing.T) {
-	configureGlobals()
+	global.configureGlobals(edwoodtest.NewDisplay())
 	mr := new(mockResponder)
 
 	x := &Xfid{
@@ -540,8 +540,8 @@ func TestXfidclose(t *testing.T) {
 }
 
 func TestXfidwriteQWdata(t *testing.T) {
-	configureGlobals()
 	display := edwoodtest.NewDisplay()
+	global.configureGlobals(display)
 
 	mr := new(mockResponder)
 	w := NewWindow().initHeadless(nil)
@@ -672,8 +672,8 @@ func TestXfidwriteQWtag(t *testing.T) {
 }
 
 func TestXfidwriteQWwrsel(t *testing.T) {
-	configureGlobals()
 	mockDisplay := edwoodtest.NewDisplay()
+	global.configureGlobals(mockDisplay)
 
 	w := NewWindow().initHeadless(nil)
 	w.col = new(Column)
@@ -745,7 +745,7 @@ func TestXfidwriteQlabel(t *testing.T) {
 }
 
 func TestXfidwriteQcons(t *testing.T) {
-	configureGlobals()
+	global.configureGlobals(edwoodtest.NewDisplay())
 	mr := new(mockResponder)
 
 	global.row.Init(image.Rectangle{
@@ -782,9 +782,9 @@ func TestXfidwriteQWerrors(t *testing.T) {
 	// be using a quality backing mock.
 	data := []byte("window error: Hello, 世界!\n")
 
-	configureGlobals()
-	mr := new(mockResponder)
 	mockdisplay := edwoodtest.NewDisplay()
+	global.configureGlobals(mockdisplay)
+	mr := new(mockResponder)
 
 	global.row.display = mockdisplay
 
@@ -892,7 +892,7 @@ func TestXfidwriteQWeditout(t *testing.T) {
 }
 
 func TestXfidwriteQWctl(t *testing.T) {
-	configureGlobals()
+	global.configureGlobals(edwoodtest.NewDisplay())
 	warnings = nil
 	global.cwarn = nil
 
@@ -1121,7 +1121,7 @@ func TestXfidreadQWbodyQWtag(t *testing.T) {
 	// TODO(rjk): These tests are fragile in how they setup their skeleton.
 	// Use the common skeleton.
 	display := edwoodtest.NewDisplay()
-	configureGlobals()
+	global.configureGlobals(display)
 	const data = "This is an εxαmplε sentence.\n"
 
 	for _, tc := range []struct {


### PR DESCRIPTION
To help with #56 and other frame.Frame improvements, update the draw
mock to record the commands sent to 9fans.net/go/draw. Further use
this in some simple tests of frame.Insert to demonstrate that the
mocks work and significantly expand test coverage of the frame unit
tests.
