### PR TITLE
Use a mock Display instance in Fsys testing

### DIFF
--- a/edwoodtest/draw.go
+++ b/edwoodtest/draw.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"image"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"unicode/utf8"
@@ -48,8 +50,8 @@ func (d *mockDisplay) Opaque() draw.Image { return newimageimpl(d, "opaque", ima
 func (d *mockDisplay) Transparent() draw.Image {
 	return newimageimpl(d, "transparent", image.Rectangle{})
 }
-func (d *mockDisplay) InitKeyboard() *draw.Keyboardctl { return nil }
-func (d *mockDisplay) InitMouse() *draw.Mousectl       { return nil }
+func (d *mockDisplay) InitKeyboard() *draw.Keyboardctl { return &draw.Keyboardctl{} }
+func (d *mockDisplay) InitMouse() *draw.Mousectl       { return &draw.Mousectl{} }
 
 // TODO(rjk): Support a richer variety of fonts with better metrics.
 // NB: to make the recorded ops easier to read, I provide them in
@@ -270,8 +272,23 @@ func NewFont(width, height int) draw.Font {
 	}
 }
 
-func (f *mockFont) Name() string             { return "/lib/font/edwood.font" }
+// const MockFontName = "/lib/font/bit/veryloverylongstringherengstringhere/euro.8.font"
+const MockFontName = "/lib/font/bit/lucsans/euro.8.font"
+
+func (f *mockFont) Name() string             { return Plan9FontPath(MockFontName) }
 func (f *mockFont) Height() int              { return f.height }
 func (f *mockFont) BytesWidth(b []byte) int  { return f.width * utf8.RuneCount(b) }
 func (f *mockFont) RunesWidth(r []rune) int  { return f.width * len(r) }
 func (f *mockFont) StringWidth(s string) int { return f.width * utf8.RuneCountInString(s) }
+
+func Plan9FontPath(name string) string {
+	const prefix = "/lib/font/bit"
+	if strings.HasPrefix(name, prefix) {
+		root := os.Getenv("PLAN9")
+		if root == "" {
+			root = "/usr/local/plan9"
+		}
+		return filepath.Join(root, "/font/", name[len(prefix):])
+	}
+	return name
+}

--- a/guide
+++ b/guide
@@ -2,13 +2,15 @@
 Edit X:edwood/\+Errors: 1,$d
 X:edwood/.*\.go: w
 
-go build -tags debug
+{go build -tags debug}
 ./testedwood.sh
 
-go test -covermode=count -coverprofile=count.out
+{go test -covermode=count -coverprofile=count.out}
 go tool cover -html=count.out
 
-go test --run 'TestFlushWarnings' -covermode=count -coverprofile=count.out
+go vet
+
+go test --run 'TestXfidreadQWctl' -covermode=count -coverprofile=count.out
 
 // Edit commands for converting C to Go
 cs 'flushwarnings\('

--- a/row_test.go
+++ b/row_test.go
@@ -123,7 +123,7 @@ func checkDumpFsys(t *testing.T, dump *dumpfile.Content, fsys *client.Fsys) {
 			t.Errorf("tag is %q; expected %q", w.tag, dw.Tag)
 		}
 
-		if p := plan9FontPath(dw.Font); unscaledFontName(w.font) != p {
+		if p := edwoodtest.Plan9FontPath(dw.Font); unscaledFontName(w.font) != p {
 			t.Errorf("font for %q is %q; expected %q", w.name, unscaledFontName(w.font), p)
 		}
 
@@ -294,18 +294,6 @@ func unscaledFontName(fname string) string {
 	return strings.TrimLeftFunc(fname, func(r rune) bool {
 		return (r >= '0' && r <= '9') || r == '*'
 	})
-}
-
-func plan9FontPath(name string) string {
-	const prefix = "/lib/font/bit"
-	if strings.HasPrefix(name, prefix) {
-		root := os.Getenv("PLAN9")
-		if root == "" {
-			root = "/usr/local/plan9"
-		}
-		return filepath.Join(root, "/font/", name[len(prefix):])
-	}
-	return name
 }
 
 type winInfo struct {

--- a/wind.go
+++ b/wind.go
@@ -505,7 +505,7 @@ func (w *Window) Clean(conservative bool) bool {
 }
 
 // CtlPrint generates the contents of the fsys's acme/<id>/ctl pseduo-file if fonts is true.
-// Otherwise,it emits a portion of the per-window dump file contents.
+// Otherwise, it emits a portion of the per-window dump file contents.
 func (w *Window) CtlPrint(fonts bool) string {
 	isdir := 0
 	if w.body.file.IsDir() {

--- a/xfid_test.go
+++ b/xfid_test.go
@@ -1306,7 +1306,12 @@ func TestXfidreadQWaddr(t *testing.T) {
 }
 
 func TestXfidreadQWctl(t *testing.T) {
-	const want = "          1          32          14           0           0           0 /lib/font/edwood.font           0 "
+	const prewant = "          1          32          14           0           0           0 "
+	const postwant = "           0 "
+	want := prewant + edwoodtest.Plan9FontPath(edwoodtest.MockFontName) + postwant
+	if len(want) > 128 {
+		want = want[:128]
+	}
 
 	global.WinID = 0
 	w := NewWindow().initHeadless(nil)


### PR DESCRIPTION
The Fsys tests launch an Edwood instance and then connect to it via
the 9p protocol. Previously this Edwood instance required a real
display, devdraw, window server, etc. This CL modifies the startup
logic to let this Edwood instance instead use a mock Display
instance.
