### PR TITLE
no-conversion observer to frame

### DIFF
--- a/file/buffer_adapter_test.go
+++ b/file/buffer_adapter_test.go
@@ -14,23 +14,6 @@ func TestNewTypeBufferCreation(t *testing.T) {
 	}
 }
 
-func TestNewDeleteAt(t *testing.T) {
-	b := NewTypeBuffer([]rune("hello"), nil)
-
-	b.DeleteAt(0, 2, 0)
-
-	if got, want := b.String(), "llo"; got != want {
-		t.Errorf("didn't run delete correctly got %q want %q", got, want)
-	}
-	if got, want := b.HasUndoableChanges(), false; got != want {
-		t.Errorf("HasUndoableChanges wrong got %v want %v", got, want)
-	}
-	if got, want := b.HasRedoableChanges(), false; got != want {
-		t.Errorf("HasRedoableChanges wrong got %v want %v", got, want)
-	}
-
-}
-
 func TestNewIndexRune(t *testing.T) {
 	b := NewTypeBuffer([]rune("yi 海老hi 海老麺麺"), nil)
 

--- a/file/buffer_observer.go
+++ b/file/buffer_observer.go
@@ -5,9 +5,9 @@ package file
 // notified of all buffer mutations made.
 type BufferObserver interface {
 
-	// inserted informs the implementer that rune array r was inserted at position q0.
-	Inserted(q0 int, r []rune)
+	// inserted informs the implementer that byte array b was inserted at position q0.
+	Inserted(q0 OffsetTuple, b []byte, nr int)
 
 	// deleted informs the implementer that character range [q0,q1) was deleted.
-	Deleted(q0, q1 int)
+	Deleted(q0, q1 OffsetTuple)
 }

--- a/file/helpers_test.go
+++ b/file/helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 type stateSummary struct {
@@ -69,23 +70,28 @@ func MakeTestObserver(t *testing.T) *testObserver {
 	}
 }
 
-func (to *testObserver) Inserted(q0 int, r []rune) {
+func (to *testObserver) Inserted(q0 OffsetTuple, b []byte, nr int) {
 	to.t.Helper()
+
+	if got, want := nr, utf8.RuneCount(b); got != want {
+		to.t.Errorf("testObserver.Inserted bad nr for %q: got %d, want %d", string(b), got, want)
+	}
+
 	o := &observation{
 		callback: "Inserted",
-		q0:       q0,
-		payload:  string(r),
+		q0:       q0.R,
+		payload:  string(b),
 	}
 	to.t.Log(o)
 	to.tape = append(to.tape, o)
 }
 
-func (to *testObserver) Deleted(q0, q1 int) {
+func (to *testObserver) Deleted(q0, q1 OffsetTuple) {
 	to.t.Helper()
 	o := &observation{
 		callback: "Deleted",
-		q0:       q0,
-		q1:       q1,
+		q0:       q0.R,
+		q1:       q1.R,
 	}
 	to.t.Log(o)
 	to.tape = append(to.tape, o)

--- a/file/observable_editable_buffer.go
+++ b/file/observable_editable_buffer.go
@@ -281,8 +281,7 @@ func (e *ObservableEditableBuffer) Load(q0 int, fd io.Reader, sethash bool) (int
 	}
 
 	runes, _, hasNulls := util.Cvttorunes(d, len(d))
-	e.f.InsertAt(q0, runes, e.seq)
-	e.inserted(q0, runes)
+	e.InsertAt(q0, runes)
 	return len(runes), hasNulls, err
 }
 
@@ -294,12 +293,24 @@ func (e *ObservableEditableBuffer) Dirty() bool {
 
 // InsertAt is a forwarding function for file.InsertAt.
 // p0 is position in runes.
-func (e *ObservableEditableBuffer) InsertAt(p0 int, s []rune) {
+func (e *ObservableEditableBuffer) InsertAt(rp0 int, rs []rune) {
+	p0 := e.f.RuneTuple(rp0)
+	s, nr := RunesToBytes(rs)
+
+	e.Insert(p0, s, nr)
+}
+
+// Insert is a forwarding function for file.Insert.
+// p0 is position in runes.
+func (e *ObservableEditableBuffer) Insert(p0 OffsetTuple, s []byte, nr int) {
 	before := e.getTagStatus()
 	defer e.notifyTagObservers(before)
 
-	e.f.InsertAt(p0, s, e.seq)
-	e.inserted(p0, s)
+	e.f.Insert(p0, s, nr, e.seq)
+	if e.seq < 1 {
+		e.f.FlattenHistory()
+	}
+	e.inserted(p0, s, nr)
 }
 
 // SetName sets the name of the backing for this file. Some backing names
@@ -337,13 +348,24 @@ func (e *ObservableEditableBuffer) Undo(isundo bool) (q0, q1 int, ok bool) {
 	return q0, q1, ok
 }
 
-// DeleteAt is a forwarding function for file.DeleteAt.
-// q0, q1 are in runes.
-func (e *ObservableEditableBuffer) DeleteAt(q0, q1 int) {
+// DeleteAt is a forwarding function for buffer.DeleteAt.
+// rp0, rp1 are in runes.
+func (e *ObservableEditableBuffer) DeleteAt(rp0, rp1 int) {
+	p0 := e.f.RuneTuple(rp0)
+	p1 := e.f.RuneTuple(rp1)
+
+	e.Delete(p0, p1)
+}
+
+// Delete is a forwarding function for buffer.Delete.
+func (e *ObservableEditableBuffer) Delete(q0, q1 OffsetTuple) {
 	before := e.getTagStatus()
 	defer e.notifyTagObservers(before)
 
-	e.f.DeleteAt(q0, q1, e.seq)
+	e.f.Delete(q0, q1, e.seq)
+	if e.seq < 1 {
+		e.f.FlattenHistory()
+	}
 	e.deleted(q0, q1)
 }
 
@@ -402,17 +424,17 @@ func (e *ObservableEditableBuffer) RedoSeq() int {
 // inserted is a package-only entry point from the underlying
 // buffer (file.Buffer or file.File) to run the registered observers
 // on a change in the buffer.
-func (e *ObservableEditableBuffer) inserted(q0 int, r []rune) {
+func (e *ObservableEditableBuffer) inserted(q0 OffsetTuple, b []byte, nr int) {
 	e.treatasclean = false
 	for observer := range e.observers {
-		observer.Inserted(q0, r)
+		observer.Inserted(q0, b, nr)
 	}
 }
 
 // deleted is a package-only entry point from the underlying
 // buffer (file.Buffer or file.File) to run the registered observers
 // on a change in the buffer.
-func (e *ObservableEditableBuffer) deleted(q0 int, q1 int) {
+func (e *ObservableEditableBuffer) deleted(q0, q1 OffsetTuple) {
 	e.treatasclean = false
 	for observer := range e.observers {
 		observer.Deleted(q0, q1)
@@ -430,8 +452,7 @@ func (e *ObservableEditableBuffer) Commit() {
 func (e *ObservableEditableBuffer) InsertAtWithoutCommit(p0 int, s []rune) {
 	before := e.getTagStatus()
 	defer e.notifyTagObservers(before)
-	e.f.InsertAtWithoutCommit(p0, s, e.seq)
-	e.inserted(p0, s)
+	e.InsertAt(p0, s)
 }
 
 // IsDirOrScratch returns true if the File has a synthetic backing of

--- a/file/offset_tuple.go
+++ b/file/offset_tuple.go
@@ -2,11 +2,18 @@ package file
 
 import "fmt"
 
-type OffSetTuple struct {
+type OffsetTuple struct {
 	B int
 	R int
 }
 
-func (o OffSetTuple) String() string {
+func (o OffsetTuple) String() string {
 	return fmt.Sprintf("offsettuple b: %d r: %d", o.B, o.R)
+}
+
+func Ot(b, r int) OffsetTuple {
+	return OffsetTuple{
+		B: b,
+		R: r,
+	}
 }

--- a/wind.go
+++ b/wind.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"image"
 	"os"
@@ -533,7 +534,12 @@ func (w *Window) Eventf(format string, args ...interface{}) {
 	if w.owner == 0 {
 		util.AcmeError("no window owner", nil)
 	}
-	b := []byte(fmt.Sprintf(format, args...))
+	buffy := new(bytes.Buffer)
+	fmt.Fprintf(buffy, format, args...)
+	b := buffy.Bytes()
+
+	// TODO(rjk): events should be a bytes.Buffer?
+
 	w.events = append(w.events, byte(w.owner))
 	w.events = append(w.events, b...)
 	x = w.eventx


### PR DESCRIPTION
Change the file.BufferObserver interface to eliminate all unnecessary
[]byte-[]rune conversions down into frame.
