### PR TITLE
Fix a race condition with error windows

### DIFF
--- a/xfid.go
+++ b/xfid.go
@@ -433,7 +433,9 @@ func xfidwrite(x *Xfid) {
 	//x.fcall.Data[x.fcall.Count] = 0; // null-terminate. unneeded
 	switch qid {
 	case Qcons:
+		global.row.lk.Lock()
 		w = errorwin(x.f.mntdir, 'X')
+		global.row.lk.Unlock()
 		updateText(&w.body)
 
 	case Qlabel:


### PR DESCRIPTION
Fixes #57: we lookup a window in `edwood/util.go:66`. It's happy to
find a window from `g.row` while `g.row` is locked and that window
struct can be invalid at the time during a `del()` action. So lock the
row/column struct while obtaining the window object.
