### PR TITLE
Set environment for shell cmd execution

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -894,7 +894,16 @@ func runproc(win *Window, s string, dir string, newns bool, argaddr string, arg 
 			shell = "rc"
 		}
 		rcarg = []string{shell, "-c", t}
+
+		env := os.Environ()
+		env = append(env, fmt.Sprintf("winid=%d", winid))
+		if filename != "" {
+			env = append(env, fmt.Sprintf("%%=%v", filename))
+			env = append(env, fmt.Sprintf("samfile=%v", filename))
+		}
+
 		cmd := exec.Command(rcarg[0], rcarg[1:]...)
+		cmd.Env = env
 		cmd.Dir = dir
 		cmd.Stdin = sin
 		cmd.Stdout = sout


### PR DESCRIPTION
Environment variables like`$samfile`, `$%`, and `$winid` were not being set when the command was being executed using `Hard()` (acmeshell not set, command contains `$`, etc). For example, in acme you can execute `echo $winid` and see the window id printed in an error window which can be useful in many situations. This PR restores restores that original acme behavior in Edwood.

Adding tests for these cases requires that the `Window` is available to `runproc` which the current test suite does not set. Let me know if there is somewhere else this should be tested and I can add test cases for this.