### PR TITLE
Hoist ObservableEditableBuffer

### DIFF
--- a/file/buffer_adapter.go
+++ b/file/buffer_adapter.go
@@ -1,0 +1,83 @@
+package file
+
+import (
+	"flag"
+	"io"
+)
+
+// BufferAdapter is a (temporary) interface between
+// ObservableEditableBuffer and either the legacy file.File or
+// file.Buffer implementations.
+type BufferAdapter interface {
+	// Mark sets an Undo point and and discards Redo records. Call this at
+	// the beginning of a set of edits that ought to be undo-able as a unit.
+	// This is equivalent to file.Buffer.Commit() NB: current implementation
+	// permits calling Mark on an empty file to indicate that one can undo to
+	// the file state at the time of calling Mark.
+	Mark()
+
+	// HasUncommitedChanges returns true if there are changes that
+	// have been made to the File since the last Commit.
+	HasUncommitedChanges() bool
+
+	// HasRedoableChanges returns true if there are entries in the Redo
+	// log that can be redone.
+	HasRedoableChanges() bool
+	// HasUndoableChanges returns true if there are changes to the File
+	// that can be undone.
+	HasUndoableChanges() bool
+
+	// Nr returns the number of valid runes in the File.
+	Nr() int
+
+	// ReadC reads a single rune from the File.
+	ReadC(q int) rune
+
+	// InsertAt inserts s runes at rune address p0.
+	InsertAt(p0 int, s []rune, seq int)
+
+	UnsetName(seq int)
+
+	// Undo undoes edits if isundo is true or redoes edits if isundo is false.
+	// It returns the new selection q0, q1 and a bool indicating if the
+	// returned selection is meaningful.
+	// TODO(rjk): do we use the returned values?
+	Undo(isundo bool, seq int) (int, int, bool, int)
+
+	// DeleteAt removes the rune range [p0,p1) from File.
+	DeleteAt(p0, p1, seq int)
+
+	// RedoSeq finds the seq of the last redo record.
+	RedoSeq() int
+
+	// Commit writes the in-progress edits to the real buffer instead of
+	// keeping them in the cache.
+	Commit(seq int)
+
+	Read(q0 int, r []rune) (int, error)
+	String() string
+	Reader(q0 int, q1 int) io.Reader
+	IndexRune(r rune) int
+
+	// InsertAtWithoutCommit inserts s at p0 by only writing to the cache.
+	InsertAtWithoutCommit(p0 int, s []rune)
+}
+
+// Enforce that *file.File implements BufferAdapter.
+var (
+	_ BufferAdapter = (*File)(nil)
+
+	// TODO(rjk): Make this compile. :-)
+	// _ BufferAdapter = (*Buffer)(nil)
+
+	newTypeBuffer bool
+)
+
+func init() {
+	flag.BoolVar(&newTypeBuffer, "newtypebuffer", false, "turn on the file.Buffer new Buffer implementation")
+}
+
+func NewTypeBuffer(r []rune, oeb *ObservableEditableBuffer) BufferAdapter {
+	// TODO(rjk): Write this.
+	return BufferAdapter(nil)
+}

--- a/file/file_file_test.go
+++ b/file/file_file_test.go
@@ -37,8 +37,10 @@ func TestFileHandlesNilEpsilonDelta(t *testing.T) {
 		{"redo (nil epsilon)", false, 14, 17, 14, 17, nil, nil},
 	} {
 		oeb := MakeObservableEditableBuffer("", []rune("This is an example sentence.\n"))
-		oeb.f.delta = tc.delta
-		oeb.f.epsilon = tc.epsilon
+
+		fimpl := oeb.f.(*File)
+		fimpl.delta = tc.delta
+		fimpl.epsilon = tc.epsilon
 
 		q0, q1 := tc.q0, tc.q1
 		if nq0, nq1, hazselection := oeb.Undo(tc.isundo); hazselection {

--- a/file/file_test.go
+++ b/file/file_test.go
@@ -376,31 +376,31 @@ func TestFileUpdateInfo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("stat failed: %v", err)
 	}
-	f := MakeObservableEditableBuffer(filename, nil).f
-	f.oeb.SetHash(EmptyHash)
-	f.oeb.SetInfo(nil)
+	oeb := MakeObservableEditableBuffer(filename, nil)
+	oeb.SetHash(EmptyHash)
+	oeb.SetInfo(nil)
 
-	f.oeb.UpdateInfo(filename, d)
-	if f.oeb.Info() != nil {
-		t.Errorf("File info is %v; want nil", f.oeb.Info())
+	oeb.UpdateInfo(filename, d)
+	if oeb.Info() != nil {
+		t.Errorf("File info is %v; want nil", oeb.Info())
 	}
 
 	h, err := HashFor(filename)
 	if err != nil {
 		t.Fatalf("HashFor(%v) failed: %v", filename, err)
 	}
-	f.oeb.SetHash(h)
-	f.oeb.SetInfo(nil)
-	f.oeb.UpdateInfo(filename, d)
-	if f.oeb.Info() != d {
-		t.Errorf("File info is %v; want %v", f.oeb.Info(), d)
+	oeb.SetHash(h)
+	oeb.SetInfo(nil)
+	oeb.UpdateInfo(filename, d)
+	if oeb.Info() != d {
+		t.Errorf("File info is %v; want %v", oeb.Info(), d)
 	}
 }
 
 func TestFileUpdateInfoError(t *testing.T) {
 	filename := "/non-existent-file"
-	f := MakeObservableEditableBuffer(filename, nil).f
-	err := f.oeb.UpdateInfo(filename, nil)
+	oeb := MakeObservableEditableBuffer(filename, nil)
+	err := oeb.UpdateInfo(filename, nil)
 	want := "failed to compute hash for"
 	if err == nil || !strings.HasPrefix(err.Error(), want) {
 		t.Errorf("File.UpdateInfo returned error %q; want prefix %q", err, want)


### PR DESCRIPTION
Prior to installing file.Buffer underneath ObservableEditableBuffer,
insert an interposing interface layer BufferAdapter to permit an OEB
to use either a file.File or a file.Buffer.
