### PR TITLE
Fix bxscan default insert

### DIFF
--- a/frame/boxtest_helpers_test.go
+++ b/frame/boxtest_helpers_test.go
@@ -19,18 +19,16 @@ func makeBox(s string) *frbox {
 	switch s {
 	case "\t":
 		return &frbox{
-			Wid:    5000,
+			Wid:    10,
 			Nrune:  -1,
-			Ptr:    []byte(s),
 			Bc:     r,
 			Minwid: 10,
 		}
 
 	case "\n":
 		return &frbox{
-			Wid:    5000,
+			Wid:    10000,
 			Nrune:  -1,
-			Ptr:    []byte(s),
 			Bc:     r,
 			Minwid: 0,
 		}

--- a/frame/boxtest_helpers_test.go
+++ b/frame/boxtest_helpers_test.go
@@ -82,7 +82,7 @@ func expectedboxesequal(t *testing.T, prefix, name string, i int, frame *frameim
 		case want.Ptr == nil && got.Ptr != nil:
 			t.Errorf("%s-%s: result box [%d] mismatch: got %#v (%s) want %#v (nil)", prefix, name, i, got, string(got.Ptr), want)
 		case want.Ptr != nil && got.Ptr != nil:
-			t.Errorf("%s-%s: result box [%d] mismatch: got %#v (%s) want %#v (%s)", prefix, name, i, got, string(got.Ptr), want, string(want.Ptr))
+			t.Errorf("%s-%s: result box [%d] mismatch: got %#v (%q) want %#v (%q)", prefix, name, i, got, string(got.Ptr), want, string(want.Ptr))
 		}
 	}
 }

--- a/frame/insert.go
+++ b/frame/insert.go
@@ -75,7 +75,7 @@ func (f *frameimpl) bxscan(inby []byte, ppt *image.Point) (image.Point, *frameim
 				}
 			}
 			_, n := utf8.DecodeRune(inby[i:])
-			wipbox.Ptr = wipbox.Ptr[:len(wipbox.Ptr)+n]
+			wipbox.Ptr = append(wipbox.Ptr, inby[i:i+n]...)
 			wipbox.Nrune++
 			i += n
 		}

--- a/frame/insert.go
+++ b/frame/insert.go
@@ -8,10 +8,18 @@ import (
 )
 
 func (frame *frameimpl) addifnonempty(box *frbox, inby []byte) *frbox {
-	if box != nil && len(box.Ptr) > 0 {
-		// log.Printf("addifnonempty %q", string(box.Ptr))
+	if box == nil {
+		return &frbox{
+			Ptr: inby,
+		}
+	}
+
+	if len(box.Ptr) > 0 {
 		box.Wid = frame.font.BytesWidth(box.Ptr)
 		frame.box = append(frame.box, box)
+		return &frbox{
+			Ptr: inby,
+		}
 	}
 	return nil
 }
@@ -44,6 +52,7 @@ func (f *frameimpl) bxscan(inby []byte, ppt *image.Point) (image.Point, *frameim
 		if nl > f.maxlines {
 			break
 		}
+
 		switch inby[i] {
 		case '\t':
 			wipbox = frame.addifnonempty(wipbox, inby[i+1:i+1])
@@ -69,13 +78,14 @@ func (f *frameimpl) bxscan(inby []byte, ppt *image.Point) (image.Point, *frameim
 			i++
 			nl++
 		default:
+			_, n := utf8.DecodeRune(inby[i:])
 			if wipbox == nil {
 				wipbox = &frbox{
-					Ptr: inby[i:i],
+					Ptr: inby[i : i+n],
 				}
+			} else {
+				wipbox.Ptr = wipbox.Ptr[:len(wipbox.Ptr)+n]
 			}
-			_, n := utf8.DecodeRune(inby[i:])
-			wipbox.Ptr = append(wipbox.Ptr, inby[i:i+n]...)
 			wipbox.Nrune++
 			i += n
 		}

--- a/frame/insert_test.go
+++ b/frame/insert_test.go
@@ -145,6 +145,24 @@ func TestBxscan(t *testing.T) {
 			image.Pt(10, 15),
 			image.Pt(10+2*10, 15+13+13),
 		},
+		InsertTest{
+			"tabs and newlines placed in dedicated boxes",
+			&frameimpl{
+				font:              mockFont(),
+				defaultfontheight: 13,
+				rect:              image.Rect(10, 15, 10+57, 15+57),
+				maxtab:            8,
+			},
+			func(f *frameimpl) (image.Point, image.Point, *frameimpl) {
+				pt1 := image.Pt(10, 15)
+				pt2, f := f.bxscan([]byte("\ta\n"), &pt1)
+				return pt1, pt2, f
+			},
+			3,
+			[]*frbox{makeBox("\t"), makeBox("a"), makeBox("\n")},
+			image.Pt(10, 15),
+			image.Pt(10, 15+13),
+		},
 	})
 }
 


### PR DESCRIPTION
This fixes #438: The default case in `bxscan` was not ignoring tabs that had already been placed into a box in the associated switch statement case, leading to `frbox.Ptr` not containing the last character when this occurred. As an example, `frbox.Ptr` was being built up as follows:

```
[9]
[9 120]
[9 120 102]
[9 120 102 105]
[9 120 102 105 100]
[9 120 102 105 100 95]
[9 120 102 105 100 95 116]
[9 120 102 105 100 95 116 101]
[9 120 102 105 100 95 116 101 115]
[9 120 102 105 100 95 116 101 115 116]
[9 120 102 105 100 95 116 101 115 116 46]
[9 120 102 105 100 95 116 101 115 116 46 103]
```

Changing the default case to only take a slice of `inby` from the current index fixes this issue:

```
[120]
[120 102]
[120 102 105]
[120 102 105 100]
[120 102 105 100 95]
[120 102 105 100 95 116]
[120 102 105 100 95 116 101]
[120 102 105 100 95 116 101 115]
[120 102 105 100 95 116 101 115 116]
[120 102 105 100 95 116 101 115 116 46]
[120 102 105 100 95 116 101 115 116 46 103]
[120 102 105 100 95 116 101 115 116 46 103 111]
```

The test helpers have also been fixed to accommodate test cases containing tabs and newlines.