### PR TITLE
Rune-boundary access to undo.Buffer

### DIFF
--- a/file/file_test.go
+++ b/file/file_test.go
@@ -26,7 +26,7 @@ func TestDelObserver(t *testing.T) {
 	for _, text := range testData {
 		f.AddObserver(text)
 	}
-	println("Size is now: ", f.GetObserverSize())
+	t.Log("Size is now: ", f.GetObserverSize())
 	for i, text := range testData {
 		err := f.DelObserver(text)
 		if err != nil {

--- a/file/offset_tuple.go
+++ b/file/offset_tuple.go
@@ -7,14 +7,6 @@ type OffSetTuple struct {
 	r int
 }
 
-// can work this api to be a little better...
-func (o OffSetTuple) add(b, r int) OffSetTuple {
-	return OffSetTuple{
-		b: o.b + b,
-		r: o.r + r,
-	}
-}
-
 func (o OffSetTuple) String() string {
 	return fmt.Sprintf("offsettuple b: %d r: %d", o.b, o.r)
 }

--- a/file/offset_tuple.go
+++ b/file/offset_tuple.go
@@ -1,0 +1,20 @@
+package file
+
+import "fmt"
+
+type OffSetTuple struct {
+	b int64
+	r int64
+}
+
+// can work this api to be a little better...
+func (o OffSetTuple) add(b, r int64) OffSetTuple {
+	return OffSetTuple{
+		b: o.b + b,
+		r: o.r + r,
+	}
+}
+
+func (o OffSetTuple) String() string {
+	return fmt.Sprintf("offsettuple b: %d r: %d", o.b, o.r)
+}

--- a/file/offset_tuple.go
+++ b/file/offset_tuple.go
@@ -3,12 +3,12 @@ package file
 import "fmt"
 
 type OffSetTuple struct {
-	b int64
-	r int64
+	b int
+	r int
 }
 
 // can work this api to be a little better...
-func (o OffSetTuple) add(b, r int64) OffSetTuple {
+func (o OffSetTuple) add(b, r int) OffSetTuple {
 	return OffSetTuple{
 		b: o.b + b,
 		r: o.r + r,

--- a/file/undo_test.go
+++ b/file/undo_test.go
@@ -18,18 +18,18 @@ func TestOverall(t *testing.T) {
 	b.checkPiecesCnt(t, 2)
 	b.checkContent("#1", t, "")
 
-	b.insertString(0, "All work makes John a dull boy")
+	b.insertString(0, "All work ウクラ makes John a dull boy")
 	b.checkPiecesCnt(t, 3)
-	b.checkContent("#2", t, "All work makes John a dull boy")
+	b.checkContent("#2", t, "All work ウクラ makes John a dull boy")
 
 	b.insertString(9, "and no playing ")
 	b.checkPiecesCnt(t, 6)
-	b.checkContent("#3", t, "All work and no playing makes John a dull boy")
+	b.checkContent("#3", t, "All work and no playing ウクラ makes John a dull boy")
 
 	b.Commit()
 	// Also check that multiple change commits don't create empty changes.
 	b.Commit()
-	b.deleteCreateOffsetTuple(20, 14)
+	b.deleteCreateOffsetTuple(20, 18)
 	b.checkContent("#4", t, "All work and no play a dull boy")
 
 	b.insertString(20, " makes Jack")
@@ -38,12 +38,12 @@ func TestOverall(t *testing.T) {
 	b.Undo()
 	b.checkContent("#6", t, "All work and no play a dull boy")
 	b.Undo()
-	b.checkContent("#7", t, "All work and no playing makes John a dull boy")
+	b.checkContent("#7", t, "All work and no playing ウクラ makes John a dull boy")
 	b.Undo()
-	b.checkContent("#8", t, "All work makes John a dull boy")
+	b.checkContent("#8", t, "All work ウクラ makes John a dull boy")
 
 	b.Redo()
-	b.checkContent("#9", t, "All work and no playing makes John a dull boy")
+	b.checkContent("#9", t, "All work and no playing ウクラ makes John a dull boy")
 	b.Redo()
 	b.checkContent("#10", t, "All work and no play a dull boy")
 	b.Redo()

--- a/file/undo_test.go
+++ b/file/undo_test.go
@@ -320,7 +320,7 @@ func TestPieceNr(t *testing.T) {
 	buffAfterInserts := string(eng2) + string(manderianBytes) + string(eng1)
 	b.checkContent("TestPieceNr: third insert", t, buffAfterInserts)
 
-	fmt.Printf("Before delete: %v\n", string(b.Bytes()))
+	t.Logf("Before delete: %v\n", string(b.Bytes()))
 
 	b.deleteCreateOffsetTuple(13, 10) // Currently, the offset translates to 17 (should be 20). Should be deleting a total of 25 bytes
 
@@ -405,20 +405,6 @@ func (t *Buffer) delete(off, length int) {
 
 func (t *Buffer) cacheDelete(off, length int) {
 	t.deleteCreateOffsetTuple((off), (length))
-}
-
-func (t *Buffer) printPieces() {
-	for p := t.begin; p != nil; p = p.next {
-		prev, next := 0, 0
-		if p.prev != nil {
-			prev = p.prev.id
-		}
-		if p.next != nil {
-			next = p.next.id
-		}
-		fmt.Printf("%d, p:%d, n:%d = %s\n", p.id, prev, next, string(p.data))
-	}
-	fmt.Println()
 }
 
 func TestRuneTuple(t *testing.T) {


### PR DESCRIPTION
The original undo.Buffer implementation provided only
byte-grannularity access. Edwood assumes the ability to access its
backing text storage at rune boundaries. Add support for (hopefully)
efficient rune-boundary access.
