### PR TITLE
Efficient ReadC

### DIFF
--- a/file/buffer_adapter.go
+++ b/file/buffer_adapter.go
@@ -3,6 +3,7 @@ package file
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"io"
 	"strings"
 )
@@ -35,12 +36,7 @@ func (b *Buffer) Commit(seq int) {
 // TODO(rjk): Implement RuneReader
 func (b *Buffer) ReadC(q int) rune {
 	p0 := b.RuneTuple(q)
-
-	sr := io.NewSectionReader(b, int64(p0.B), 8)
-	bsr := bufio.NewReaderSize(sr, 8)
-
-	// TODO(rjk): Add some error checking?
-	r, _, _ := bsr.ReadRune()
+	r, _, _ := b.ReadRuneAt(p0)
 	return r
 }
 
@@ -103,4 +99,19 @@ func (b *Buffer) String() string {
 	// TODO(rjk): Add some error checking.
 	io.Copy(buffy, sr)
 	return buffy.String()
+}
+
+// viewedState returns a string representation of a Buffer b good for debugging.
+func (b *Buffer) viewedState() string {
+	sb := new(strings.Builder)
+
+	fmt.Fprintf(sb, "Buffer (vws: %v, vwl: %v) {\n", b.vws, b.vwl)
+	for p := b.begin; p != nil; p = p.next {
+		if p == b.viewed {
+			sb.WriteString("->")
+		}
+		fmt.Fprintf(sb, "	id: %d len: %d nr: %d data: %q\n", p.id, p.len(), p.nr, string(p.data))
+	}
+	sb.WriteString("}")
+	return sb.String()
 }

--- a/file/buffer_adapter_test.go
+++ b/file/buffer_adapter_test.go
@@ -90,3 +90,24 @@ func TestNewRead(t *testing.T) {
 		})
 	}
 }
+
+func TestReadCSplit(t *testing.T) {
+	b := NewBuffer([]byte("hello\n1 2 3 4\nfoo"), len("hello\n1 2 3 4\nfoo"))
+
+	t.Log("before insert", b.viewedState())
+
+	b.Insert(b.RuneTuple(len("hello\n1 2")), []byte("X"), 1, 1)
+
+	t.Log("after insert", b.viewedState())
+
+	s := "hello\n1 2X 3 4\nfoo"
+	if got, want := b.String(), s; got != want {
+		t.Errorf("buffer contents not as expected got %q, want %q", got, want)
+	}
+
+	for i, r := range s {
+		if got, want := b.ReadC(i), r; got != want {
+			t.Errorf("something went wrong? %d got '%c' %d, want '%c'", i, got, got, want)
+		}
+	}
+}

--- a/file/buffer_test.go
+++ b/file/buffer_test.go
@@ -14,25 +14,25 @@ func TestOverall(t *testing.T) {
 	b.checkPiecesCnt(t, 2)
 	b.checkContent("#0", t, "")
 
-	b.insertString(0, "")
+	b.insertString(0, "", t)
 	b.checkPiecesCnt(t, 2)
 	b.checkContent("#1", t, "")
 
-	b.insertString(0, "All work ウクラ makes John a dull boy")
+	b.insertString(0, "All work ウクラ makes John a dull boy", t)
 	b.checkPiecesCnt(t, 3)
 	b.checkContent("#2", t, "All work ウクラ makes John a dull boy")
 
-	b.insertString(9, "and no playing ")
+	b.insertString(9, "and no playing ", t)
 	b.checkPiecesCnt(t, 6)
 	b.checkContent("#3", t, "All work and no playing ウクラ makes John a dull boy")
 
 	b.SetUndoPoint()
 	// Also check that multiple change commits don't create empty changes.
 	b.SetUndoPoint()
-	b.deleteCreateOffsetTuple(20, 18)
+	b.deleteCreateOffsetTuple(20, 18, t)
 	b.checkContent("#4", t, "All work and no play a dull boy")
 
-	b.insertString(20, " makes Jack")
+	b.insertString(20, " makes Jack", t)
 	b.checkContent("#5", t, "All work and no play makes Jack a dull boy")
 
 	b.Undo(0)
@@ -57,19 +57,19 @@ func TestCacheInsertAndDelete(t *testing.T) {
 	b.checkPiecesCnt(t, 3)
 	b.checkContent("#0", t, "testing insertation")
 
-	b.cacheInsertString(8, "caching")
+	b.cacheInsertString(8, "caching", t)
 	b.checkPiecesCnt(t, 6)
 	b.checkContent("#1", t, "testing cachinginsertation")
 
-	b.cacheInsertString(15, " ")
+	b.cacheInsertString(15, " ", t)
 	b.checkPiecesCnt(t, 6)
 	b.checkContent("#2", t, "testing caching insertation")
 
-	b.cacheDelete(12, 3)
+	b.cacheDelete(12, 3, t)
 	b.checkPiecesCnt(t, 6)
 	b.checkContent("#3", t, "testing cach insertation")
 
-	b.cacheInsertString(12, "ed")
+	b.cacheInsertString(12, "ed", t)
 	b.checkPiecesCnt(t, 6)
 	b.checkContent("#4", t, "testing cached insertation")
 }
@@ -77,7 +77,7 @@ func TestCacheInsertAndDelete(t *testing.T) {
 func TestSimulateBackspace(t *testing.T) {
 	b := NewBufferNoNr([]byte("apples and oranges"))
 	for i := 5; i > 0; i-- {
-		b.cacheDelete(i, 1)
+		b.cacheDelete(i, 1, t)
 	}
 	b.checkContent("#0", t, "a and oranges")
 	b.Undo(0)
@@ -87,7 +87,7 @@ func TestSimulateBackspace(t *testing.T) {
 func TestSimulateDeleteKey(t *testing.T) {
 	b := NewBufferNoNr([]byte("apples and oranges"))
 	for i := 0; i < 4; i++ {
-		b.cacheDelete(7, 1)
+		b.cacheDelete(7, 1, t)
 	}
 	b.checkContent("#0", t, "apples oranges")
 	b.Undo(0)
@@ -96,12 +96,12 @@ func TestSimulateDeleteKey(t *testing.T) {
 
 func TestDelete(t *testing.T) {
 	b := NewBufferNoNr([]byte("and what is a dream?"))
-	b.insertString(9, "exactly ")
+	b.insertString(9, "exactly ", t)
 	b.checkContent("#0", t, "and what exactly is a dream?")
 
-	b.delete(22, 2000)
+	b.delete(22, 2000, t)
 	b.checkContent("#1", t, "and what exactly is a ")
-	b.insertString(22, "joke?")
+	b.insertString(22, "joke?", t)
 	b.checkContent("#2", t, "and what exactly is a joke?")
 
 	cases := []struct {
@@ -115,7 +115,7 @@ func TestDelete(t *testing.T) {
 		{11, 3, "and what exly is a joke?"},
 	}
 	for _, c := range cases {
-		b.delete(c.off, c.len)
+		b.delete(c.off, c.len, t)
 		b.checkContent("#3", t, c.expected)
 		b.Undo(0)
 		b.checkContent("#4", t, "and what exactly is a joke?")
@@ -124,8 +124,8 @@ func TestDelete(t *testing.T) {
 
 func TestDeleteAtTheEndOfCachedPiece(t *testing.T) {
 	b := NewBufferNoNr([]byte("Original data."))
-	b.cacheInsertString(8, ",")
-	b.cacheDelete(9, 1)
+	b.cacheInsertString(8, ",", t)
+	b.cacheDelete(9, 1, t)
 	b.checkContent("#0", t, "Original,data.")
 	b.Undo(0)
 	b.checkContent("#1", t, "Original data.")
@@ -136,13 +136,13 @@ func TestGroupChanges(t *testing.T) {
 	b.checkPiecesCnt(t, 3)
 	// b.GroupChanges()
 
-	b.cacheDelete(0, 6)
+	b.cacheDelete(0, 6, t)
 	b.checkContent("#0", t, "1, group 2, group 3")
 
-	b.cacheDelete(3, 6)
+	b.cacheDelete(3, 6, t)
 	b.checkContent("#1", t, "1, 2, group 3")
 
-	b.cacheDelete(6, 6)
+	b.cacheDelete(6, 6, t)
 	b.checkContent("#2", t, "1, 2, 3")
 
 	b.Undo(0)
@@ -160,7 +160,7 @@ func TestSaving(t *testing.T) {
 	b := NewBufferNoNr(nil)
 
 	b.checkModified(t, 1, false)
-	b.insertString(0, "stars can frighten")
+	b.insertString(0, "stars can frighten", t)
 	b.checkModified(t, 2, true)
 
 	b.Clean()
@@ -171,7 +171,7 @@ func TestSaving(t *testing.T) {
 	b.Redo(0)
 	b.checkModified(t, 5, false)
 
-	b.insertString(0, "Neptun, Titan, ")
+	b.insertString(0, "Neptun, Titan, ", t)
 	b.checkModified(t, 6, true)
 	b.Undo(0)
 	b.checkModified(t, 7, false)
@@ -185,7 +185,7 @@ func TestSaving(t *testing.T) {
 	b = NewBufferNoNr([]byte("my book is closed"))
 	b.checkModified(t, 10, false)
 
-	b.insertString(17, ", I read no more")
+	b.insertString(17, ", I read no more", t)
 	b.checkModified(t, 11, true)
 	b.Undo(0)
 	b.checkModified(t, 12, false)
@@ -201,10 +201,10 @@ func TestSaving(t *testing.T) {
 
 func TestReader(t *testing.T) {
 	b := NewBufferNoNr(nil)
-	b.insertString(0, "So many")
-	b.insertString(7, " books,")
-	b.insertString(14, " so little")
-	b.insertString(24, " time.")
+	b.insertString(0, "So many", t)
+	b.insertString(7, " books,", t)
+	b.insertString(14, " so little", t)
+	b.insertString(24, " time.", t)
 	b.checkContent("#0", t, "So many books, so little time.")
 
 	cases := []struct {
@@ -240,11 +240,11 @@ func TestBufferSize(t *testing.T) {
 		want   int
 	}{
 		0: {func() {}, 0},
-		1: {func() { b.insertString(0, " Like") }, 5},
-		2: {func() { b.insertString(0, " Colour") }, 12},
-		3: {func() { b.insertString(7, " You") }, 16},
-		4: {func() { b.delete(5, 1) }, 15},
-		5: {func() { b.insertString(0, "Pink is the") }, 26},
+		1: {func() { b.insertString(0, " Like", t) }, 5},
+		2: {func() { b.insertString(0, " Colour", t) }, 12},
+		3: {func() { b.insertString(7, " You", t) }, 16},
+		4: {func() { b.delete(5, 1, t) }, 15},
+		5: {func() { b.insertString(0, "Pink is the", t) }, 26},
 		6: {func() { b.Undo(0) }, 15},
 		7: {func() { b.Redo(0) }, 26},
 	}
@@ -260,14 +260,14 @@ func TestBufferSize(t *testing.T) {
 func TestUndoRedoReturnedOffsets(t *testing.T) {
 	b := NewBufferNoNr(nil)
 	insert := func(off, len int) {
-		b.insertString(off, strings.Repeat(".", len))
+		b.insertString(off, strings.Repeat(".", len), t)
 	}
 	insert(0, 7)
 	insert(7, 5)
 	insert(12, 9)
-	b.delete(8, 8)
+	b.delete(8, 8, t)
 	insert(3, 19)
-	b.delete(0, 20)
+	b.delete(0, 20, t)
 
 	undo, redo := (*Buffer).Undo, (*Buffer).Redo
 	tests := []struct {
@@ -310,25 +310,25 @@ func TestPieceNr(t *testing.T) {
 	eng2 := []byte("This is the")
 	eng3 := []byte("In the midst")
 
-	b.insertCreateOffsetTuple(0, manderianBytes)
+	b.insertCreateOffsetTuple(0, manderianBytes, t)
 	b.checkContent("TestPieceNr: First insert", t, string(manderianBytes))
 
-	b.insertCreateOffsetTuple(b.Nr(), eng1)
+	b.insertCreateOffsetTuple(b.Nr(), eng1, t)
 	b.checkContent("TestPieceNr: Second insert", t, string(manderianBytes)+string(eng1))
 
-	b.insertCreateOffsetTuple(0, eng2)
+	b.insertCreateOffsetTuple(0, eng2, t)
 	buffAfterInserts := string(eng2) + string(manderianBytes) + string(eng1)
 	b.checkContent("TestPieceNr: third insert", t, buffAfterInserts)
 
 	t.Logf("Before delete: %v\n", string(b.Bytes()))
 
-	b.deleteCreateOffsetTuple(13, 10) // Currently, the offset translates to 17 (should be 20). Should be deleting a total of 25 bytes
+	b.deleteCreateOffsetTuple(13, 10, t) // Currently, the offset translates to 17 (should be 20). Should be deleting a total of 25 bytes
 
 	buffAfterDelete := []rune(buffAfterInserts)
 	buffAfterDelete = append(buffAfterDelete[:13], buffAfterDelete[23:]...)
 	b.checkContent("TestPieceNr: after 1 delete", t, string(buffAfterDelete))
 
-	b.insertCreateOffsetTuple(8, eng3)
+	b.insertCreateOffsetTuple(8, eng3, t)
 	buffAfterDelete = append(buffAfterDelete[:8], append([]rune(string(eng3)), buffAfterDelete[8:]...)...)
 	b.checkContent("TestPieceNr: after everything", t, string(buffAfterDelete))
 
@@ -386,122 +386,281 @@ func (b *Buffer) checkContent(name string, t *testing.T, expected string) {
 	}
 }
 
-func (t *Buffer) insertString(off int, data string) {
-	t.SetUndoPoint()
-	t.cacheInsertString(off, data)
+func (b *Buffer) insertString(off int, data string, t *testing.T) {
+	b.SetUndoPoint()
+	b.cacheInsertString(off, data, t)
 }
 
-func (t *Buffer) cacheInsertString(off int, data string) {
-	err := t.insertCreateOffsetTuple((off), []byte(data))
+func (b *Buffer) cacheInsertString(off int, data string, t *testing.T) {
+	err := b.insertCreateOffsetTuple((off), []byte(data), t)
 	if err != nil {
 		panic(err)
 	}
 }
 
-func (t *Buffer) delete(off, length int) {
-	t.SetUndoPoint()
-	t.cacheDelete(off, length)
+func (b *Buffer) delete(off, length int, t *testing.T) {
+	b.SetUndoPoint()
+	b.cacheDelete(off, length, t)
 }
 
-func (t *Buffer) cacheDelete(off, length int) {
-	t.deleteCreateOffsetTuple((off), (length))
+func (b *Buffer) cacheDelete(off, length int, t *testing.T) {
+	b.deleteCreateOffsetTuple(off, length, t)
 }
 
 func TestRuneTuple(t *testing.T) {
 	tt := []struct {
-		name  string
-		buf   []string
-		roff  int
-		bwant int
+		name    string
+		buf     []string
+		roff    int
+		bwant   int
+		preops  []int
+		bviewed int
 	}{
 		{
-			name:  "one buf, start",
-			buf:   []string{"foo"},
-			roff:  0,
-			bwant: 0,
+			name:    "zero buf, start",
+			buf:     []string{},
+			roff:    0,
+			bwant:   0,
+			bviewed: 1,
 		},
 		{
-			name:  "one buf, middle",
-			buf:   []string{"foo"},
-			roff:  1,
-			bwant: 1,
+			name:    "one buf, start",
+			buf:     []string{"foo"},
+			roff:    0,
+			bwant:   0,
+			bviewed: 1,
 		},
 		{
-			name:  "one buf, end",
-			buf:   []string{"foo"},
-			roff:  2,
-			bwant: 2,
+			name:    "one buf, middle",
+			buf:     []string{"foo"},
+			roff:    1,
+			bwant:   1,
+			bviewed: 3,
 		},
 		{
-			name:  "one buf, not-ASCII, mid",
-			buf:   []string{"a痛苦本身"},
-			roff:  2,
-			bwant: len("a痛"),
+			name:    "one buf, end",
+			buf:     []string{"foo"},
+			roff:    2,
+			bwant:   2,
+			bviewed: 3,
 		},
 		{
-			name:  "one buf, not-ASCII, end",
-			buf:   []string{"痛苦本身"},
-			roff:  3,
-			bwant: len("痛苦本"),
+			name:    "one buf, not-ASCII, mid",
+			buf:     []string{"a痛苦本身"},
+			roff:    2,
+			bwant:   len("a痛"),
+			bviewed: 3,
 		},
 		{
-			name:  "one buf, not-ASCII, past-end",
-			buf:   []string{"痛苦本身"},
-			roff:  4,
-			bwant: len("痛苦本身"),
+			name:    "one buf, not-ASCII, end",
+			buf:     []string{"痛苦本身"},
+			roff:    3,
+			bwant:   len("痛苦本"),
+			bviewed: 3,
 		},
 		{
-			name:  "one buf, not-ASCII, far past-end",
-			buf:   []string{"痛苦本身"},
-			roff:  1000,
-			bwant: len("痛苦本身"),
+			name:    "one buf, not-ASCII, past-end",
+			buf:     []string{"痛苦本身"},
+			roff:    4,
+			bwant:   len("痛苦本身"),
+			bviewed: 3,
 		},
 		{
-			name:  "three bufs, not-ASCII, start of middle piece",
-			buf:   []string{"痛苦本身", "痛苦本", "痛苦痛苦本身"},
-			roff:  5,
-			bwant: len("痛苦本身痛"),
+			name:    "one buf, not-ASCII, far past-end",
+			buf:     []string{"痛苦本身"},
+			roff:    1000,
+			bwant:   len("痛苦本身"),
+			bviewed: 2,
 		},
 		{
-			name:  "one buf, not-ASCII, end of middle piece",
-			buf:   []string{"痛苦本身", "痛苦本", "痛苦痛苦本身"},
-			roff:  7,
-			bwant: len("痛苦本身痛苦本"),
+			name:    "three bufs, not-ASCII, start of middle piece",
+			buf:     []string{"痛苦本身", "痛ö本", "a苦痛苦本b"},
+			roff:    5,
+			bwant:   len("痛苦本身痛"),
+			bviewed: 4,
 		},
 		{
-			name:  "one buf, not-ASCII, start of end piece",
-			buf:   []string{"痛苦本身", "痛苦本", "痛苦痛苦本身"},
-			roff:  8,
-			bwant: len("痛苦本身痛苦本痛"),
+			name:    "three bufs, not-ASCII, end of middle piece",
+			buf:     []string{"痛苦本身", "痛苦本", "痛苦痛苦本身"},
+			roff:    7,
+			bwant:   len("痛苦本身痛苦本"),
+			bviewed: 4,
 		},
 		{
-			name:  "one buf, not-ASCII, end of end piece",
-			buf:   []string{"痛苦本身", "痛苦本", "痛苦痛苦本身"},
-			roff:  13,
-			bwant: len("痛苦本身痛苦本痛苦痛苦本身"),
+			name:    "three bufs, not-ASCII, start of end piece",
+			buf:     []string{"痛苦本身", "痛苦本", "痛苦痛苦本身"},
+			roff:    8,
+			bwant:   len("痛苦本身痛苦本痛"),
+			bviewed: 5,
+		},
+		{
+			name:    "three bufs, not-ASCII, end of end piece",
+			buf:     []string{"痛苦本身", "痛苦本", "痛苦痛苦本身"},
+			roff:    13,
+			bwant:   len("痛苦本身痛苦本痛苦痛苦本身"),
+			bviewed: 5,
 		},
 		{
 			// Count runes in xyz: echo -n xyz| u wc -m
-			name:  "failing case in TestPieceNr",
-			buf:   []string{"This is the", "痛苦本身可能是很多痛苦, 但主要的原因是痛苦, 但我给它时间陷入这种痛苦, 以至于有些巨大的痛苦Lorem ipsum in Mandarin"},
-			roff:  23,
-			bwant: len("This is the痛苦本身可能是很多痛苦,"),
+			name:    "failing case in TestPieceNr",
+			buf:     []string{"This is the", "痛苦本身可能是很多痛苦, 但主要的原因是痛苦, 但我给它时间陷入这种痛苦, 以至于有些巨大的痛苦Lorem ipsum in Mandarin"},
+			roff:    23,
+			bwant:   len("This is the痛苦本身可能是很多痛苦,"),
+			bviewed: 4,
+		},
+		{
+			name:    "one buf, not-ASCII, mid, preop 0",
+			buf:     []string{"a痛苦本身"},
+			roff:    2,
+			bwant:   len("a痛"),
+			preops:  []int{0},
+			bviewed: 3,
+		},
+		{
+			name:    "one buf, not-ASCII, mid, preop way past end",
+			buf:     []string{"a痛苦本身"},
+			roff:    2,
+			bwant:   len("a痛"),
+			preops:  []int{20},
+			bviewed: 3,
+		},
+		{
+			name:    "one buf, not-ASCII, mid, preop 1",
+			buf:     []string{"a痛苦本身"},
+			roff:    2,
+			bwant:   len("a痛"),
+			preops:  []int{1},
+			bviewed: 3,
+		},
+		{
+			name:    "one buf, not-ASCII, mid, preop 3",
+			buf:     []string{"a痛苦本身"},
+			roff:    2,
+			bwant:   len("a痛"),
+			preops:  []int{3},
+			bviewed: 3,
+		},
+		{
+			name:    "three bufs, not-ASCII, preop 3rd piece 8",
+			buf:     []string{"痛苦本身", "痛ö本", "a苦痛苦本b"},
+			roff:    1,
+			bwant:   len("痛"),
+			preops:  []int{8},
+			bviewed: 3,
+		},
+		{
+			name:    "three bufs, not-ASCII, preop 3rd piece 8, back to 5",
+			buf:     []string{"痛苦本身", "痛ö本", "a苦痛苦本b"},
+			roff:    5,
+			bwant:   len("痛苦本身痛"),
+			bviewed: 4,
+			preops:  []int{8},
+		},
+		{
+			name:    "three bufs, not-ASCII, preop 3rd piece 8, back to 7",
+			buf:     []string{"痛苦本身", "痛ö本", "a苦痛苦本b"},
+			roff:    7,
+			bwant:   len("痛苦本身痛ö本"),
+			preops:  []int{8},
+			bviewed: 4,
+		},
+		{
+			name:    "three bufs, not-ASCII, preop 3rd piece 8, back to 6",
+			buf:     []string{"痛苦本身", "痛ö本", "a苦痛苦本b"},
+			roff:    6,
+			bwant:   len("痛苦本身痛ö"),
+			preops:  []int{8},
+			bviewed: 4,
+		},
+		{
+			name:    "three bufs, not-ASCII, preop 3rd piece 8, back to 2",
+			buf:     []string{"痛苦本身", "痛ö本", "a苦痛苦本b"},
+			roff:    2,
+			bwant:   len("痛苦"),
+			preops:  []int{8},
+			bviewed: 3,
+		},
+		{
+			name:    "three bufs, not-ASCII, preop 3rd piece pastend",
+			buf:     []string{"痛苦本身", "痛ö本", "a苦痛苦本b"},
+			roff:    1,
+			bwant:   len("痛"),
+			preops:  []int{50},
+			bviewed: 3,
+		},
+		{
+			name:    "three bufs, not-ASCII, preop 3rd piece pastend, back to 5",
+			buf:     []string{"痛苦本身", "痛ö本", "a苦痛苦本b"},
+			roff:    5,
+			bwant:   len("痛苦本身痛"),
+			bviewed: 4,
+			preops:  []int{50},
+		},
+		{
+			name: "three bufs, not-ASCII, preop 3rd piece pastend, back to 7",
+			//
+			buf:     []string{"痛苦本身", "痛ö本", "a苦痛苦本b"},
+			roff:    7,
+			bwant:   len("痛苦本身痛ö本"),
+			preops:  []int{50},
+			bviewed: 4,
+		},
+		{
+			name:    "three bufs, not-ASCII, preop 3rd piece pastend, back to 6",
+			buf:     []string{"痛苦本身", "痛ö本", "a苦痛苦本b"},
+			roff:    6,
+			bwant:   len("痛苦本身痛ö"),
+			preops:  []int{50},
+			bviewed: 4,
+		},
+		{
+			name:    "three bufs, not-ASCII, preop 3rd piece pastend, back to 2",
+			buf:     []string{"痛苦本身", "痛ö本", "a苦痛苦本b"},
+			roff:    2,
+			bwant:   len("痛苦"),
+			preops:  []int{50},
+			bviewed: 3,
+		},
+		{
+			// NB: b.viewed is the piece that we would append an insert to.
+			// Character 9 is in the next piece.
+			name:    "failing case with single character structures",
+			buf:     []string{"hello\n1 2", "X", " 3 4\nfoo"},
+			roff:    9,
+			bwant:   9,
+			bviewed: 3,
+			preops:  []int{8},
 		},
 	}
 	for _, tv := range tt {
 		t.Run(tv.name, func(t *testing.T) {
 			b := NewBufferNoNr(nil)
 			for _, s := range tv.buf {
-				b.insertString(b.Nr(), s)
+				b.insertString(b.Nr(), s, t)
 			}
 			b.checkPiecesCnt(t, 2+len(tv.buf))
 
-			gt := b.RuneTuple((tv.roff))
-			if got, want := gt.B, tv.bwant; got != (want) {
+			// New bi-directional RuneTuple depends on the state of previous
+			// RuneTuple invocations to speed up operation. Run additional RuneTuple
+			// invocations here for their side-effects.
+			for _, d := range tv.preops {
+				b.RuneTuple(d)
+			}
+
+			t.Logf("test RuneTuple %d, %s", tv.roff, b.viewedState())
+			gt := b.RuneTuple(tv.roff)
+			t.Logf("test RuneTuple result %v, %s", gt, b.viewedState())
+
+			if got, want := gt.B, tv.bwant; got != want {
 				t.Errorf("%s got %d != want %d", "byte", got, want)
 			}
-			if got, want := gt.R, tv.roff; got != (want) {
+
+			if got, want := gt.R, tv.roff; got != want {
 				t.Errorf("%s got %d != want %d", "rune", got, want)
+			}
+
+			if got, want := b.viewed.id, tv.bviewed; got != want {
+				t.Errorf("%s got %d != want %d", "piece id", got, want)
 			}
 		})
 	}
@@ -527,10 +686,252 @@ func NewBufferNoNr(content []byte) *Buffer {
 	return NewBuffer(content, utf8.RuneCount(content))
 }
 
-func (b *Buffer) insertCreateOffsetTuple(off int, content []byte) error {
-	return b.Insert(b.RuneTuple(off), content, utf8.RuneCount(content), 1)
+func (b *Buffer) insertCreateOffsetTuple(off int, content []byte, t *testing.T) error {
+	t.Helper()
+	t.Logf("insertCreateOffsetTuple before RuneTuple %d state %s", off, b.viewedState())
+
+	start := b.RuneTuple(off)
+
+	t.Logf("insertCreateOffsetTuple after RuneTuple state %s", b.viewedState())
+
+	err := b.Insert(start, content, utf8.RuneCount(content), 1)
+
+	t.Logf("insertCreateOffsetTuple after Insert state %s", b.viewedState())
+
+	return err
 }
 
-func (b *Buffer) deleteCreateOffsetTuple(off, length int) error {
-	return b.Delete(b.RuneTuple(off), b.RuneTuple(off+length), 1)
+func (b *Buffer) deleteCreateOffsetTuple(off, length int, t *testing.T) error {
+	t.Helper()
+	t.Logf("deleteCreateOffsetTuple before first RuneTuple %d state %s", off, b.viewedState())
+	start := b.RuneTuple(off)
+	t.Logf("deleteCreateOffsetTuple before second RuneTuple %d state %s", off+length, b.viewedState())
+	end := b.RuneTuple(off + length)
+	t.Logf("before calling Delete start %v, end %v, state %s", start, end, b.viewedState())
+
+	return b.Delete(start, end, 1)
+}
+
+// RuneTuple creates a byte, rune offset pair (i.e. OffsetTuple) for a
+// given offset in runes.
+// TODO(rjk): Consider using the cached piece to speed this up.
+func (b *Buffer) OldRuneTuple(off int) OffsetTuple {
+	b.validateInvariant()
+
+	tr, tb := 0, 0
+	p := b.begin
+
+	// Find piece
+	for ; p != b.end && tr+p.nr < off; p = p.next {
+		tr += p.nr
+		tb += len(p.data)
+	}
+
+	// Find the byte offset in piece p
+	for i := 0; tr < off; tr++ {
+		_, sz := utf8.DecodeRune(p.data[i:])
+		tb += sz
+		i += sz
+	}
+
+	return OffsetTuple{
+		B: tb,
+		R: tr,
+	}
+}
+
+func TestFindPiece(t *testing.T) {
+	tt := []struct {
+		name   string
+		buf    []string
+		roff   int
+		preops []int
+	}{
+		{
+			name: "zero buf, start",
+			buf:  []string{},
+			roff: 0,
+		},
+		{
+			name: "one buf, start",
+			buf:  []string{"foo"},
+			roff: 0,
+		},
+		{
+			name: "one buf, middle",
+			buf:  []string{"foo"},
+			roff: 1,
+		},
+		{
+			name: "one buf, end",
+			buf:  []string{"foo"},
+			roff: 2,
+		},
+		{
+			name: "one buf, not-ASCII, mid",
+			buf:  []string{"a痛苦本身"},
+			roff: 2,
+		},
+		{
+			name: "one buf, not-ASCII, end",
+			buf:  []string{"痛苦本身"},
+			roff: 3,
+		},
+		{
+			name: "one buf, not-ASCII, past-end",
+			buf:  []string{"痛苦本身"},
+			roff: 4,
+		},
+		{
+			name: "one buf, not-ASCII, far past-end",
+			buf:  []string{"痛苦本身"},
+			roff: 1000,
+		},
+		{
+			name: "three bufs, not-ASCII, start of middle piece",
+			buf:  []string{"痛苦本身", "痛ö本", "a苦痛苦本b"},
+			roff: 5,
+		},
+		{
+			name: "three bufs, not-ASCII, end of middle piece",
+			buf:  []string{"痛苦本身", "痛苦本", "痛苦痛苦本身"},
+			roff: 7,
+		},
+		{
+			name: "three bufs, not-ASCII, start of end piece",
+			buf:  []string{"痛苦本身", "痛苦本", "痛苦痛苦本身"},
+			roff: 8,
+		},
+		{
+			name: "three bufs, not-ASCII, end of end piece",
+			buf:  []string{"痛苦本身", "痛苦本", "痛苦痛苦本身"},
+			roff: 13,
+		},
+		{
+			// Count runes in xyz: echo -n xyz| u wc -m
+			name: "failing case in TestPieceNr",
+			buf:  []string{"This is the", "痛苦本身可能是很多痛苦, 但主要的原因是痛苦, 但我给它时间陷入这种痛苦, 以至于有些巨大的痛苦Lorem ipsum in Mandarin"},
+			roff: 23,
+		},
+		{
+			name:   "one buf, not-ASCII, mid, preop 0",
+			buf:    []string{"a痛苦本身"},
+			roff:   2,
+			preops: []int{0},
+		},
+		{
+			name:   "one buf, not-ASCII, mid, preop way past end",
+			buf:    []string{"a痛苦本身"},
+			roff:   2,
+			preops: []int{20},
+		},
+		{
+			name:   "one buf, not-ASCII, mid, preop 1",
+			buf:    []string{"a痛苦本身"},
+			roff:   2,
+			preops: []int{1},
+		},
+		{
+			name:   "one buf, not-ASCII, mid, preop 3",
+			buf:    []string{"a痛苦本身"},
+			roff:   2,
+			preops: []int{3},
+		},
+		{
+			name:   "three bufs, not-ASCII, preop 3rd piece 8",
+			buf:    []string{"痛苦本身", "痛ö本", "a苦痛苦本b"},
+			roff:   1,
+			preops: []int{8},
+		},
+		{
+			name:   "three bufs, not-ASCII, preop 3rd piece 8, back to 5",
+			buf:    []string{"痛苦本身", "痛ö本", "a苦痛苦本b"},
+			roff:   5,
+			preops: []int{8},
+		},
+		{
+			name:   "three bufs, not-ASCII, preop 3rd piece 8, back to 7",
+			buf:    []string{"痛苦本身", "痛ö本", "a苦痛苦本b"},
+			roff:   7,
+			preops: []int{8},
+		},
+		{
+			name:   "three bufs, not-ASCII, preop 3rd piece 8, back to 6",
+			buf:    []string{"痛苦本身", "痛ö本", "a苦痛苦本b"},
+			roff:   6,
+			preops: []int{8},
+		},
+		{
+			name:   "three bufs, not-ASCII, preop 3rd piece 8, back to 2",
+			buf:    []string{"痛苦本身", "痛ö本", "a苦痛苦本b"},
+			roff:   2,
+			preops: []int{8},
+		},
+		{
+			name:   "failing case from TestOverall",
+			buf:    []string{"All work ", "and no playing ", "ウクラ makes John a dull boy"},
+			roff:   20,
+			preops: []int{20, 20 + 18},
+		},
+	}
+	for _, tv := range tt {
+		t.Run(tv.name, func(t *testing.T) {
+			b := NewBufferNoNr(nil)
+			for _, s := range tv.buf {
+				b.insertString(b.Nr(), s, t)
+			}
+			b.checkPiecesCnt(t, 2+len(tv.buf))
+
+			// We need the targetoff that will be an argument to findPiece. Make
+			// it here.
+			targetoff := b.RuneTuple(tv.roff)
+
+			// Invalidate the cached data to make sure that everything is consistent.
+			b.InvalidateCachedData()
+
+			// New bi-directional findPiece depends on the state of previous findPiece and
+			// RuneTuple invocations to speed up operation. Run additional RuneTuple
+			// invocations here for their side-effects.
+			for _, d := range tv.preops {
+				b.RuneTuple(d)
+			}
+
+			t.Logf("test findPiece %v, %s", targetoff, b.viewedState())
+			gotp, gotb, gotr := b.findPiece(targetoff)
+			t.Logf("test findPiece after %s", b.viewedState())
+
+			wantp, wantb, wantr := b.old_findPiece(targetoff)
+
+			if got, want := gotp, wantp; got != want {
+				t.Errorf("%s got %+v != want %+v", "piece", got, want)
+			}
+
+			if got, want := gotb, wantb; got != want {
+				t.Errorf("%s got %d != want %d", "byte", got, want)
+			}
+
+			if got, want := gotr, wantr; got != want {
+				t.Errorf("%s got %d != want %d", "rune", got, want)
+			}
+		})
+	}
+}
+
+// old_findPiece returns the piece holding the text at the byte offset, the
+// byte offset into piece and similarly for the rune offset. If off
+// happens to be at a piece boundary (i.e. the first byte of a piece)
+// then the previous piece to the left is returned with an offset of the
+// piece's length.
+//
+// If off is zero, the beginning sentinel piece is returned.
+func (b *Buffer) old_findPiece(off OffsetTuple) (*piece, int, int) {
+	tr, tb := 0, 0
+	for p := b.begin; p.next != nil; p = p.next {
+		if tb <= off.B && off.B <= tb+p.len() {
+			return p, off.B - tb, off.R - tr
+		}
+		tb += p.len()
+		tr += p.nr
+	}
+	return nil, 0, 0
 }

--- a/file/file_test.go
+++ b/file/file_test.go
@@ -52,10 +52,12 @@ func TestFileInsertAtWithoutCommit(t *testing.T) {
 
 	f.InsertAtWithoutCommit(0, []rune(s1))
 
+	t.Logf("contents %q, %s", f.f.String(), f.f.viewedState())
+
 	i := 0
 	for _, r := range s1 {
 		if got, want := f.ReadC(i), r; got != want {
-			t.Errorf("ReadC failed. got %v want % v", got, want)
+			t.Errorf("ReadC failed %d. got %v want % v", i, got, want)
 		}
 		i++
 	}

--- a/file/observable_editable_buffer.go
+++ b/file/observable_editable_buffer.go
@@ -450,8 +450,6 @@ func (e *ObservableEditableBuffer) Commit() {
 // InsertAtWithoutCommit is a forwarding function for file.InsertAtWithoutCommit.
 // forwards to InsertAt for file.Buffer.
 func (e *ObservableEditableBuffer) InsertAtWithoutCommit(p0 int, s []rune) {
-	before := e.getTagStatus()
-	defer e.notifyTagObservers(before)
 	e.InsertAt(p0, s)
 }
 

--- a/file/offset_tuple.go
+++ b/file/offset_tuple.go
@@ -17,3 +17,10 @@ func Ot(b, r int) OffsetTuple {
 		R: r,
 	}
 }
+
+func (o OffsetTuple) decrement(p *piece) OffsetTuple {
+	return Ot(
+		o.B-len(p.data),
+		o.R-p.nr,
+	)
+}


### PR DESCRIPTION
My pragmatic (aka lazy) implementation of the code connecting newtype
file.Buffer to ObservableEditableBuffer "improved" ReadC from O(n) to
O(n^2). This reduced performance. I fixed this:

* Introduce a benchmark to clearly demonstrate the magnitude of my
foolishness.

* Introduce an optimized RuneTuple that used a cached location to
speed up incremental RuneTuple operations. In partciular, O(1) to move
forward or backwards character-by-character.

* Modify findPiece to offer a similar optimization (and run in O(1) if
following a RuneTuple operation.)

* Cache the Nr() computation to reduce the runtime of loops in Edwood
that call Nr() in the loop

* Write a new implementation of ReadC using all of this.

Performance benefit:
Before: BenchmarkLook3/jumpToNumberedLine-10         	       1	8375066042 ns/op
After: BenchmarkLook3/jumpToNumberedLine-10         	     560	   2092816 ns/op
