### PR TITLE
Additional removal of Commit concept

### DIFF
--- a/file/buffer_adapter.go
+++ b/file/buffer_adapter.go
@@ -26,12 +26,6 @@ func NewTypeBuffer(inputrunes []rune, oeb *ObservableEditableBuffer) *Buffer {
 	return nb
 }
 
-// Commit writes the in-progress edits to the real buffer instead of
-// keeping them in the cache.
-func (b *Buffer) Commit(seq int) {
-	// NOP
-}
-
 // ReadC reads a single rune from the File.
 // TODO(rjk): Implement RuneReader
 func (b *Buffer) ReadC(q int) rune {

--- a/file/file_test.go
+++ b/file/file_test.go
@@ -47,29 +47,6 @@ func TestDelObserver(t *testing.T) {
 	}
 }
 
-func TestFileInsertAtWithoutCommit(t *testing.T) {
-	f := MakeObservableEditableBuffer("edwood", []rune{})
-
-	f.InsertAtWithoutCommit(0, []rune(s1))
-
-	t.Logf("contents %q, %s", f.f.String(), f.f.viewedState())
-
-	i := 0
-	for _, r := range s1 {
-		if got, want := f.ReadC(i), r; got != want {
-			t.Errorf("ReadC failed %d. got %v want % v", i, got, want)
-		}
-		i++
-	}
-
-	if got, want := f.Nr(), 6; got != want {
-		t.Errorf("Nr failed. got %v want % v", got, want)
-	}
-
-	check(t, "TestFileInsertAt after TestFileInsertAtWithoutCommit", f,
-		&stateSummary{false, false, false, s1})
-}
-
 const s1 = "hi 海老麺"
 const s2 = "bye"
 
@@ -79,19 +56,16 @@ func TestFileInsertAt(t *testing.T) {
 	// Force Undo.
 	f.seq = 1
 
-	f.InsertAtWithoutCommit(0, []rune(s1))
+	f.InsertAt(0, []rune(s1))
 
 	// NB: the read code not include the uncommitted content.
 	check(t, "TestFileInsertAt after InsertAtWithoutCommits", f,
 		&stateSummary{true, false, true, s1})
 
-	f.Commit()
-
 	check(t, "TestFileInsertAt after InsertAtWithoutCommits", f,
 		&stateSummary{true, false, true, s1})
 
 	f.InsertAt(f.Nr(), []rune(s2))
-	f.Commit()
 
 	check(t, "TestFileUndoRedo after InsertAt", f,
 		&stateSummary{true, false, true, s1 + s2})
@@ -575,12 +549,11 @@ func TestTagObserversFireCorrectly(t *testing.T) {
 	}
 
 	oeb.Mark(2)
-	oeb.InsertAtWithoutCommit(0, []rune("hi"))
+	oeb.InsertAt(0, []rune("hi"))
 	if got, want := *counts, (observercount{0, 6}); got != want {
 		t.Errorf("got %+v, want %+v", got, want)
 	}
 
-	oeb.Commit()
 	if got, want := *counts, (observercount{0, 6}); got != want {
 		t.Errorf("got %+v, want %+v", got, want)
 	}

--- a/file/observable_editable_buffer.go
+++ b/file/observable_editable_buffer.go
@@ -435,18 +435,6 @@ func (e *ObservableEditableBuffer) deleted(q0, q1 OffsetTuple) {
 	}
 }
 
-// Commit is a forwarding function for file.Commit.
-// nop with file.Buffer.
-func (e *ObservableEditableBuffer) Commit() {
-	e.f.Commit(e.seq)
-}
-
-// InsertAtWithoutCommit is a forwarding function for file.InsertAtWithoutCommit.
-// forwards to InsertAt for file.Buffer.
-func (e *ObservableEditableBuffer) InsertAtWithoutCommit(p0 int, s []rune) {
-	e.InsertAt(p0, s)
-}
-
 // IsDirOrScratch returns true if the File has a synthetic backing of
 // a directory listing or has a name pattern that excludes it from
 // being saved under typical circumstances.

--- a/text.go
+++ b/text.go
@@ -1001,10 +1001,7 @@ func (t *Text) Type(r rune) {
 			return
 		}
 
-		// TODO(rjk): figure out the way of nofill
-		// TODO(rjk): I'd like the Undo op to group typing better.
 		setUndoPoint()
-		t.file.Commit()
 		t.Delete(q0, q0+nnb, true)
 
 		// Run through the code that will update the t.w.body.file.details.Name.
@@ -1032,8 +1029,8 @@ func (t *Text) Type(r rune) {
 			rp = rp[:nr]
 		}
 	}
-	// otherwise ordinary character; just insert, typically in caches of all texts
-	t.file.InsertAtWithoutCommit(t.q0, rp[:nr])
+	// Otherwise ordinary character; just insert it.
+	t.file.InsertAt(t.q0, rp[:nr])
 	t.SetSelect(t.q0+nr, t.q0+nr)
 
 	// Always commit if the typing is into a tag. The reason to do this is to
@@ -1053,7 +1050,6 @@ func (t *Text) Type(r rune) {
 }
 
 func (t *Text) Commit() {
-	t.file.Commit()
 	if t.what == Body {
 		t.w.utflastqid = -1
 	}

--- a/text_test.go
+++ b/text_test.go
@@ -434,7 +434,6 @@ func checkTabexpand(t *testing.T, getText func(tabexpand bool, tabstop int) *Tex
 		for _, r := range tc.input {
 			text.Type(r)
 		}
-		text.file.Commit()
 
 		gr := make([]rune, text.file.Nr())
 		text.file.Read(0, gr[:text.file.Nr()])


### PR DESCRIPTION
Now that newtype text buffers don't require Commit, further cleanup
the code around this.
