### PR TITLE
Add buffer.End()

### DIFF
--- a/file/buffer_test.go
+++ b/file/buffer_test.go
@@ -384,6 +384,10 @@ func (b *Buffer) checkContent(name string, t *testing.T, expected string) {
 	if actualNr != expectedNr {
 		t.Errorf("%v: got '%v' runes, expected '%v' runes", name, actualNr, expectedNr)
 	}
+
+	if got, want := b.Size(), len(expected); got != want {
+		t.Errorf("%v: b.Size() got %d, want %d", name, got, want)
+	}
 }
 
 func (b *Buffer) insertString(off int, data string, t *testing.T) {
@@ -887,7 +891,7 @@ func TestFindPiece(t *testing.T) {
 			targetoff := b.RuneTuple(tv.roff)
 
 			// Invalidate the cached data to make sure that everything is consistent.
-			b.InvalidateCachedData()
+			b.invalidateCachedData()
 
 			// New bi-directional findPiece depends on the state of previous findPiece and
 			// RuneTuple invocations to speed up operation. Run additional RuneTuple
@@ -934,4 +938,10 @@ func (b *Buffer) old_findPiece(off OffsetTuple) (*piece, int, int) {
 		tr += p.nr
 	}
 	return nil, 0, 0
+}
+
+// invalidateCachedData clears cached data.
+func (b *Buffer) invalidateCachedData() {
+	b.viewed = nil
+	b.pend = Ot(-1, -1)
 }

--- a/file/offset_tuple.go
+++ b/file/offset_tuple.go
@@ -32,6 +32,14 @@ func (p0 OffsetTuple) Less(p1 OffsetTuple) bool {
 	return p0.R < p1.R
 }
 
+func (p0 OffsetTuple) Add(b, r int) OffsetTuple {
+	return Ot(p0.B+b, p0.R+r)
+}
+
+func (p0 OffsetTuple) Sub(b, r int) OffsetTuple {
+	return Ot(p0.B-b, p0.R-r)
+}
+
 var (
 	// Force that BufferCursor is an io.RuneReader.
 	_ io.RuneReader = (*BufferCursor)(nil)

--- a/text.go
+++ b/text.go
@@ -451,7 +451,8 @@ func (t *Text) Inserted(oq0 file.OffsetTuple, b []byte, nr int) {
 	}
 
 	t.logInsert(oq0, b, nr)
-	// TODO(rjk): I do too much work here.
+	// TODO(rjk): The below should only be invoked once (at the end) of a
+	// sequence of modifications to the file.Buffer, not here per action.
 	t.SetSelect(t.q0, t.q1)
 	if t.fr != nil && t.display != nil {
 		t.ScrDraw(t.fr.GetFrameFillStatus().Nchars)

--- a/wind.go
+++ b/wind.go
@@ -404,7 +404,8 @@ func (w *Window) Undo(isundo bool) {
 		body.q0, body.q1 = q0, q1
 	}
 
-	// TODO(rjk): Is this absolutely essential.
+	// TODO(rjk): Updates the scrollbar and selection.
+	// Be sure not to do this inside of the Undo operation's callbacks.
 	body.Show(body.q0, body.q1, true)
 }
 


### PR DESCRIPTION
Cache both the number of runes and number of bytes in a file.Buffer
for efficiently obtaining an OffsetTuple for the end of the Buffer.
