### PR TITLE
Remove HasUncommitedChanges from SaveableAndDirty

### DIFF
--- a/file/file_test.go
+++ b/file/file_test.go
@@ -65,7 +65,7 @@ func TestFileInsertAtWithoutCommit(t *testing.T) {
 	}
 
 	check(t, "TestFileInsertAt after TestFileInsertAtWithoutCommit", f,
-		&stateSummary{true, true, false, true, s1})
+		&stateSummary{true, true, false, false, s1})
 }
 
 const s1 = "hi 海老麺"

--- a/file/observable_editable_buffer.go
+++ b/file/observable_editable_buffer.go
@@ -249,7 +249,7 @@ func (e *ObservableEditableBuffer) ReadC(q int) rune {
 // as clean and is this File writable to a backing. They are combined in
 // this method.
 func (e *ObservableEditableBuffer) SaveableAndDirty() bool {
-	sad := (e.f.HasUncommitedChanges() || e.Dirty()) && !e.IsDirOrScratch()
+	sad := e.Dirty() && !e.IsDirOrScratch()
 	return e.details.Name != "" && sad
 }
 


### PR DESCRIPTION
SaveableAndDirty only needs to be true for buffers with Undo so
there's no need to invoke HasUncommitedChanges. Helps with #97 because
file.Buffer does not have a Commit concept.
