### PR TITLE
Increased frame test coverage

### DIFF
--- a/frame/delete_test.go
+++ b/frame/delete_test.go
@@ -1,0 +1,250 @@
+package frame
+
+import (
+	"image"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func deleteSingleCharacterAtLineEnd(t *testing.T, fr Frame, iv *invariants) {
+	t.Helper()
+
+	fr.Insert([]rune("0ab"), 0)
+	gdo(t, fr).Clear()
+
+	s := fr.Delete(2, 3)
+
+	if got, want := s, 0; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func deleteSingleCharacterInMiddle(t *testing.T, fr Frame, iv *invariants) {
+	t.Helper()
+
+	fr.Insert([]rune("0ab"), 0)
+	gdo(t, fr).Clear()
+
+	s := fr.Delete(1, 2)
+
+	if got, want := s, 0; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func deleteNewlineTocreateWrappedLine(t *testing.T, fr Frame, iv *invariants) {
+	t.Helper()
+
+	fr.Insert([]rune("0ab\n1cd\n2ef"), 0)
+	gdo(t, fr).Clear()
+
+	s := fr.Delete(len("0ab"), len("0ab\n"))
+
+	if got, want := s, 0; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func rippleUpDeletedChar(t *testing.T, fr Frame, iv *invariants) {
+	t.Helper()
+
+	// gdo(t, fr).Clear()
+	fr.Insert([]rune("0ab1cd2ef"), 0)
+	gdo(t, fr).Clear()
+
+	s := fr.Delete(1, 2) // a
+
+	if got, want := s, 0; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func deleteTab(t *testing.T, fr Frame, iv *invariants) {
+	t.Helper()
+
+	t.Log(fr.GetMaxtab())
+
+	// gdo(t, fr).Clear()
+	fr.Insert([]rune("0	ab1cd2ef"), 0)
+	gdo(t, fr).Clear()
+
+	s := fr.Delete(1, 2) // a
+
+	if got, want := s, 1; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func deleteCharBeforeTab(t *testing.T, fr Frame, iv *invariants) {
+	t.Helper()
+
+	t.Log(fr.GetMaxtab())
+
+	// gdo(t, fr).Clear()
+	fr.Insert([]rune("0a	b1cd2ef"), 0)
+	gdo(t, fr).Clear()
+
+	s := fr.Delete(1, 2) // a
+
+	if got, want := s, 0; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func rippleUpMultiLine(t *testing.T, fr Frame, iv *invariants) {
+	t.Helper()
+
+	// gdo(t, fr).Clear()
+	fr.Insert([]rune("0a\nb1\ncd2\nef"), 0)
+	gdo(t, fr).Clear()
+
+	s := fr.Delete(0, 6) // 0a\nb1\n
+
+	if got, want := s, 2; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// TestDelete is a high-level Dete test
+func TestDelete(t *testing.T) {
+	iv := &invariants{
+		topcorner: image.Pt(20, 10),
+	}
+
+	*validate = true
+
+	tests := []struct {
+		name        string
+		fn          func(t *testing.T, fr Frame, iv *invariants)
+		want        []string
+		textarea    image.Rectangle
+		knowntofail bool
+	}{
+		{
+			// Delete a single character at line end as we'd see with a backspace
+			// key press.
+			name: "deleteSingleCharacterAtLineEnd",
+			fn:   deleteSingleCharacterAtLineEnd,
+			want: []string{
+				"fill (46,10)-(59,20) [2,0],[1,1]",
+			},
+			textarea: image.Rect(20, 10, 60, 40),
+		},
+		{
+			// Delete a single character in the middle of a terminal line.
+			name: "deleteSingleCharacterInMiddle",
+			fn:   deleteSingleCharacterInMiddle,
+			want: []string{
+				"blit (46,10)-(59,20) [2,0],[1,1], to (33,10)-(46,20) [1,0],[1,1]",
+				"fill (46,10)-(46,20) [2,0],[0,1]",
+				"fill (46,10)-(59,20) [2,0],[1,1]",
+			},
+			textarea: image.Rect(20, 10, 60, 40),
+		},
+		{
+			// Delete a newline to create a wrapped line. TODO(rjk): This op blits a
+			// line to itself. This is visually fine but is wasted work. None of the
+			// drawops generated here are necessary for a correct screen update.
+			name: "deleteNewlineTocreateWrappedLine",
+			fn:   deleteNewlineTocreateWrappedLine,
+			want: []string{
+				"blit (20,20)-(59,30) [0,1],[3,1], to (20,20)-(59,30) [0,1],[3,1]",
+				"fill (59,20)-(59,30) [3,1],[0,1]",
+			},
+			textarea: image.Rect(20, 10, 60, 40),
+		},
+
+		{
+			// Ripple up a single deleted character.
+			name: "rippleUpDeletedChar",
+			fn:   rippleUpDeletedChar,
+			want: []string{
+				"blit (46,10)-(59,20) [2,0],[1,1], to (33,10)-(46,20) [1,0],[1,1]",
+				"fill (46,10)-(46,20) [2,0],[0,1]",
+				"blit (20,20)-(33,30) [0,1],[1,1], to (46,10)-(59,20) [2,0],[1,1]",
+				"fill (59,10)-(60,20) [3,0],[-,1]",
+				"blit (33,20)-(59,30) [1,1],[2,1], to (20,20)-(46,30) [0,1],[2,1]",
+				"fill (46,20)-(46,30) [2,1],[0,1]",
+				"blit (20,30)-(33,40) [0,2],[1,1], to (46,20)-(59,30) [2,1],[1,1]",
+				"fill (59,20)-(60,30) [3,1],[-,1]",
+				"blit (33,30)-(59,40) [1,2],[2,1], to (20,30)-(46,40) [0,2],[2,1]",
+				"fill (46,30)-(46,40) [2,2],[0,1]",
+				"fill (46,30)-(59,40) [2,2],[1,1]",
+			},
+			textarea: image.Rect(20, 10, 60, 40),
+		},
+		{
+			// character followed by tab where character after tab shouldn't move, delete the tab
+			// have to make this wide enough for tabs to work.
+			name: "deleteTab",
+			fn:   deleteTab,
+			want: []string{
+				"blit (124,10)-(137,20) [8,0],[1,1], to (33,10)-(46,20) [1,0],[1,1]",
+				"fill (46,10)-(46,20) [2,0],[0,1]",
+				"blit (20,20)-(111,30) [0,1],[7,1], to (46,10)-(137,20) [2,0],[7,1]",
+				"fill (137,10)-(137,20) [9,0],[0,1]",
+				"fill (137,10)-(140,20) [9,0],[-,1]",
+				"fill (20,20)-(111,30) [0,1],[7,1]",
+				"fill (137,10)-(140,20) [9,0],[-,1]",
+				"fill (20,20)-(111,30) [0,1],[7,1]",
+			},
+			// Has to be wide enough to accommodate a tab. Tab is 8 * 13 charwidths = 104.
+			textarea: image.Rect(20, 10, 140, 40),
+		},
+		{
+			// Character followed by tab where character after tab shouldn't move,
+			// delete the character, tab should stretch.
+			name: "deleteCharBeforeTab",
+			fn:   deleteCharBeforeTab,
+			want: []string{
+				"fill (33,10)-(124,20) [1,0],[7,1]",
+			},
+			// Has to be wide enough to accommodate a tab. Tab is 8 * 13 charwidths = 104.
+			textarea: image.Rect(20, 10, 140, 40),
+		},
+		{
+			// Ripple up a multiline deletion, text off the bottom.
+			name: "rippleUpMultiLine",
+			fn:   rippleUpMultiLine,
+			want: []string{
+				"blit (20,30)-(60,40) [0,2],[-,1], to (20,10)-(60,20) [0,0],[-,1]",
+				"blit (20,40)-(60,40) [0,3],[-,0], to (20,20)-(60,20) [0,1],[-,0]",
+				"fill (20,20)-(60,30) [0,1],[-,1]",
+				"fill (20,30)-(60,40) [0,2],[-,1]",
+				"fill (20,40)-(20,50) [0,3],[0,1]",
+			},
+			textarea: image.Rect(20, 10, 60, 40),
+		},
+		// Rippling tabs
+		// Tabs in narrow columns (what are they even suppose to do?)
+		// Need Tab insertion tests too (At beginning of document, into a narrow Window, forcing ripple)
+		// character followed by tab where character after tab shouldn't move, delete the character
+		// chunk, range, chunk (what does that mean?)
+		// blank line rippling
+		// delete whole line
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.knowntofail {
+				return
+			}
+
+			iv.textarea = tc.textarea
+			fr := setupFrame(t, iv)
+
+			// TODO(rjk): validate here
+
+			tc.fn(t, fr, iv)
+
+			// TODO(rjk): validate here
+
+			// Peek inside.
+			got := gdo(t, fr).DrawOps()
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Errorf("dump mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/frame/frame.go
+++ b/frame/frame.go
@@ -34,7 +34,8 @@ type SelectScrollUpdater interface {
 	DefaultFontHeight() int
 
 	// Delete deletes from the Frame the text between p0 and p1; p1 points at
-	// the first rune beyond the deletion.
+	// the first rune beyond the deletion. Returns the number of whole lines
+	// removed.
 	//
 	// Delete will clear a selection or tick if present but not put it back.
 	Delete(int, int) int

--- a/frame/insert_more_test.go
+++ b/frame/insert_more_test.go
@@ -7,6 +7,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
+// TODO(rjk): Test having a height that's not a multiple of the font
+// height. Particularly relevant for supporting lines of differing
+// heights.
+
 // TestInsertAligned is a high-level Insert test that uses a frame where
 // the character edge aligns with the width of the text region.
 func TestInsertAligned(t *testing.T) {

--- a/frame/insert_test.go
+++ b/frame/insert_test.go
@@ -171,6 +171,8 @@ type invariants struct {
 	textarea  image.Rectangle
 }
 
+// setupFrame makes a Frame object for testing with a recording Display
+// implementation.
 func setupFrame(t *testing.T, iv *invariants) Frame {
 	t.Helper()
 	display := edwoodtest.NewDisplay()
@@ -421,7 +423,8 @@ func TestInsert(t *testing.T) {
 		textarea    image.Rectangle
 		knowntofail bool
 	}{
-		// TODO(rjk): Test wrapping of lines contaning tabs.
+		// TODO(rjk): Test cases
+		// 3. add a newline after one already there.
 		{
 			name: "setupFrame",
 			fn:   nop,
@@ -469,6 +472,170 @@ func TestInsert(t *testing.T) {
 				`screen-800x600 <- string "ポポポポポポポポポポポポhello" atpoint: (20,30) [0,2] fill: black`,
 			},
 			textarea: image.Rect(20, 10, 400, 500),
+		},
+		{
+			// Insert into a long line
+			name: "insertIntoLongLine",
+			fn:   insertIntoLongLine,
+			want: []string{
+				"blit (20,40)-(46,50) [0,3],[2,1], to (20,40)-(46,50) [0,3],[2,1]",
+				"fill (267,30)-(400,40) [19,2],[-,1]",
+				"blit (20,30)-(254,40) [0,2],[18,1], to (33,30)-(267,40) [1,2],[18,1]",
+				"blit (384,20)-(397,30) [28,1],[1,1], to (20,30)-(33,40) [0,2],[1,1]",
+				"blit (33,20)-(384,30) [1,1],[27,1], to (46,20)-(397,30) [2,1],[27,1]",
+				"fill (397,20)-(400,30) [29,1],[-,1]",
+				"fill (33,20)-(46,30) [1,1],[1,1]",
+				`screen-800x600 <- string "X" atpoint: (33,20) [1,1] fill: black`,
+			},
+			textarea: image.Rect(20, 10, 400, 500),
+		},
+		{
+			// Insert into a line with a tab
+			name: "insertTabAndChar",
+			fn:   insertTabAndChar,
+			want: []string{
+				"blit (33,10)-(46,20) [1,0],[1,1], to (124,10)-(137,20) [8,0],[1,1]",
+				"fill (33,10)-(124,20) [1,0],[7,1]",
+				"fill (46,10)-(124,20) [2,0],[6,1]",
+				"fill (33,10)-(46,20) [1,0],[1,1]",
+				`screen-800x600 <- string "X" atpoint: (33,10) [1,0] fill: black`,
+			},
+			textarea: image.Rect(20, 10, 400, 500),
+		},
+		{
+			// Insert text that doesn't fit.
+			name: "insertPastEnd",
+			fn:   insertPastEnd,
+			want: []string{
+				"fill (20,10)-(60,20) [0,0],[-,1]",
+				"fill (20,20)-(60,40) [0,1],[-,2]",
+				"fill (20,40)-(20,50) [0,3],[0,1]",
+				`screen-800x600 <- string "a本ポ" atpoint: (20,10) [0,0] fill: black`,
+				`screen-800x600 <- string "ポポポ" atpoint: (20,20) [0,1] fill: black`,
+				`screen-800x600 <- string "ポポh" atpoint: (20,30) [0,2] fill: black`},
+			textarea: image.Rect(20, 10, 60, 40),
+		},
+		{
+			// Split a wrapped line by inserting a newline.
+			name:     "splitWrappedLine",
+			fn:       splitWrappedLine,
+			textarea: image.Rect(20, 10, 60, 60),
+			// This inserts an additional blankline for a newline added to the end of
+			// a full text row that doesn't belong there. The contents of the screen
+			// no longer match what we'd expect based on the box model. e.g.
+			// insertForcesWrap below shows that the newline should add a box without
+			// actually drawing anything. Subsequent edits then induce confusion.
+			knowntofail: true,
+		},
+		{
+			// Insert a single character that forces conversion of non-wrapped to
+			// wrapped with wripple to end.
+			name:     "insertForcesWrap",
+			fn:       insertForcesWrap,
+			textarea: image.Rect(20, 10, 60, 60),
+			want: []string{
+				"fill (20,10)-(60,20) [0,0],[-,1]",
+				"fill (20,20)-(60,50) [0,1],[-,3]",
+				"fill (20,50)-(59,60) [0,4],[3,1]",
+				`screen-800x600 <- string "0ab" atpoint: (20,10) [0,0] fill: black`,
+				`screen-800x600 <- string "1cd" atpoint: (20,20) [0,1] fill: black`,
+				`screen-800x600 <- string "2ef" atpoint: (20,30) [0,2] fill: black`,
+				`screen-800x600 <- string "3gh" atpoint: (20,40) [0,3] fill: black`,
+				`screen-800x600 <- string "4ij" atpoint: (20,50) [0,4] fill: black`,
+				"blit (20,30)-(60,50) [0,2],[-,2], to (20,40)-(60,60) [0,3],[-,2]",
+				"blit (59,20)-(60,30) [3,1],[-,1], to (59,30)-(60,40) [3,2],[-,1]",
+				"blit (20,20)-(59,30) [0,1],[3,1], to (20,30)-(59,40) [0,2],[3,1]",
+				"fill (33,20)-(60,30) [1,1],[-,1]",
+				"blit (46,10)-(59,20) [2,0],[1,1], to (20,20)-(33,30) [0,1],[1,1]",
+				"fill (46,10)-(60,20) [2,0],[-,1]",
+				"fill (20,20)-(20,30) [0,1],[0,1]",
+				`screen-800x600 <- string "X" atpoint: (46,10) [2,0] fill: black`,
+			},
+		},
+		{
+			// Append a pair of characters at the end of the otherwise full text
+			// area.
+			name:     "appendAtEnd",
+			fn:       appendAtEnd,
+			textarea: image.Rect(20, 10, 60, 60),
+			want: []string{
+				"fill (20,10)-(60,20) [0,0],[-,1]",
+				"fill (20,20)-(60,50) [0,1],[-,3]",
+				"fill (20,50)-(59,60) [0,4],[3,1]",
+				`screen-800x600 <- string "0ab" atpoint: (20,10) [0,0] fill: black`,
+				`screen-800x600 <- string "1cd" atpoint: (20,20) [0,1] fill: black`,
+				`screen-800x600 <- string "2ef" atpoint: (20,30) [0,2] fill: black`,
+				`screen-800x600 <- string "3gh" atpoint: (20,40) [0,3] fill: black`,
+				`screen-800x600 <- string "4ij" atpoint: (20,50) [0,4] fill: black`,
+			},
+		},
+
+		{
+			// Append a multibox string that hangs off the end. TODO(rjk): Draws a
+			// zero-width fill off the end of text area. This is conceivably wrong.
+			// It would (for example) make some drawing stacks unhappy.
+			name:     "appendHangingLongAtEnd",
+			fn:       appendHangingLongAtEnd,
+			textarea: image.Rect(20, 10, 60, 60),
+			want: []string{
+				"fill (20,10)-(60,20) [0,0],[-,1]",
+				"fill (20,20)-(60,60) [0,1],[-,4]",
+				"fill (20,60)-(20,70) [0,5],[0,1]",
+				`screen-800x600 <- string "0" atpoint: (20,10) [0,0] fill: black`,
+				`screen-800x600 <- string "1" atpoint: (20,20) [0,1] fill: black`,
+				`screen-800x600 <- string "2" atpoint: (20,30) [0,2] fill: black`,
+				`screen-800x600 <- string "3" atpoint: (20,40) [0,3] fill: black`,
+				`screen-800x600 <- string "4" atpoint: (20,50) [0,4] fill: black`,
+				"fill (33,50)-(60,60) [1,4],[-,1]",
+				"fill (20,60)-(20,70) [0,5],[0,1]",
+				`screen-800x600 <- string "XX" atpoint: (33,50) [1,4] fill: black`,
+			},
+		},
+		{
+			// Insert a multibox string that forces ripple past the end.
+			name:     "insertWrappedThatForcesRipple",
+			fn:       insertWrappedThatForcesRipple,
+			textarea: image.Rect(20, 10, 60, 60),
+			want: []string{
+				"fill (20,10)-(60,20) [0,0],[-,1]",
+				"fill (20,20)-(60,60) [0,1],[-,4]",
+				"fill (20,60)-(20,70) [0,5],[0,1]",
+				`screen-800x600 <- string "0" atpoint: (20,10) [0,0] fill: black`,
+				`screen-800x600 <- string "1" atpoint: (20,20) [0,1] fill: black`,
+				`screen-800x600 <- string "2" atpoint: (20,30) [0,2] fill: black`,
+				`screen-800x600 <- string "3b" atpoint: (20,40) [0,3] fill: black`,
+				`screen-800x600 <- string "4" atpoint: (20,50) [0,4] fill: black`,
+				"fill (59,50)-(60,60) [3,4],[-,1]",
+				"blit (33,40)-(46,50) [1,3],[1,1], to (46,50)-(59,60) [2,4],[1,1]",
+				"fill (33,40)-(60,50) [1,3],[-,1]",
+				"fill (20,50)-(46,60) [0,4],[2,1]",
+				`screen-800x600 <- string "ij" atpoint: (33,40) [1,3] fill: black`,
+				`screen-800x600 <- string "XX" atpoint: (20,50) [0,4] fill: black`,
+			},
+		},
+		{
+			// Insert a string that pushes a blank line off the end.
+			name:     "insertPushesBlankLineOffEnd",
+			fn:       insertPushesBlankLineOffEnd,
+			textarea: image.Rect(20, 10, 60, 60),
+			want: []string{
+				"fill (20,10)-(60,20) [0,0],[-,1]",
+				"fill (20,20)-(60,60) [0,1],[-,4]",
+				"fill (20,60)-(20,70) [0,5],[0,1]",
+				`screen-800x600 <- string "0ab" atpoint: (20,10) [0,0] fill: black`,
+				`screen-800x600 <- string "1cd" atpoint: (20,20) [0,1] fill: black`,
+				`screen-800x600 <- string "2ef" atpoint: (20,30) [0,2] fill: black`,
+				`screen-800x600 <- string "3gh" atpoint: (20,40) [0,3] fill: black`,
+				"blit (20,30)-(60,50) [0,2],[-,2], to (20,40)-(60,60) [0,3],[-,2]",
+				"blit (59,20)-(60,30) [3,1],[-,1], to (59,30)-(60,40) [3,2],[-,1]",
+				"blit (20,20)-(59,30) [0,1],[3,1], to (20,30)-(59,40) [0,2],[3,1]",
+				"fill (33,20)-(60,30) [1,1],[-,1]",
+				"blit (46,10)-(59,20) [2,0],[1,1], to (20,20)-(33,30) [0,1],[1,1]",
+				"blit (33,10)-(46,20) [1,0],[1,1], to (46,10)-(59,20) [2,0],[1,1]",
+				"fill (59,10)-(60,20) [3,0],[-,1]",
+				"fill (33,10)-(46,20) [1,0],[1,1]",
+				`screen-800x600 <- string "X" atpoint: (33,10) [1,0] fill: black`,
+			},
 		},
 		{
 			// Insert into a long line

--- a/frame/util.go
+++ b/frame/util.go
@@ -94,6 +94,8 @@ func (f *frameimpl) newwid(pt image.Point, b *frbox) int {
 	return b.Wid
 }
 
+// TODO(rjk): Expand the test cases involving \t characters.
+// TODO(rjk): Wouldn't it be nicer if this was a method on frbox?
 func (f *frameimpl) newwid0(pt image.Point, b *frbox) int {
 	c := f.rect.Max.X
 	x := pt.X
@@ -101,6 +103,7 @@ func (f *frameimpl) newwid0(pt image.Point, b *frbox) int {
 		return b.Wid
 	}
 	if x+int(b.Minwid) > c {
+		// A tab character doesn't fit at the end of the line.
 		pt.X = f.rect.Min.X
 		x = pt.X
 	}


### PR DESCRIPTION
Ongoing preparatory work to address issue #56: improve the frame test
harness, simplify the edwoodtest mock display code's output (to make
it easier to reason about) and expand test coverage on frame.Insert and
frame.Delete.
