### PR TITLE
Fix a rendering bug with filled lines

### DIFF
--- a/frame/draw.go
+++ b/frame/draw.go
@@ -237,7 +237,7 @@ func (f *frameimpl) Tick(pt image.Point, ticked bool) {
 }
 
 func (f *frameimpl) _draw(pt image.Point) image.Point {
-	// f.LogBoxes("_draw -- start")
+	// f.Logboxes("_draw -- start")
 	for nb := 0; nb < len(f.box); nb++ {
 		b := f.box[nb]
 		if b == nil {
@@ -246,6 +246,7 @@ func (f *frameimpl) _draw(pt image.Point) image.Point {
 		}
 		pt = f.cklinewrap0(pt, b)
 		if pt.Y == f.rect.Max.Y {
+			f.lastlinefull = true
 			f.nchars -= f.strlen(nb)
 			f.delbox(nb, len(f.box)-1)
 			break
@@ -270,7 +271,7 @@ func (f *frameimpl) _draw(pt image.Point) image.Point {
 			}
 		}
 	}
-	// f.LogBoxes("_draw -- end")
+	// f.Logboxes("_draw -- end")
 	return pt
 }
 

--- a/frame/frame.go
+++ b/frame/frame.go
@@ -253,6 +253,10 @@ type frbox struct {
 // 	m.reallock.Unlock()
 // }
 
+// TODO(rjk): It might make sense to group frameimpl into context (e.g.
+// fonts, etc.) and the actual boxes. At any rate, it's worth thinking
+// carefully about the data structures and how they should really be put
+// together.
 type frameimpl struct {
 	lk sync.Mutex
 	// lk debugginglock

--- a/frame/insert_more_test.go
+++ b/frame/insert_more_test.go
@@ -45,12 +45,23 @@ func TestInsertAligned(t *testing.T) {
 			name:     "splitWrappedLine",
 			fn:       splitWrappedLine,
 			textarea: image.Rect(20, 10, 59, 60),
-			// This inserts an additional blankline for a newline added to the end of
-			// a full text row that doesn't belong there. The contents of the screen
-			// no longer match what we'd expect based on the box model. e.g.
-			// insertForcesWrap below shows that the newline should add a box without
-			// actually drawing anything. Subsequent edits then induce confusion.
-			knowntofail: true,
+			want: []string{
+				"fill (20,10)-(59,20) [0,0],[3,1]",
+				"fill (20,20)-(59,50) [0,1],[3,3]",
+				"fill (20,50)-(33,60) [0,4],[1,1]",
+				`screen-800x600 <- string "a本ポ" atpoint: (20,10) [0,0] fill: black`,
+				`screen-800x600 <- string "ポポポ" atpoint: (20,20) [0,1] fill: black`,
+				`screen-800x600 <- string "ポポh" atpoint: (20,30) [0,2] fill: black`,
+				`screen-800x600 <- string "ell" atpoint: (20,40) [0,3] fill: black`,
+				`screen-800x600 <- string "o" atpoint: (20,50) [0,4] fill: black`,
+				// The previously failing insertion starts here. We didn't have to do
+				// anything in this case. But we still fill blank space at the end of the
+				// line over again. This is (hopefully) harmless.
+				// TODO(rjk): Elide the 0-width draws.
+				"fill (58,10)-(59,20) [-,0],[-,1]",
+				"fill (20,20)-(20,30) [0,1],[0,1]",
+			},
+			knowntofail: false,
 		},
 		{
 			// Insert a single character that forces conversion of non-wrapped to
@@ -92,6 +103,9 @@ func TestInsertAligned(t *testing.T) {
 				`screen-800x600 <- string "2ef" atpoint: (20,30) [0,2] fill: black`,
 				`screen-800x600 <- string "3gh" atpoint: (20,40) [0,3] fill: black`,
 				`screen-800x600 <- string "4ij" atpoint: (20,50) [0,4] fill: black`,
+				"fill (58,50)-(59,60) [-,4],[-,1]",
+				// Doesn't this stick below? it's 0 wide?
+				"fill (20,60)-(20,70) [0,5],[0,1]",
 			},
 		},
 

--- a/frame/ptofchar.go
+++ b/frame/ptofchar.go
@@ -6,6 +6,11 @@ import (
 	"unicode/utf8"
 )
 
+// ptofcharptb returns the point of run p based on the current box state.
+// NB: it is possible that a different rune at p would give a different
+// result. Consequently, the result of this function will not say where a
+// new rune at position p should be positioned, only where the current
+// rune at p is positioned.
 func (f *frameimpl) ptofcharptb(p int, pt image.Point, bn int) image.Point {
 	var w int
 	var r rune
@@ -26,6 +31,7 @@ func (f *frameimpl) ptofcharptb(p int, pt image.Point, bn int) image.Point {
 			}
 			break
 		}
+
 		p -= l
 		pt = f.advance(pt, b)
 	}
@@ -39,7 +45,7 @@ func (f *frameimpl) Ptofchar(p int) image.Point {
 	return f.ptofcharptb(p, f.rect.Min, 0)
 }
 
-func (f *frameimpl) ptofcharnb(p int, nb int) image.Point {
+func (f *frameimpl) ptofcharnb(p int, _ int) image.Point {
 	pt := image.Point{}
 	pt = f.ptofcharptb(p, f.rect.Min, 0)
 	return pt

--- a/frame/util.go
+++ b/frame/util.go
@@ -40,7 +40,7 @@ func (f *frameimpl) canfit(pt image.Point, b *frbox) (int, bool) {
 	return 0, false
 }
 
-// cklinewrap returns a new for where the given the box b should be
+// cklinewrap returns a new point for where the given the box b should be
 // placed. NB: this code is not going to do the right thing with a newline box.
 func (f *frameimpl) cklinewrap(p image.Point, b *frbox) (ret image.Point) {
 	ret = p
@@ -128,7 +128,7 @@ func (f *frameimpl) newwid0(pt image.Point, b *frbox) int {
 // TODO(rjk): Possibly does not work correctly.
 // clean merges boxes where possible over boxes [n0, n1)
 func (f *frameimpl) clean(pt image.Point, n0, n1 int) {
-	//log.Println("clean", pt, n0, n1, f.Rect.Max.X)
+	// log.Println("clean", pt, n0, n1, f.rect.Max.X)
 	//	f.Logboxes("--- clean: starting ---")
 	c := f.rect.Max.X
 	nb := 0
@@ -149,6 +149,10 @@ func (f *frameimpl) clean(pt image.Point, n0, n1 int) {
 		pt = f.cklinewrap(pt, b)
 		pt = f.advance(pt, b)
 	}
+	// Because we strip the boxes past the end in _draw, this will wrongly
+	// change lastlinefull when we run this at the end of of insert.
+	// Consequently, I modified insert to not clean if there was nothing to
+	// add.
 	f.lastlinefull = false
 	if pt.Y >= f.rect.Max.Y {
 		f.lastlinefull = true
@@ -172,6 +176,7 @@ func Rpt(min, max image.Point) image.Rectangle {
 }
 
 // Logboxes shows the box model to the log for debugging convenience.
+// TODO(rjk): Add the computed position for the boxes too.
 func (f *frameimpl) Logboxes(message string, args ...interface{}) {
 	log.Printf(message, args...)
 	for i, b := range f.box {


### PR DESCRIPTION
Inserting an actual newline at the end of a soft line-broken box no
longer inserts a spurious blank line. This fixes a pernicious
rendering issue.
