### PR TITLE
De-hoisted the oeb implementation

### DIFF
--- a/file/buffer.go
+++ b/file/buffer.go
@@ -372,12 +372,9 @@ func (b *Buffer) findPiece(off OffSetTuple) (*piece, int, int) {
 	return nil, 0, 0
 }
 
-// Undo reverts the last performed action. It returns the offset in bytes
-// at which the first change of the action occurred and the number of bytes
-// the change added at off. If there is no action to undo, Undo returns -1
-// as the offset.
-// TODO(rjk): Rationalize the returned values. I'm not sure that they're
-// useful for correct.
+// Undo reverts the last performed action. It returns the new selection
+// q0, q1 and a bool indicating if the returned selection is meaningful..
+// If there is no action to undo, Undo returns -1 as the offset.
 func (b *Buffer) Undo(_ int) (int, int, bool, int) {
 	// log.Println("Undo start")
 	// defer log.Println("Undo end")
@@ -480,10 +477,9 @@ func (b *Buffer) filenameChangeAction(a *action) (int, int, bool, int) {
 	return -1, 0, false, 0
 }
 
-// Redo repeats the last undone action. It returns the offset in bytes
-// at which the last change of the action occurred and the number of bytes
-// the change added at off. If there is no action to redo, Redo returns -1
-// as the offset.
+// Redo repeats the last undone action. It returns new selection q0, q1
+// and a bool indicating if the returned selection is meaningful.. If
+// there is no action to redo, Redo returns -1 as the offset.
 func (b *Buffer) Redo(_ int) (int, int, bool, int) {
 	//	log.Println("Redo start")
 	//	defer log.Println("Redo end")
@@ -512,10 +508,9 @@ func (b *Buffer) Redo(_ int) (int, int, bool, int) {
 	return roff, roff - nr, true, b.actions[b.head-1].seq
 }
 
-// RedoSeq finds the seq of the last redo record. TODO(rjk): This has no
-// analog in file.Buffer. The value of seq is used to track intra and
-// inter File edit actions so that cross-File changes via Edit X can be
-// undone with a single action.
+// RedoSeq finds the seq of the last redo record.The value of seq is used
+// to track intra and inter File edit actions so that cross-File changes
+// via Edit X can be undone with a single action.
 func (b *Buffer) RedoSeq() int {
 	if len(b.actions) > 0 && b.head < len(b.actions) {
 		return b.actions[b.head].seq
@@ -739,16 +734,22 @@ func (b *Buffer) Bytes() []byte {
 	return byteBuf
 }
 
+// HasUncommitedChanges returns true if there are changes that
+// have been made to the File since the last Commit.
 // TODO(rjk): This concept is not needed in a file.Buffer world. Improve
 // this.
 func (b *Buffer) HasUncommitedChanges() bool {
 	return false
 }
 
+// HasUndoableChanges returns true if there are changes to the File
+// that can be undone.
 func (b *Buffer) HasUndoableChanges() bool {
 	return b.head != 0
 }
 
+// HasRedoableChanges returns true if there are entries in the Redo
+// log that can be redone.
 func (b *Buffer) HasRedoableChanges() bool {
 	return b.head <= len(b.actions)-1
 }

--- a/file/buffer_adapter.go
+++ b/file/buffer_adapter.go
@@ -7,77 +7,11 @@ import (
 	"strings"
 )
 
-// BufferAdapter is a (temporary) interface between
-// ObservableEditableBuffer and either the legacy file.File or
-// file.Buffer implementations.
-type BufferAdapter interface {
-	// Mark sets an Undo point and and discards Redo records. Call this at
-	// the beginning of a set of edits that ought to be undo-able as a unit.
-	// This is equivalent to file.Buffer.Commit() NB: current implementation
-	// permits calling Mark on an empty file to indicate that one can undo to
-	// the file state at the time of calling Mark.
-	Mark()
-
-	// HasUncommitedChanges returns true if there are changes that
-	// have been made to the File since the last Commit.
-	HasUncommitedChanges() bool
-
-	// HasRedoableChanges returns true if there are entries in the Redo
-	// log that can be redone.
-	HasRedoableChanges() bool
-	// HasUndoableChanges returns true if there are changes to the File
-	// that can be undone.
-	HasUndoableChanges() bool
-
-	// Nr returns the number of valid runes in the File.
-	Nr() int
-
-	// ReadC reads a single rune from the File.
-	ReadC(q int) rune
-
-	// InsertAt inserts s runes at rune address p0.
-	InsertAt(p0 int, s []rune, seq int)
-
-	UnsetName(fname string, seq int)
-
-	// Undo undoes edits. It returns the new selection q0, q1 and a bool
-	// indicating if the returned selection is meaningful.
-	Undo(seq int) (int, int, bool, int)
-
-	// Redo redoes a previous group of edits.
-	// TODO(rjk): must support the return values.
-	Redo(seq int) (int, int, bool, int)
-
-	// DeleteAt removes the rune range [p0,p1) from File.
-	DeleteAt(p0, p1, seq int)
-
-	// RedoSeq finds the seq of the last redo record.
-	RedoSeq() int
-
-	// Commit writes the in-progress edits to the real buffer instead of
-	// keeping them in the cache.
-	Commit(seq int)
-
-	Read(q0 int, r []rune) (int, error)
-	String() string
-	Reader(q0 int, q1 int) io.Reader
-
-	// TODO(rjk): This should probably return an OffsetTuple
-	IndexRune(r rune) int
-
-	// InsertAtWithoutCommit inserts s at p0 by only writing to the cache.
-	InsertAtWithoutCommit(p0 int, s []rune, seq int)
-}
-
-// Enforce that *file.File implements BufferAdapter.
-var (
-	_ BufferAdapter = (*Buffer)(nil)
-)
-
-func NewTypeBuffer(inputrunes []rune, oeb *ObservableEditableBuffer) BufferAdapter {
+func NewTypeBuffer(inputrunes []rune, oeb *ObservableEditableBuffer) *Buffer {
 	// TODO(rjk): Figure out how to plumb in the oeb object to setup Undo
 	// observer callbacks.
 
+	// TODO(rjk): We can do better.
 	buffy := new(bytes.Buffer)
 	buffy.Grow(len(inputrunes))
 	for _, r := range inputrunes {
@@ -89,10 +23,13 @@ func NewTypeBuffer(inputrunes []rune, oeb *ObservableEditableBuffer) BufferAdapt
 	return nb
 }
 
+// Commit writes the in-progress edits to the real buffer instead of
+// keeping them in the cache.
 func (b *Buffer) Commit(seq int) {
 	// NOP
 }
 
+// DeleteAt removes the rune range [p0,p1) from File.
 func (b *Buffer) DeleteAt(rp0, rp1, seq int) {
 	p0 := b.RuneTuple(rp0)
 	p1 := b.RuneTuple(rp1)
@@ -104,6 +41,7 @@ func (b *Buffer) DeleteAt(rp0, rp1, seq int) {
 	}
 }
 
+// InsertAt inserts s runes at rune address p0.
 func (b *Buffer) InsertAt(rp0 int, rs []rune, seq int) {
 	p0 := b.RuneTuple(rp0)
 
@@ -121,6 +59,8 @@ func (b *Buffer) InsertAt(rp0 int, rs []rune, seq int) {
 	}
 }
 
+// ReadC reads a single rune from the File.
+// TODO(rjk): Implement RuneReader
 func (b *Buffer) ReadC(q int) rune {
 	p0 := b.RuneTuple(q)
 
@@ -155,7 +95,11 @@ func (b *Buffer) InsertAtWithoutCommit(p0 int, s []rune, seq int) {
 	b.InsertAt(p0, s, seq)
 }
 
-// TODO(rjk): propagate the new name.
+// Mark sets an Undo point and and discards Redo records. Call this at
+// the beginning of a set of edits that ought to be undo-able as a unit.
+// This is equivalent to file.Buffer.Commit() NB: current implementation
+// permits calling Mark on an empty file to indicate that one can undo to
+// the file state at the time of calling Mark.
 func (b *Buffer) Mark() {
 	b.SetUndoPoint()
 }

--- a/file/helpers_test.go
+++ b/file/helpers_test.go
@@ -6,17 +6,6 @@ import (
 	"testing"
 )
 
-type checkable interface {
-	BufferAdapter
-
-	// Return the entire backing as a string.
-	readwholefile(*testing.T) string
-
-	// Return true to enable tests of UncommittedChanges. This concept does not
-	// exist with file.Buffer.
-	commitisgermane() bool
-}
-
 type stateSummary struct {
 	HasUncommitedChanges bool
 	HasUndoableChanges   bool
@@ -34,8 +23,7 @@ func (b *Buffer) readwholefile(*testing.T) string {
 func check(t *testing.T, testname string, oeb *ObservableEditableBuffer, fss *stateSummary) {
 	t.Helper()
 
-	// Lets the test infrastructure call against file.Buffer or file.File.
-	f := oeb.f.(checkable)
+	f := oeb.f
 
 	if f.commitisgermane() {
 		if got, want := oeb.HasUncommitedChanges(), fss.HasUncommitedChanges; got != want {

--- a/file/observable_editable_buffer.go
+++ b/file/observable_editable_buffer.go
@@ -21,8 +21,7 @@ type ObservableEditableBuffer struct {
 	observers       map[BufferObserver]struct{}
 	statusobservers map[TagStatusObserver]struct{}
 
-	// The switchable implementation.
-	f BufferAdapter
+	f *Buffer
 
 	Elog sam.Elog
 


### PR DESCRIPTION
While implementing the newtype file.Buffer, I'd abstracted it
internally to exist both old and new types to exist simultaneously.
With the removal of old type buffers, remove this. Cleanup that's part
of #97.
