### PR TITLE
Add []byte Insert to frame

### DIFF
--- a/frame/frame.go
+++ b/frame/frame.go
@@ -39,7 +39,7 @@ type SelectScrollUpdater interface {
 	// Delete will clear a selection or tick if present but not put it back.
 	Delete(int, int) int
 
-	// Insert inserts r into Frame f starting at index p0.
+	// Insert inserts r into Frame f starting at rune index p0.
 	// If a NUL (0) character is inserted, chaos will ensue. Tabs
 	// and newlines are handled by the library, but all other characters,
 	// including control characters, are just displayed. For example,
@@ -47,6 +47,7 @@ type SelectScrollUpdater interface {
 	//
 	// Insert will remove the selection or tick  if present but update selection offsets.
 	Insert([]rune, int) bool
+	InsertByte([]byte, int) bool
 
 	IsLastLineFull() bool
 	Rect() image.Rectangle

--- a/frame/insert_test.go
+++ b/frame/insert_test.go
@@ -1,7 +1,6 @@
 package frame
 
 import (
-	"bytes"
 	"image"
 	"strings"
 	"testing"
@@ -47,10 +46,6 @@ func (bx InsertTest) Verify(t *testing.T, prefix string, result interface{}) {
 	testcore(t, prefix, bx.name, r.frame, bx.nbox, bx.afterboxes)
 }
 
-func mkRu(s string) []rune {
-	return bytes.Runes([]byte(s))
-}
-
 func makereplicatedstring(c int) string {
 	var b strings.Builder
 	b.WriteString("a本")
@@ -74,7 +69,7 @@ func TestBxscan(t *testing.T) {
 			},
 			func(f *frameimpl) (image.Point, image.Point, *frameimpl) {
 				pt1 := image.Pt(10, 15)
-				pt2, f := f.bxscan(mkRu("本"), &pt1)
+				pt2, f := f.bxscan([]byte("本"), &pt1)
 				return pt1, pt2, f
 			},
 			1,
@@ -91,7 +86,7 @@ func TestBxscan(t *testing.T) {
 			},
 			func(f *frameimpl) (image.Point, image.Point, *frameimpl) {
 				pt1 := image.Pt(56, 15)
-				pt2, f := f.bxscan(mkRu("本"), &pt1)
+				pt2, f := f.bxscan([]byte("本"), &pt1)
 				return pt1, pt2, f
 			},
 			1,
@@ -108,7 +103,7 @@ func TestBxscan(t *testing.T) {
 			},
 			func(f *frameimpl) (image.Point, image.Point, *frameimpl) {
 				pt1 := image.Pt(58, 15)
-				pt2, f := f.bxscan(mkRu("本"), &pt1)
+				pt2, f := f.bxscan([]byte("本"), &pt1)
 				return pt1, pt2, f
 			},
 			1,
@@ -125,7 +120,7 @@ func TestBxscan(t *testing.T) {
 			},
 			func(f *frameimpl) (image.Point, image.Point, *frameimpl) {
 				pt1 := image.Pt(56, 15)
-				pt2, f := f.bxscan(mkRu("本a"), &pt1)
+				pt2, f := f.bxscan([]byte("本a"), &pt1)
 				return pt1, pt2, f
 			},
 			2,
@@ -142,7 +137,7 @@ func TestBxscan(t *testing.T) {
 			},
 			func(f *frameimpl) (image.Point, image.Point, *frameimpl) {
 				pt1 := image.Pt(10, 15)
-				pt2, f := f.bxscan(mkRu(bigstring), &pt1)
+				pt2, f := f.bxscan([]byte(bigstring), &pt1)
 				return pt1, pt2, f
 			},
 			3,

--- a/frame/unlockedproxy.go
+++ b/frame/unlockedproxy.go
@@ -40,6 +40,12 @@ func (up *selectscrollupdaterimpl) Insert(r []rune, p0 int) bool {
 	return f.insertimpl(r, p0)
 }
 
+func (up *selectscrollupdaterimpl) InsertByte(b []byte, p0 int) bool {
+	// log.Println("selectscrollupdaterimpl.InsertByte")
+	f := (*frameimpl)(up)
+	return f.insertbyteimpl(b, p0)
+}
+
 func (up *selectscrollupdaterimpl) IsLastLineFull() bool {
 	// log.Println("selectscrollupdaterimpl.IsLastLineFull")
 	f := (*frameimpl)(up)

--- a/framemock_test.go
+++ b/framemock_test.go
@@ -22,6 +22,7 @@ func (mf *MockFrame) Charofpt(pt image.Point) int                  { return 0 }
 func (mf *MockFrame) DefaultFontHeight() int                       { return 10 }
 func (mf *MockFrame) Delete(int, int) int                          { return 0 }
 func (mf *MockFrame) Insert([]rune, int) bool                      { return false }
+func (mf *MockFrame) InsertByte([]byte, int) bool                  { return false }
 func (mf *MockFrame) IsLastLineFull() bool                         { return false }
 func (mf *MockFrame) Rect() image.Rectangle                        { return image.Rect(0, 0, 0, 0) }
 func (mf *MockFrame) TextOccupiedHeight(r image.Rectangle) int     { return 0 }


### PR DESCRIPTION
frame promptly converts its input []rune into []byte. This is
unnecessary when file.Buffer stores and can provide inserts as []byte.
Modify frame to provide []byte insertion.
