### PR TITLE
Test and visualize frame operations

### DIFF
--- a/acme_test.go
+++ b/acme_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"image"
 	"os/exec"
 	"reflect"
 	"testing"
@@ -212,7 +213,7 @@ func startMockWaitthread(ctx context.Context) (done <-chan struct{}) {
 	global.cedit = make(chan int)
 	warnings = nil
 	global.row = Row{
-		display: edwoodtest.NewDisplay(),
+		display: edwoodtest.NewDisplay(image.Rectangle{}),
 		tag: Text{
 			file: file.MakeObservableEditableBuffer("", nil),
 		},

--- a/edwoodtest/svg_drawops.go
+++ b/edwoodtest/svg_drawops.go
@@ -1,0 +1,267 @@
+package edwoodtest
+
+// TODO(rjk): write up some entry points
+
+import (
+	"html/template"
+	"image"
+	"io"
+	"log"
+	"strings"
+)
+
+var tmpl *template.Template
+
+// init creates a single template with multiple sub-templates.
+func init() {
+	tmpl = template.New("svgout")
+	template.Must(tmpl.New("Bytes").Parse(bytetemplate))
+	template.Must(tmpl.New("Fill").Parse(filltemplate))
+	template.Must(tmpl.New("Boundingbox").Parse(boundingboxtemplate))
+	template.Must(tmpl.New("Blit").Parse(blittemplate))
+	template.Must(tmpl.New("Final").Parse(finalfiletemplate))
+}
+
+const bytetemplate = `<g id="draw{{.Id}}">
+	<use href="#draw{{.SrcId}}" />
+	{{range .Glyphs}}<text x="{{.X}}" y="{{.Y}}" fill="black" class="small">{{.R}}</text>
+	{{end -}}
+	</g>`
+
+type Glyphy struct {
+	X int
+	Y int
+	R string
+}
+
+type Bytesargs struct {
+	Id     int
+	SrcId  int
+	Glyphs []Glyphy
+}
+
+// TODO(rjk): plumb the colour
+// TODO(rjk): structure this more nicely
+// TODO(rjk): generalize font metrics
+// TODO(rjk): use the font metrics in the generated SVG
+func bytessvg(id int, sp image.Point, b []byte) string {
+	s := string(b)
+
+	glyphs := make([]Glyphy, 0, len(s))
+	x := sp.X
+	for _, r := range s {
+		glyphs = append(glyphs, Glyphy{
+			R: string(r),
+			X: x + 2,
+			// 9p uses the top corner, not the baseline.
+			Y: sp.Y + fheight - 2,
+		})
+
+		// TODO(rjk): Configure this. Need metrics
+		x += fwidth
+	}
+
+	byteargs := Bytesargs{
+		Id:     id,
+		SrcId:  id - 1,
+		Glyphs: glyphs,
+	}
+
+	swr := new(strings.Builder)
+	if err := tmpl.ExecuteTemplate(swr, "Bytes", byteargs); err != nil {
+		log.Printf("can't run the template on %v because %v\n", byteargs, err)
+	}
+
+	return swr.String()
+}
+
+// TODO(rjk): refactor this together with the other code.
+type Fillargs struct {
+	Id    int
+	SrcId int
+	Box   image.Rectangle
+	Rect  image.Rectangle
+}
+
+const filltemplate = `<g id="draw{{.Id}}">
+	<use href="#draw{{.SrcId}}" />
+	<rect x="{{.Rect.Min.X}}" y="{{.Rect.Min.Y}}" width="{{.Rect.Dx}}" height="{{.Rect.Dy}}" fill="#ffffdd"/>
+	</g>`
+
+func fillsvg(id int, rect, box image.Rectangle) string {
+	fillargs := Fillargs{
+		Id:    id,
+		SrcId: id - 1,
+		Rect:  rect,
+		Box:   box,
+	}
+
+	swr := new(strings.Builder)
+	if err := tmpl.ExecuteTemplate(swr, "Fill", fillargs); err != nil {
+		log.Printf("can't run the template on fill because %v\n", err)
+	}
+
+	return swr.String()
+}
+
+type Blitargs struct {
+	Id         int
+	SrcId      int
+	BlitOffset int
+	Src        image.Rectangle
+	Dest       image.Point
+}
+
+const blittemplate = `<use href="#draw{{.SrcId}}" />
+<rect x="{{.Src.Min.X}}" y="{{.Src.Min.Y}}" width="{{.Src.Dx}}" height="{{.Src.Dy}}" fill="none" stroke="red"/>
+<g transform="translate({{.BlitOffset}}, 0)">
+	<g id="draw{{.Id}}">
+		<use href="#draw{{.SrcId}}" />
+		<clipPath id="draw{{.Id}}_blitsource">
+			<!-- This is the rectangle corresponding to the blit source -->
+			<rect x="{{.Src.Min.X}}" y="{{.Src.Min.Y}}" width="{{.Src.Dx}}" height="{{.Src.Dy}}" />
+		</clipPath>
+		<use href="#draw{{.SrcId}}" clip-path="url(#draw{{.Id}}_blitsource)" x="{{.Dest.X}}" y="{{.Dest.Y}}" />
+	</g>
+</g>
+`
+
+// blitsvg returns an SVG fragment visulizing a blit operation.
+func blitsvg(id int, src image.Rectangle, pt image.Point, offset int) string {
+	blitargs := Blitargs{
+		Id:         id,
+		SrcId:      id - 1,
+		Src:        src,
+		Dest:       pt.Sub(src.Min),
+		BlitOffset: offset,
+	}
+
+	swr := new(strings.Builder)
+	if err := tmpl.ExecuteTemplate(swr, "Blit", blitargs); err != nil {
+		log.Printf("can't run the template on Blit because %v\n", err)
+	}
+
+	return swr.String()
+}
+
+const boundingboxtemplate = `<g id="draw{{.Id}}">
+	<rect x="{{.Box.Min.X}}" y="{{.Box.Min.Y}}" width="{{.Box.Dx}}" height="{{.Box.Dy}}" fill="none" stroke="black"/>
+	</g>`
+
+// TODO(rjk): There is opportunity to refactor this quite extensively.
+type Boxargs struct {
+	Id  int
+	Box image.Rectangle
+}
+
+// boundingboxsvg generates a starting point visualization: the region of
+// interest.
+func boundingboxsvg(id int, box image.Rectangle) string {
+	boxargs := Boxargs{
+		Id:  id,
+		Box: box,
+	}
+
+	swr := new(strings.Builder)
+	if err := tmpl.ExecuteTemplate(swr, "Boundingbox", boxargs); err != nil {
+		log.Printf("can't run the template on Boundingbox because %v\n", err)
+	}
+
+	return swr.String()
+}
+
+// TODO(rjk): Note that I could configure the font here from fwidth, fheight.
+// Note how I can introduce variables. Note also how I can invoke a
+// function. The function is just an argument to the template execution.
+// The use of call is how I can make arbitrary functions for content
+// generation.
+const finalfiletemplate = `<html lang="en-US">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+</head>
+<body>
+<svg viewBox="{{.ViewBox.Min.X}} {{.ViewBox.Min.Y}} {{.ViewBox.Max.X}} {{.ViewBox.Max.Y}}" xmlns="http://www.w3.org/2000/svg">
+
+<style>
+	.small { font: 8px sans-serif; }
+</style>
+
+{{- $boxsize := .ScreenBox.Dy -}}
+{{- $vertfunc := .VertOffset }}
+{{range $index, $element := .Fragments}}
+<g transform="translate(0, {{call $vertfunc $index $boxsize}})">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">{{$element.Annotation}}</text>
+	</g>
+	{{$element.SVG}}
+</g>
+{{end}}
+</svg>
+</body>
+</html>
+`
+
+// verticaloffset is a helper function used inside the template
+// execution. Note above how it's passed into the template as VertOffset
+// and then used via a call template statement.
+func verticaloffset(i, boxheight int) int {
+	return i * (boxheight + padding)
+}
+
+// TODO(rjk): There is opportunity to refactor this.
+type Finalfileargs struct {
+	// Becomes the viewBox property of the generated SVG.
+	ViewBox image.Rectangle
+
+	// The previous draw ops as separate strings.
+	Fragments []AnnotatedFragments
+
+	// The rectangle of interest. For example, in a test of the frame code,
+	// this might be the rectangle corresponding to the text area.
+	ScreenBox image.Rectangle
+
+	// Helper function used to move down in the visualization between
+	// successive draw operations.
+	VertOffset func(int, int) int
+}
+
+type AnnotatedFragments struct {
+	// A descriptive annotation for this fragment.
+	Annotation string
+
+	// The chunk of SVG corresponding to this fragment.
+	SVG template.HTML
+}
+
+const (
+	padding   = 40 // edge padding
+	blitspace = 30 // distance between the blit src and blit dest
+)
+
+// singlesvgfile writes a single HTML file to w containing a scrollable
+// sequence of subops. rectofi is the rectangle of interest to consider.
+func singlesvgfile(w io.Writer, subops, annotations []string, rectofi image.Rectangle) error {
+	annotatedfrags := make([]AnnotatedFragments, 0, len(subops))
+
+	for i, s := range subops {
+		annotatedfrags = append(annotatedfrags, AnnotatedFragments{
+			Annotation: annotations[i],
+			SVG:        template.HTML(s),
+		})
+	}
+
+	finalargs := Finalfileargs{
+		ViewBox: image.Rect(
+			rectofi.Min.X-padding,
+			rectofi.Min.Y-padding,
+			2*rectofi.Dx()+blitspace+2*padding,
+			(rectofi.Dy()+padding)*len(subops),
+		),
+		Fragments:  annotatedfrags,
+		ScreenBox:  rectofi,
+		VertOffset: verticaloffset,
+	}
+
+	return tmpl.ExecuteTemplate(w, "Final", finalargs)
+}

--- a/frame/delete_test.go
+++ b/frame/delete_test.go
@@ -69,7 +69,7 @@ func deleteTab(t *testing.T, fr Frame, iv *invariants) {
 	fr.Insert([]rune("0	ab1cd2ef"), 0)
 	gdo(t, fr).Clear()
 
-	s := fr.Delete(1, 2) // a
+	s := fr.Delete(1, 2) // the tab
 
 	if got, want := s, 1; got != want {
 		t.Errorf("got %v, want %v", got, want)
@@ -245,6 +245,8 @@ func TestDelete(t *testing.T) {
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("dump mismatch (-want +got):\n%s", diff)
 			}
+
+			visualizedoutputtest(t, fr)
 		})
 	}
 }

--- a/frame/insert_more_test.go
+++ b/frame/insert_more_test.go
@@ -198,6 +198,8 @@ func TestInsertAligned(t *testing.T) {
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("dump mismatch (-want +got):\n%s", diff)
 			}
+
+			visualizedoutputtest(t, fr)
 		})
 	}
 }

--- a/frame/insert_test.go
+++ b/frame/insert_test.go
@@ -191,7 +191,7 @@ type invariants struct {
 // implementation.
 func setupFrame(t *testing.T, iv *invariants) Frame {
 	t.Helper()
-	display := edwoodtest.NewDisplay()
+	display := edwoodtest.NewDisplay(iv.textarea)
 
 	var textcolors [NumColours]draw.Image
 
@@ -430,15 +430,8 @@ func insertForcesRippleOfWrapped(t *testing.T, fr Frame, iv *invariants) {
 	}
 }
 
-func gdo(t *testing.T, fr Frame) edwoodtest.GettableDrawOps {
-	t.Helper()
-	frimpl := fr.(*frameimpl)
-	gdo := frimpl.display.(edwoodtest.GettableDrawOps)
-	return gdo
-}
-
 func nop(t *testing.T, _ Frame, _ *invariants) {
-	t.Log("hi from nop")
+	// t.Log("hi from nop")
 }
 
 // TODO(rjk): Conceivably the bxscan test can go away once I have written
@@ -478,18 +471,19 @@ func TestInsert(t *testing.T) {
 				"fill (20,10)-(46,20) [0,0],[2,1]",
 				`screen-800x600 <- string "ab" atpoint: (20,10) [0,0] fill: black`,
 			},
-			textarea: image.Rect(20, 10, 400, 500),
+			textarea: image.Rect(20, 10, 400, 100),
 		},
 		{
 			// A short but newline containing string that fits inserted at the start.
 			name: "multiInsertShortString",
 			fn:   multiInsertShortString,
-			want: []string{"fill (20,10)-(400,20) [0,0],[-,1]",
+			want: []string{
+				"fill (20,10)-(400,20) [0,0],[-,1]",
 				"fill (20,20)-(46,30) [0,1],[2,1]",
 				`screen-800x600 <- string "ab" atpoint: (20,10) [0,0] fill: black`,
 				`screen-800x600 <- string "cd" atpoint: (20,20) [0,1] fill: black`,
 			},
-			textarea: image.Rect(20, 10, 400, 500),
+			textarea: image.Rect(20, 10, 400, 100),
 		},
 		{
 			// A long line inserted. Requires wrapping the inserted line and rippling
@@ -505,13 +499,15 @@ func TestInsert(t *testing.T) {
 				`screen-800x600 <- string "a本ポポポポポポポポポポポポポポポポポポポポポポポポポポ" atpoint: (33,20) [1,1] fill: black`,
 				`screen-800x600 <- string "ポポポポポポポポポポポポhello" atpoint: (20,30) [0,2] fill: black`,
 			},
-			textarea: image.Rect(20, 10, 400, 500),
+			textarea: image.Rect(20, 10, 400, 100),
 		},
+		// one
 		{
 			// Insert into a long line
 			name: "insertIntoLongLine",
 			fn:   insertIntoLongLine,
 			want: []string{
+				// This first blit is a nop.
 				"blit (20,40)-(46,50) [0,3],[2,1], to (20,40)-(46,50) [0,3],[2,1]",
 				"fill (267,30)-(400,40) [19,2],[-,1]",
 				"blit (20,30)-(254,40) [0,2],[18,1], to (33,30)-(267,40) [1,2],[18,1]",
@@ -521,7 +517,7 @@ func TestInsert(t *testing.T) {
 				"fill (33,20)-(46,30) [1,1],[1,1]",
 				`screen-800x600 <- string "X" atpoint: (33,20) [1,1] fill: black`,
 			},
-			textarea: image.Rect(20, 10, 400, 500),
+			textarea: image.Rect(20, 10, 400, 100),
 		},
 		{
 			// Insert into a line with a tab
@@ -534,20 +530,7 @@ func TestInsert(t *testing.T) {
 				"fill (33,10)-(46,20) [1,0],[1,1]",
 				`screen-800x600 <- string "X" atpoint: (33,10) [1,0] fill: black`,
 			},
-			textarea: image.Rect(20, 10, 400, 500),
-		},
-		{
-			// Insert text that doesn't fit.
-			name: "insertPastEnd",
-			fn:   insertPastEnd,
-			want: []string{
-				"fill (20,10)-(60,20) [0,0],[-,1]",
-				"fill (20,20)-(60,40) [0,1],[-,2]",
-				"fill (20,40)-(20,50) [0,3],[0,1]",
-				`screen-800x600 <- string "a本ポ" atpoint: (20,10) [0,0] fill: black`,
-				`screen-800x600 <- string "ポポポ" atpoint: (20,20) [0,1] fill: black`,
-				`screen-800x600 <- string "ポポh" atpoint: (20,30) [0,2] fill: black`},
-			textarea: image.Rect(20, 10, 60, 40),
+			textarea: image.Rect(20, 10, 400, 100),
 		},
 		{
 			// Split a wrapped line by inserting a newline.
@@ -617,27 +600,6 @@ func TestInsert(t *testing.T) {
 		},
 
 		{
-			// Append a multibox string that hangs off the end. TODO(rjk): Draws a
-			// zero-width fill off the end of text area. This is conceivably wrong.
-			// It would (for example) make some drawing stacks unhappy.
-			name:     "appendHangingLongAtEnd",
-			fn:       appendHangingLongAtEnd,
-			textarea: image.Rect(20, 10, 60, 60),
-			want: []string{
-				"fill (20,10)-(60,20) [0,0],[-,1]",
-				"fill (20,20)-(60,60) [0,1],[-,4]",
-				"fill (20,60)-(20,70) [0,5],[0,1]",
-				`screen-800x600 <- string "0" atpoint: (20,10) [0,0] fill: black`,
-				`screen-800x600 <- string "1" atpoint: (20,20) [0,1] fill: black`,
-				`screen-800x600 <- string "2" atpoint: (20,30) [0,2] fill: black`,
-				`screen-800x600 <- string "3" atpoint: (20,40) [0,3] fill: black`,
-				`screen-800x600 <- string "4" atpoint: (20,50) [0,4] fill: black`,
-				"fill (33,50)-(60,60) [1,4],[-,1]",
-				"fill (20,60)-(20,70) [0,5],[0,1]",
-				`screen-800x600 <- string "XX" atpoint: (33,50) [1,4] fill: black`,
-			},
-		},
-		{
 			// Insert a multibox string that forces ripple past the end.
 			name:     "insertWrappedThatForcesRipple",
 			fn:       insertWrappedThatForcesRipple,
@@ -682,35 +644,6 @@ func TestInsert(t *testing.T) {
 				"fill (33,10)-(46,20) [1,0],[1,1]",
 				`screen-800x600 <- string "X" atpoint: (33,10) [1,0] fill: black`,
 			},
-		},
-		{
-			// Insert into a long line
-			name: "insertIntoLongLine",
-			fn:   insertIntoLongLine,
-			want: []string{
-				"blit (20,40)-(46,50) [0,3],[2,1], to (20,40)-(46,50) [0,3],[2,1]",
-				"fill (267,30)-(400,40) [19,2],[-,1]",
-				"blit (20,30)-(254,40) [0,2],[18,1], to (33,30)-(267,40) [1,2],[18,1]",
-				"blit (384,20)-(397,30) [28,1],[1,1], to (20,30)-(33,40) [0,2],[1,1]",
-				"blit (33,20)-(384,30) [1,1],[27,1], to (46,20)-(397,30) [2,1],[27,1]",
-				"fill (397,20)-(400,30) [29,1],[-,1]",
-				"fill (33,20)-(46,30) [1,1],[1,1]",
-				`screen-800x600 <- string "X" atpoint: (33,20) [1,1] fill: black`,
-			},
-			textarea: image.Rect(20, 10, 400, 500),
-		},
-		{
-			// Insert into a line with a tab
-			name: "insertTabAndChar",
-			fn:   insertTabAndChar,
-			want: []string{
-				"blit (33,10)-(46,20) [1,0],[1,1], to (124,10)-(137,20) [8,0],[1,1]",
-				"fill (33,10)-(124,20) [1,0],[7,1]",
-				"fill (46,10)-(124,20) [2,0],[6,1]",
-				"fill (33,10)-(46,20) [1,0],[1,1]",
-				`screen-800x600 <- string "X" atpoint: (33,10) [1,0] fill: black`,
-			},
-			textarea: image.Rect(20, 10, 400, 500),
 		},
 		{
 			// Insert text that doesn't fit.
@@ -726,31 +659,6 @@ func TestInsert(t *testing.T) {
 			textarea: image.Rect(20, 10, 60, 40),
 		},
 		{
-			// Insert a single character that forces conversion of non-wrapped to
-			// wrapped with wripple to end.
-			name:     "insertForcesWrap",
-			fn:       insertForcesWrap,
-			textarea: image.Rect(20, 10, 60, 60),
-			want: []string{
-				"fill (20,10)-(60,20) [0,0],[-,1]",
-				"fill (20,20)-(60,50) [0,1],[-,3]",
-				"fill (20,50)-(59,60) [0,4],[3,1]",
-				`screen-800x600 <- string "0ab" atpoint: (20,10) [0,0] fill: black`,
-				`screen-800x600 <- string "1cd" atpoint: (20,20) [0,1] fill: black`,
-				`screen-800x600 <- string "2ef" atpoint: (20,30) [0,2] fill: black`,
-				`screen-800x600 <- string "3gh" atpoint: (20,40) [0,3] fill: black`,
-				`screen-800x600 <- string "4ij" atpoint: (20,50) [0,4] fill: black`,
-				"blit (20,30)-(60,50) [0,2],[-,2], to (20,40)-(60,60) [0,3],[-,2]",
-				"blit (59,20)-(60,30) [3,1],[-,1], to (59,30)-(60,40) [3,2],[-,1]",
-				"blit (20,20)-(59,30) [0,1],[3,1], to (20,30)-(59,40) [0,2],[3,1]",
-				"fill (33,20)-(60,30) [1,1],[-,1]",
-				"blit (46,10)-(59,20) [2,0],[1,1], to (20,20)-(33,30) [0,1],[1,1]",
-				"fill (46,10)-(60,20) [2,0],[-,1]",
-				"fill (20,20)-(20,30) [0,1],[0,1]",
-				`screen-800x600 <- string "X" atpoint: (46,10) [2,0] fill: black`,
-			},
-		},
-		{
 			// Append a multibox string that hangs off the end. TODO(rjk): Draws a
 			// zero-width fill off the end of text area. This is conceivably wrong.
 			// It would (for example) make some drawing stacks unhappy.
@@ -769,52 +677,6 @@ func TestInsert(t *testing.T) {
 				"fill (33,50)-(60,60) [1,4],[-,1]",
 				"fill (20,60)-(20,70) [0,5],[0,1]",
 				`screen-800x600 <- string "XX" atpoint: (33,50) [1,4] fill: black`,
-			},
-		},
-		{
-			// Insert a multibox string that forces ripple past the end.
-			name:     "insertWrappedThatForcesRipple",
-			fn:       insertWrappedThatForcesRipple,
-			textarea: image.Rect(20, 10, 60, 60),
-			want: []string{
-				"fill (20,10)-(60,20) [0,0],[-,1]",
-				"fill (20,20)-(60,60) [0,1],[-,4]",
-				"fill (20,60)-(20,70) [0,5],[0,1]",
-				`screen-800x600 <- string "0" atpoint: (20,10) [0,0] fill: black`,
-				`screen-800x600 <- string "1" atpoint: (20,20) [0,1] fill: black`,
-				`screen-800x600 <- string "2" atpoint: (20,30) [0,2] fill: black`,
-				`screen-800x600 <- string "3b" atpoint: (20,40) [0,3] fill: black`,
-				`screen-800x600 <- string "4" atpoint: (20,50) [0,4] fill: black`,
-				"fill (59,50)-(60,60) [3,4],[-,1]",
-				"blit (33,40)-(46,50) [1,3],[1,1], to (46,50)-(59,60) [2,4],[1,1]",
-				"fill (33,40)-(60,50) [1,3],[-,1]",
-				"fill (20,50)-(46,60) [0,4],[2,1]",
-				`screen-800x600 <- string "ij" atpoint: (33,40) [1,3] fill: black`,
-				`screen-800x600 <- string "XX" atpoint: (20,50) [0,4] fill: black`,
-			},
-		},
-		{
-			// Insert a string that pushes a blank line off the end.
-			name:     "insertPushesBlankLineOffEnd",
-			fn:       insertPushesBlankLineOffEnd,
-			textarea: image.Rect(20, 10, 60, 60),
-			want: []string{
-				"fill (20,10)-(60,20) [0,0],[-,1]",
-				"fill (20,20)-(60,60) [0,1],[-,4]",
-				"fill (20,60)-(20,70) [0,5],[0,1]",
-				`screen-800x600 <- string "0ab" atpoint: (20,10) [0,0] fill: black`,
-				`screen-800x600 <- string "1cd" atpoint: (20,20) [0,1] fill: black`,
-				`screen-800x600 <- string "2ef" atpoint: (20,30) [0,2] fill: black`,
-				`screen-800x600 <- string "3gh" atpoint: (20,40) [0,3] fill: black`,
-				"blit (20,30)-(60,50) [0,2],[-,2], to (20,40)-(60,60) [0,3],[-,2]",
-				"blit (59,20)-(60,30) [3,1],[-,1], to (59,30)-(60,40) [3,2],[-,1]",
-				"blit (20,20)-(59,30) [0,1],[3,1], to (20,30)-(59,40) [0,2],[3,1]",
-				"fill (33,20)-(60,30) [1,1],[-,1]",
-				"blit (46,10)-(59,20) [2,0],[1,1], to (20,20)-(33,30) [0,1],[1,1]",
-				"blit (33,10)-(46,20) [1,0],[1,1], to (46,10)-(59,20) [2,0],[1,1]",
-				"fill (59,10)-(60,20) [3,0],[-,1]",
-				"fill (33,10)-(46,20) [1,0],[1,1]",
-				`screen-800x600 <- string "X" atpoint: (33,10) [1,0] fill: black`,
 			},
 		},
 		{
@@ -884,18 +746,9 @@ func TestInsert(t *testing.T) {
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("dump mismatch (-want +got):\n%s", diff)
 			}
+
+			// SVG based output and comparison.
+			visualizedoutputtest(t, fr)
 		})
 	}
-
-	// TODO(rjk): I had wanted a "nice" way to describe and validate the
-	// tests by automatically generating diagrams. I thought about this. See
-	// Thursday-Morning.md in the wiki. I eventually (reluctantly) concluded
-	// that the testing and debugging effort to make sure that the
-	// automatically generated diagrams were correct was the same effort as
-	// validating the ops here.
-	//
-	// I started drawing the op sequences in OmniGraffle. This is was only a
-	// little more work than doing it on paper.
-	//
-	// TODO(rjk): include the diagrams in the source tree.
 }

--- a/frame/testdata/TestDelete/deleteCharBeforeTab.html
+++ b/frame/testdata/TestDelete/deleteCharBeforeTab.html
@@ -1,0 +1,90 @@
+<html lang="en-US">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+</head>
+<body>
+<svg viewBox="-20 -30 350 490" xmlns="http://www.w3.org/2000/svg">
+
+<style>
+	.small { font: 8px sans-serif; }
+</style>
+
+<g transform="translate(0, 0)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">target rect (20,10)-(140,40)</text>
+	</g>
+	<g id="draw0">
+	<rect x="20" y="10" width="120" height="30" fill="none" stroke="black"/>
+	</g>
+</g>
+
+<g transform="translate(0, 70)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,10)-(140,20) [0,0],[-,1]</text>
+	</g>
+	<g id="draw1">
+	<use href="#draw0" />
+	<rect x="20" y="10" width="120" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 140)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,20)-(98,30) [0,1],[6,1]</text>
+	</g>
+	<g id="draw2">
+	<use href="#draw1" />
+	<rect x="20" y="20" width="78" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 210)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;0a&#34; atpoint: (20,10) [0,0] fill: black</text>
+	</g>
+	<g id="draw3">
+	<use href="#draw2" />
+	<text x="22" y="18" fill="black" class="small">0</text>
+	<text x="35" y="18" fill="black" class="small">a</text>
+	</g>
+</g>
+
+<g transform="translate(0, 280)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;b&#34; atpoint: (124,10) [8,0] fill: black</text>
+	</g>
+	<g id="draw4">
+	<use href="#draw3" />
+	<text x="126" y="18" fill="black" class="small">b</text>
+	</g>
+</g>
+
+<g transform="translate(0, 350)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;1cd2ef&#34; atpoint: (20,20) [0,1] fill: black</text>
+	</g>
+	<g id="draw5">
+	<use href="#draw4" />
+	<text x="22" y="28" fill="black" class="small">1</text>
+	<text x="35" y="28" fill="black" class="small">c</text>
+	<text x="48" y="28" fill="black" class="small">d</text>
+	<text x="61" y="28" fill="black" class="small">2</text>
+	<text x="74" y="28" fill="black" class="small">e</text>
+	<text x="87" y="28" fill="black" class="small">f</text>
+	</g>
+</g>
+
+<g transform="translate(0, 420)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (33,10)-(124,20) [1,0],[7,1]</text>
+	</g>
+	<g id="draw6">
+	<use href="#draw5" />
+	<rect x="33" y="10" width="91" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+</svg>
+</body>
+</html>

--- a/frame/testdata/TestDelete/deleteNewlineTocreateWrappedLine.html
+++ b/frame/testdata/TestDelete/deleteNewlineTocreateWrappedLine.html
@@ -1,0 +1,119 @@
+<html lang="en-US">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+</head>
+<body>
+<svg viewBox="-20 -30 190 630" xmlns="http://www.w3.org/2000/svg">
+
+<style>
+	.small { font: 8px sans-serif; }
+</style>
+
+<g transform="translate(0, 0)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">target rect (20,10)-(60,40)</text>
+	</g>
+	<g id="draw0">
+	<rect x="20" y="10" width="40" height="30" fill="none" stroke="black"/>
+	</g>
+</g>
+
+<g transform="translate(0, 70)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,10)-(60,20) [0,0],[-,1]</text>
+	</g>
+	<g id="draw1">
+	<use href="#draw0" />
+	<rect x="20" y="10" width="40" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 140)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,20)-(60,30) [0,1],[-,1]</text>
+	</g>
+	<g id="draw2">
+	<use href="#draw1" />
+	<rect x="20" y="20" width="40" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 210)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,30)-(59,40) [0,2],[3,1]</text>
+	</g>
+	<g id="draw3">
+	<use href="#draw2" />
+	<rect x="20" y="30" width="39" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 280)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;0ab&#34; atpoint: (20,10) [0,0] fill: black</text>
+	</g>
+	<g id="draw4">
+	<use href="#draw3" />
+	<text x="22" y="18" fill="black" class="small">0</text>
+	<text x="35" y="18" fill="black" class="small">a</text>
+	<text x="48" y="18" fill="black" class="small">b</text>
+	</g>
+</g>
+
+<g transform="translate(0, 350)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;1cd&#34; atpoint: (20,20) [0,1] fill: black</text>
+	</g>
+	<g id="draw5">
+	<use href="#draw4" />
+	<text x="22" y="28" fill="black" class="small">1</text>
+	<text x="35" y="28" fill="black" class="small">c</text>
+	<text x="48" y="28" fill="black" class="small">d</text>
+	</g>
+</g>
+
+<g transform="translate(0, 420)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;2ef&#34; atpoint: (20,30) [0,2] fill: black</text>
+	</g>
+	<g id="draw6">
+	<use href="#draw5" />
+	<text x="22" y="38" fill="black" class="small">2</text>
+	<text x="35" y="38" fill="black" class="small">e</text>
+	<text x="48" y="38" fill="black" class="small">f</text>
+	</g>
+</g>
+
+<g transform="translate(0, 490)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (20,20)-(59,30) [0,1],[3,1], to (20,20)-(59,30) [0,1],[3,1]</text>
+	</g>
+	<use href="#draw6" />
+<rect x="20" y="20" width="39" height="10" fill="none" stroke="red"/>
+<g transform="translate(70, 0)">
+	<g id="draw7">
+		<use href="#draw6" />
+		<clipPath id="draw7_blitsource">
+			
+			<rect x="20" y="20" width="39" height="10" />
+		</clipPath>
+		<use href="#draw6" clip-path="url(#draw7_blitsource)" x="0" y="0" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 560)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (59,20)-(59,30) [3,1],[0,1]</text>
+	</g>
+	<g id="draw8">
+	<use href="#draw7" />
+	<rect x="59" y="20" width="0" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+</svg>
+</body>
+</html>

--- a/frame/testdata/TestDelete/deleteSingleCharacterAtLineEnd.html
+++ b/frame/testdata/TestDelete/deleteSingleCharacterAtLineEnd.html
@@ -1,0 +1,56 @@
+<html lang="en-US">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+</head>
+<body>
+<svg viewBox="-20 -30 190 280" xmlns="http://www.w3.org/2000/svg">
+
+<style>
+	.small { font: 8px sans-serif; }
+</style>
+
+<g transform="translate(0, 0)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">target rect (20,10)-(60,40)</text>
+	</g>
+	<g id="draw0">
+	<rect x="20" y="10" width="40" height="30" fill="none" stroke="black"/>
+	</g>
+</g>
+
+<g transform="translate(0, 70)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,10)-(59,20) [0,0],[3,1]</text>
+	</g>
+	<g id="draw1">
+	<use href="#draw0" />
+	<rect x="20" y="10" width="39" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 140)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;0ab&#34; atpoint: (20,10) [0,0] fill: black</text>
+	</g>
+	<g id="draw2">
+	<use href="#draw1" />
+	<text x="22" y="18" fill="black" class="small">0</text>
+	<text x="35" y="18" fill="black" class="small">a</text>
+	<text x="48" y="18" fill="black" class="small">b</text>
+	</g>
+</g>
+
+<g transform="translate(0, 210)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (46,10)-(59,20) [2,0],[1,1]</text>
+	</g>
+	<g id="draw3">
+	<use href="#draw2" />
+	<rect x="46" y="10" width="13" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+</svg>
+</body>
+</html>

--- a/frame/testdata/TestDelete/deleteSingleCharacterInMiddle.html
+++ b/frame/testdata/TestDelete/deleteSingleCharacterInMiddle.html
@@ -1,0 +1,85 @@
+<html lang="en-US">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+</head>
+<body>
+<svg viewBox="-20 -30 190 420" xmlns="http://www.w3.org/2000/svg">
+
+<style>
+	.small { font: 8px sans-serif; }
+</style>
+
+<g transform="translate(0, 0)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">target rect (20,10)-(60,40)</text>
+	</g>
+	<g id="draw0">
+	<rect x="20" y="10" width="40" height="30" fill="none" stroke="black"/>
+	</g>
+</g>
+
+<g transform="translate(0, 70)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,10)-(59,20) [0,0],[3,1]</text>
+	</g>
+	<g id="draw1">
+	<use href="#draw0" />
+	<rect x="20" y="10" width="39" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 140)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;0ab&#34; atpoint: (20,10) [0,0] fill: black</text>
+	</g>
+	<g id="draw2">
+	<use href="#draw1" />
+	<text x="22" y="18" fill="black" class="small">0</text>
+	<text x="35" y="18" fill="black" class="small">a</text>
+	<text x="48" y="18" fill="black" class="small">b</text>
+	</g>
+</g>
+
+<g transform="translate(0, 210)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (46,10)-(59,20) [2,0],[1,1], to (33,10)-(46,20) [1,0],[1,1]</text>
+	</g>
+	<use href="#draw2" />
+<rect x="46" y="10" width="13" height="10" fill="none" stroke="red"/>
+<g transform="translate(70, 0)">
+	<g id="draw3">
+		<use href="#draw2" />
+		<clipPath id="draw3_blitsource">
+			
+			<rect x="46" y="10" width="13" height="10" />
+		</clipPath>
+		<use href="#draw2" clip-path="url(#draw3_blitsource)" x="-13" y="0" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 280)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (46,10)-(46,20) [2,0],[0,1]</text>
+	</g>
+	<g id="draw4">
+	<use href="#draw3" />
+	<rect x="46" y="10" width="0" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 350)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (46,10)-(59,20) [2,0],[1,1]</text>
+	</g>
+	<g id="draw5">
+	<use href="#draw4" />
+	<rect x="46" y="10" width="13" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+</svg>
+</body>
+</html>

--- a/frame/testdata/TestDelete/deleteTab.html
+++ b/frame/testdata/TestDelete/deleteTab.html
@@ -1,0 +1,178 @@
+<html lang="en-US">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+</head>
+<body>
+<svg viewBox="-20 -30 350 980" xmlns="http://www.w3.org/2000/svg">
+
+<style>
+	.small { font: 8px sans-serif; }
+</style>
+
+<g transform="translate(0, 0)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">target rect (20,10)-(140,40)</text>
+	</g>
+	<g id="draw0">
+	<rect x="20" y="10" width="120" height="30" fill="none" stroke="black"/>
+	</g>
+</g>
+
+<g transform="translate(0, 70)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,10)-(140,20) [0,0],[-,1]</text>
+	</g>
+	<g id="draw1">
+	<use href="#draw0" />
+	<rect x="20" y="10" width="120" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 140)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,20)-(111,30) [0,1],[7,1]</text>
+	</g>
+	<g id="draw2">
+	<use href="#draw1" />
+	<rect x="20" y="20" width="91" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 210)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;0&#34; atpoint: (20,10) [0,0] fill: black</text>
+	</g>
+	<g id="draw3">
+	<use href="#draw2" />
+	<text x="22" y="18" fill="black" class="small">0</text>
+	</g>
+</g>
+
+<g transform="translate(0, 280)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;a&#34; atpoint: (124,10) [8,0] fill: black</text>
+	</g>
+	<g id="draw4">
+	<use href="#draw3" />
+	<text x="126" y="18" fill="black" class="small">a</text>
+	</g>
+</g>
+
+<g transform="translate(0, 350)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;b1cd2ef&#34; atpoint: (20,20) [0,1] fill: black</text>
+	</g>
+	<g id="draw5">
+	<use href="#draw4" />
+	<text x="22" y="28" fill="black" class="small">b</text>
+	<text x="35" y="28" fill="black" class="small">1</text>
+	<text x="48" y="28" fill="black" class="small">c</text>
+	<text x="61" y="28" fill="black" class="small">d</text>
+	<text x="74" y="28" fill="black" class="small">2</text>
+	<text x="87" y="28" fill="black" class="small">e</text>
+	<text x="100" y="28" fill="black" class="small">f</text>
+	</g>
+</g>
+
+<g transform="translate(0, 420)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (124,10)-(137,20) [8,0],[1,1], to (33,10)-(46,20) [1,0],[1,1]</text>
+	</g>
+	<use href="#draw5" />
+<rect x="124" y="10" width="13" height="10" fill="none" stroke="red"/>
+<g transform="translate(150, 0)">
+	<g id="draw6">
+		<use href="#draw5" />
+		<clipPath id="draw6_blitsource">
+			
+			<rect x="124" y="10" width="13" height="10" />
+		</clipPath>
+		<use href="#draw5" clip-path="url(#draw6_blitsource)" x="-91" y="0" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 490)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (46,10)-(46,20) [2,0],[0,1]</text>
+	</g>
+	<g id="draw7">
+	<use href="#draw6" />
+	<rect x="46" y="10" width="0" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 560)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (20,20)-(111,30) [0,1],[7,1], to (46,10)-(137,20) [2,0],[7,1]</text>
+	</g>
+	<use href="#draw7" />
+<rect x="20" y="20" width="91" height="10" fill="none" stroke="red"/>
+<g transform="translate(150, 0)">
+	<g id="draw8">
+		<use href="#draw7" />
+		<clipPath id="draw8_blitsource">
+			
+			<rect x="20" y="20" width="91" height="10" />
+		</clipPath>
+		<use href="#draw7" clip-path="url(#draw8_blitsource)" x="26" y="-10" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 630)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (137,10)-(137,20) [9,0],[0,1]</text>
+	</g>
+	<g id="draw9">
+	<use href="#draw8" />
+	<rect x="137" y="10" width="0" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 700)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (137,10)-(140,20) [9,0],[-,1]</text>
+	</g>
+	<g id="draw10">
+	<use href="#draw9" />
+	<rect x="137" y="10" width="3" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 770)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,20)-(111,30) [0,1],[7,1]</text>
+	</g>
+	<g id="draw11">
+	<use href="#draw10" />
+	<rect x="20" y="20" width="91" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 840)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (137,10)-(140,20) [9,0],[-,1]</text>
+	</g>
+	<g id="draw12">
+	<use href="#draw11" />
+	<rect x="137" y="10" width="3" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 910)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,20)-(111,30) [0,1],[7,1]</text>
+	</g>
+	<g id="draw13">
+	<use href="#draw12" />
+	<rect x="20" y="20" width="91" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+</svg>
+</body>
+</html>

--- a/frame/testdata/TestDelete/deleteTabl.html
+++ b/frame/testdata/TestDelete/deleteTabl.html
@@ -1,0 +1,178 @@
+<html lang="en-US">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+</head>
+<body>
+<svg viewBox="-20 -30 350 980" xmlns="http://www.w3.org/2000/svg">
+
+<style>
+	.small { font: 8px sans-serif; }
+</style>
+
+<g transform="translate(0, 0)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">target rect (20,10)-(140,40)</text>
+	</g>
+	<g id="draw0">
+	<rect x="20" y="10" width="120" height="30" fill="none" stroke="black"/>
+	</g>
+</g>
+
+<g transform="translate(0, 70)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,10)-(140,20) [0,0],[-,1]</text>
+	</g>
+	<g id="draw1">
+	<use href="#draw0" />
+	<rect x="20" y="10" width="120" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 140)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,20)-(111,30) [0,1],[7,1]</text>
+	</g>
+	<g id="draw2">
+	<use href="#draw1" />
+	<rect x="20" y="20" width="91" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 210)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;0&#34; atpoint: (20,10) [0,0] fill: black</text>
+	</g>
+	<g id="draw3">
+	<use href="#draw2" />
+	<text x="22" y="18" fill="black" class="small">0</text>
+	</g>
+</g>
+
+<g transform="translate(0, 280)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;a&#34; atpoint: (124,10) [8,0] fill: black</text>
+	</g>
+	<g id="draw4">
+	<use href="#draw3" />
+	<text x="126" y="18" fill="black" class="small">a</text>
+	</g>
+</g>
+
+<g transform="translate(0, 350)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;b1cd2ef&#34; atpoint: (20,20) [0,1] fill: black</text>
+	</g>
+	<g id="draw5">
+	<use href="#draw4" />
+	<text x="22" y="28" fill="black" class="small">b</text>
+	<text x="35" y="28" fill="black" class="small">1</text>
+	<text x="48" y="28" fill="black" class="small">c</text>
+	<text x="61" y="28" fill="black" class="small">d</text>
+	<text x="74" y="28" fill="black" class="small">2</text>
+	<text x="87" y="28" fill="black" class="small">e</text>
+	<text x="100" y="28" fill="black" class="small">f</text>
+	</g>
+</g>
+
+<g transform="translate(0, 420)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (124,10)-(137,20) [8,0],[1,1], to (33,10)-(46,20) [1,0],[1,1]</text>
+	</g>
+	<use href="#draw5" />
+<rect x="124" y="10" width="13" height="10" fill="none" stroke="red"/>
+<g transform="translate(150, 0)">
+	<g id="draw6">
+		<use href="#draw5" />
+		<clipPath id="draw6_blitsource">
+			
+			<rect x="124" y="10" width="13" height="10" />
+		</clipPath>
+		<use href="#draw5" clip-path="url(#draw6_blitsource)" x="-91" y="0" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 490)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (46,10)-(46,20) [2,0],[0,1]</text>
+	</g>
+	<g id="draw7">
+	<use href="#draw6" />
+	<rect x="46" y="10" width="0" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 560)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (20,20)-(111,30) [0,1],[7,1], to (46,10)-(137,20) [2,0],[7,1]</text>
+	</g>
+	<use href="#draw7" />
+<rect x="20" y="20" width="91" height="10" fill="none" stroke="red"/>
+<g transform="translate(150, 0)">
+	<g id="draw8">
+		<use href="#draw7" />
+		<clipPath id="draw8_blitsource">
+			
+			<rect x="20" y="20" width="91" height="10" />
+		</clipPath>
+		<use href="#draw7" clip-path="url(#draw8_blitsource)" x="26" y="-10" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 630)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (137,10)-(137,20) [9,0],[0,1]</text>
+	</g>
+	<g id="draw9">
+	<use href="#draw8" />
+	<rect x="137" y="10" width="0" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 700)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (137,10)-(140,20) [9,0],[-,1]</text>
+	</g>
+	<g id="draw10">
+	<use href="#draw9" />
+	<rect x="137" y="10" width="3" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 770)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,20)-(111,30) [0,1],[7,1]</text>
+	</g>
+	<g id="draw11">
+	<use href="#draw10" />
+	<rect x="20" y="20" width="91" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 840)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (137,10)-(140,20) [9,0],[-,1]</text>
+	</g>
+	<g id="draw12">
+	<use href="#draw11" />
+	<rect x="137" y="10" width="3" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 910)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,20)-(111,30) [0,1],[7,1]</text>
+	</g>
+	<g id="draw13">
+	<use href="#draw12" />
+	<rect x="20" y="20" width="91" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+</svg>
+</body>
+</html>

--- a/frame/testdata/TestDelete/rippleUpDeletedChar.html
+++ b/frame/testdata/TestDelete/rippleUpDeletedChar.html
@@ -1,0 +1,245 @@
+<html lang="en-US">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+</head>
+<body>
+<svg viewBox="-20 -30 190 1260" xmlns="http://www.w3.org/2000/svg">
+
+<style>
+	.small { font: 8px sans-serif; }
+</style>
+
+<g transform="translate(0, 0)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">target rect (20,10)-(60,40)</text>
+	</g>
+	<g id="draw0">
+	<rect x="20" y="10" width="40" height="30" fill="none" stroke="black"/>
+	</g>
+</g>
+
+<g transform="translate(0, 70)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,10)-(60,20) [0,0],[-,1]</text>
+	</g>
+	<g id="draw1">
+	<use href="#draw0" />
+	<rect x="20" y="10" width="40" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 140)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,20)-(60,30) [0,1],[-,1]</text>
+	</g>
+	<g id="draw2">
+	<use href="#draw1" />
+	<rect x="20" y="20" width="40" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 210)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,30)-(59,40) [0,2],[3,1]</text>
+	</g>
+	<g id="draw3">
+	<use href="#draw2" />
+	<rect x="20" y="30" width="39" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 280)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;0ab&#34; atpoint: (20,10) [0,0] fill: black</text>
+	</g>
+	<g id="draw4">
+	<use href="#draw3" />
+	<text x="22" y="18" fill="black" class="small">0</text>
+	<text x="35" y="18" fill="black" class="small">a</text>
+	<text x="48" y="18" fill="black" class="small">b</text>
+	</g>
+</g>
+
+<g transform="translate(0, 350)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;1cd&#34; atpoint: (20,20) [0,1] fill: black</text>
+	</g>
+	<g id="draw5">
+	<use href="#draw4" />
+	<text x="22" y="28" fill="black" class="small">1</text>
+	<text x="35" y="28" fill="black" class="small">c</text>
+	<text x="48" y="28" fill="black" class="small">d</text>
+	</g>
+</g>
+
+<g transform="translate(0, 420)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;2ef&#34; atpoint: (20,30) [0,2] fill: black</text>
+	</g>
+	<g id="draw6">
+	<use href="#draw5" />
+	<text x="22" y="38" fill="black" class="small">2</text>
+	<text x="35" y="38" fill="black" class="small">e</text>
+	<text x="48" y="38" fill="black" class="small">f</text>
+	</g>
+</g>
+
+<g transform="translate(0, 490)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (46,10)-(59,20) [2,0],[1,1], to (33,10)-(46,20) [1,0],[1,1]</text>
+	</g>
+	<use href="#draw6" />
+<rect x="46" y="10" width="13" height="10" fill="none" stroke="red"/>
+<g transform="translate(70, 0)">
+	<g id="draw7">
+		<use href="#draw6" />
+		<clipPath id="draw7_blitsource">
+			
+			<rect x="46" y="10" width="13" height="10" />
+		</clipPath>
+		<use href="#draw6" clip-path="url(#draw7_blitsource)" x="-13" y="0" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 560)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (46,10)-(46,20) [2,0],[0,1]</text>
+	</g>
+	<g id="draw8">
+	<use href="#draw7" />
+	<rect x="46" y="10" width="0" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 630)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (20,20)-(33,30) [0,1],[1,1], to (46,10)-(59,20) [2,0],[1,1]</text>
+	</g>
+	<use href="#draw8" />
+<rect x="20" y="20" width="13" height="10" fill="none" stroke="red"/>
+<g transform="translate(70, 0)">
+	<g id="draw9">
+		<use href="#draw8" />
+		<clipPath id="draw9_blitsource">
+			
+			<rect x="20" y="20" width="13" height="10" />
+		</clipPath>
+		<use href="#draw8" clip-path="url(#draw9_blitsource)" x="26" y="-10" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 700)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (59,10)-(60,20) [3,0],[-,1]</text>
+	</g>
+	<g id="draw10">
+	<use href="#draw9" />
+	<rect x="59" y="10" width="1" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 770)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (33,20)-(59,30) [1,1],[2,1], to (20,20)-(46,30) [0,1],[2,1]</text>
+	</g>
+	<use href="#draw10" />
+<rect x="33" y="20" width="26" height="10" fill="none" stroke="red"/>
+<g transform="translate(70, 0)">
+	<g id="draw11">
+		<use href="#draw10" />
+		<clipPath id="draw11_blitsource">
+			
+			<rect x="33" y="20" width="26" height="10" />
+		</clipPath>
+		<use href="#draw10" clip-path="url(#draw11_blitsource)" x="-13" y="0" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 840)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (46,20)-(46,30) [2,1],[0,1]</text>
+	</g>
+	<g id="draw12">
+	<use href="#draw11" />
+	<rect x="46" y="20" width="0" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 910)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (20,30)-(33,40) [0,2],[1,1], to (46,20)-(59,30) [2,1],[1,1]</text>
+	</g>
+	<use href="#draw12" />
+<rect x="20" y="30" width="13" height="10" fill="none" stroke="red"/>
+<g transform="translate(70, 0)">
+	<g id="draw13">
+		<use href="#draw12" />
+		<clipPath id="draw13_blitsource">
+			
+			<rect x="20" y="30" width="13" height="10" />
+		</clipPath>
+		<use href="#draw12" clip-path="url(#draw13_blitsource)" x="26" y="-10" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 980)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (59,20)-(60,30) [3,1],[-,1]</text>
+	</g>
+	<g id="draw14">
+	<use href="#draw13" />
+	<rect x="59" y="20" width="1" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 1050)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (33,30)-(59,40) [1,2],[2,1], to (20,30)-(46,40) [0,2],[2,1]</text>
+	</g>
+	<use href="#draw14" />
+<rect x="33" y="30" width="26" height="10" fill="none" stroke="red"/>
+<g transform="translate(70, 0)">
+	<g id="draw15">
+		<use href="#draw14" />
+		<clipPath id="draw15_blitsource">
+			
+			<rect x="33" y="30" width="26" height="10" />
+		</clipPath>
+		<use href="#draw14" clip-path="url(#draw15_blitsource)" x="-13" y="0" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 1120)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (46,30)-(46,40) [2,2],[0,1]</text>
+	</g>
+	<g id="draw16">
+	<use href="#draw15" />
+	<rect x="46" y="30" width="0" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 1190)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (46,30)-(59,40) [2,2],[1,1]</text>
+	</g>
+	<g id="draw17">
+	<use href="#draw16" />
+	<rect x="46" y="30" width="13" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+</svg>
+</body>
+</html>

--- a/frame/testdata/TestDelete/rippleUpMultiLine.html
+++ b/frame/testdata/TestDelete/rippleUpMultiLine.html
@@ -1,0 +1,156 @@
+<html lang="en-US">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+</head>
+<body>
+<svg viewBox="-20 -30 190 840" xmlns="http://www.w3.org/2000/svg">
+
+<style>
+	.small { font: 8px sans-serif; }
+</style>
+
+<g transform="translate(0, 0)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">target rect (20,10)-(60,40)</text>
+	</g>
+	<g id="draw0">
+	<rect x="20" y="10" width="40" height="30" fill="none" stroke="black"/>
+	</g>
+</g>
+
+<g transform="translate(0, 70)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,10)-(60,20) [0,0],[-,1]</text>
+	</g>
+	<g id="draw1">
+	<use href="#draw0" />
+	<rect x="20" y="10" width="40" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 140)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,20)-(60,40) [0,1],[-,2]</text>
+	</g>
+	<g id="draw2">
+	<use href="#draw1" />
+	<rect x="20" y="20" width="40" height="20" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 210)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,40)-(20,50) [0,3],[0,1]</text>
+	</g>
+	<g id="draw3">
+	<use href="#draw2" />
+	<rect x="20" y="40" width="0" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 280)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;0a&#34; atpoint: (20,10) [0,0] fill: black</text>
+	</g>
+	<g id="draw4">
+	<use href="#draw3" />
+	<text x="22" y="18" fill="black" class="small">0</text>
+	<text x="35" y="18" fill="black" class="small">a</text>
+	</g>
+</g>
+
+<g transform="translate(0, 350)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;b1&#34; atpoint: (20,20) [0,1] fill: black</text>
+	</g>
+	<g id="draw5">
+	<use href="#draw4" />
+	<text x="22" y="28" fill="black" class="small">b</text>
+	<text x="35" y="28" fill="black" class="small">1</text>
+	</g>
+</g>
+
+<g transform="translate(0, 420)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;cd2&#34; atpoint: (20,30) [0,2] fill: black</text>
+	</g>
+	<g id="draw6">
+	<use href="#draw5" />
+	<text x="22" y="38" fill="black" class="small">c</text>
+	<text x="35" y="38" fill="black" class="small">d</text>
+	<text x="48" y="38" fill="black" class="small">2</text>
+	</g>
+</g>
+
+<g transform="translate(0, 490)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (20,30)-(60,40) [0,2],[-,1], to (20,10)-(60,20) [0,0],[-,1]</text>
+	</g>
+	<use href="#draw6" />
+<rect x="20" y="30" width="40" height="10" fill="none" stroke="red"/>
+<g transform="translate(70, 0)">
+	<g id="draw7">
+		<use href="#draw6" />
+		<clipPath id="draw7_blitsource">
+			
+			<rect x="20" y="30" width="40" height="10" />
+		</clipPath>
+		<use href="#draw6" clip-path="url(#draw7_blitsource)" x="0" y="-20" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 560)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (20,40)-(60,40) [0,3],[-,0], to (20,20)-(60,20) [0,1],[-,0]</text>
+	</g>
+	<use href="#draw7" />
+<rect x="20" y="40" width="40" height="0" fill="none" stroke="red"/>
+<g transform="translate(70, 0)">
+	<g id="draw8">
+		<use href="#draw7" />
+		<clipPath id="draw8_blitsource">
+			
+			<rect x="20" y="40" width="40" height="0" />
+		</clipPath>
+		<use href="#draw7" clip-path="url(#draw8_blitsource)" x="0" y="-20" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 630)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,20)-(60,30) [0,1],[-,1]</text>
+	</g>
+	<g id="draw9">
+	<use href="#draw8" />
+	<rect x="20" y="20" width="40" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 700)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,30)-(60,40) [0,2],[-,1]</text>
+	</g>
+	<g id="draw10">
+	<use href="#draw9" />
+	<rect x="20" y="30" width="40" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 770)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,40)-(20,50) [0,3],[0,1]</text>
+	</g>
+	<g id="draw11">
+	<use href="#draw10" />
+	<rect x="20" y="40" width="0" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+</svg>
+</body>
+</html>

--- a/frame/testdata/TestInsert/appendAtEnd.html
+++ b/frame/testdata/TestInsert/appendAtEnd.html
@@ -1,0 +1,134 @@
+<html lang="en-US">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+</head>
+<body>
+<svg viewBox="-20 -30 190 990" xmlns="http://www.w3.org/2000/svg">
+
+<style>
+	.small { font: 8px sans-serif; }
+</style>
+
+<g transform="translate(0, 0)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">target rect (20,10)-(60,60)</text>
+	</g>
+	<g id="draw0">
+	<rect x="20" y="10" width="40" height="50" fill="none" stroke="black"/>
+	</g>
+</g>
+
+<g transform="translate(0, 90)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,10)-(60,20) [0,0],[-,1]</text>
+	</g>
+	<g id="draw1">
+	<use href="#draw0" />
+	<rect x="20" y="10" width="40" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 180)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,20)-(60,50) [0,1],[-,3]</text>
+	</g>
+	<g id="draw2">
+	<use href="#draw1" />
+	<rect x="20" y="20" width="40" height="30" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 270)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,50)-(59,60) [0,4],[3,1]</text>
+	</g>
+	<g id="draw3">
+	<use href="#draw2" />
+	<rect x="20" y="50" width="39" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 360)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;0ab&#34; atpoint: (20,10) [0,0] fill: black</text>
+	</g>
+	<g id="draw4">
+	<use href="#draw3" />
+	<text x="22" y="18" fill="black" class="small">0</text>
+	<text x="35" y="18" fill="black" class="small">a</text>
+	<text x="48" y="18" fill="black" class="small">b</text>
+	</g>
+</g>
+
+<g transform="translate(0, 450)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;1cd&#34; atpoint: (20,20) [0,1] fill: black</text>
+	</g>
+	<g id="draw5">
+	<use href="#draw4" />
+	<text x="22" y="28" fill="black" class="small">1</text>
+	<text x="35" y="28" fill="black" class="small">c</text>
+	<text x="48" y="28" fill="black" class="small">d</text>
+	</g>
+</g>
+
+<g transform="translate(0, 540)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;2ef&#34; atpoint: (20,30) [0,2] fill: black</text>
+	</g>
+	<g id="draw6">
+	<use href="#draw5" />
+	<text x="22" y="38" fill="black" class="small">2</text>
+	<text x="35" y="38" fill="black" class="small">e</text>
+	<text x="48" y="38" fill="black" class="small">f</text>
+	</g>
+</g>
+
+<g transform="translate(0, 630)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;3gh&#34; atpoint: (20,40) [0,3] fill: black</text>
+	</g>
+	<g id="draw7">
+	<use href="#draw6" />
+	<text x="22" y="48" fill="black" class="small">3</text>
+	<text x="35" y="48" fill="black" class="small">g</text>
+	<text x="48" y="48" fill="black" class="small">h</text>
+	</g>
+</g>
+
+<g transform="translate(0, 720)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;4ij&#34; atpoint: (20,50) [0,4] fill: black</text>
+	</g>
+	<g id="draw8">
+	<use href="#draw7" />
+	<text x="22" y="58" fill="black" class="small">4</text>
+	<text x="35" y="58" fill="black" class="small">i</text>
+	<text x="48" y="58" fill="black" class="small">j</text>
+	</g>
+</g>
+
+<g transform="translate(0, 810)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (59,50)-(60,60) [3,4],[-,1]</text>
+	</g>
+	<g id="draw9">
+	<use href="#draw8" />
+	<rect x="59" y="50" width="1" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 900)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,60)-(20,70) [0,5],[0,1]</text>
+	</g>
+	<g id="draw10">
+	<use href="#draw9" />
+	<rect x="20" y="60" width="0" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+</svg>
+</body>
+</html>

--- a/frame/testdata/TestInsert/appendHangingLongAtEnd.html
+++ b/frame/testdata/TestInsert/appendHangingLongAtEnd.html
@@ -1,0 +1,135 @@
+<html lang="en-US">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+</head>
+<body>
+<svg viewBox="-20 -30 190 1080" xmlns="http://www.w3.org/2000/svg">
+
+<style>
+	.small { font: 8px sans-serif; }
+</style>
+
+<g transform="translate(0, 0)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">target rect (20,10)-(60,60)</text>
+	</g>
+	<g id="draw0">
+	<rect x="20" y="10" width="40" height="50" fill="none" stroke="black"/>
+	</g>
+</g>
+
+<g transform="translate(0, 90)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,10)-(60,20) [0,0],[-,1]</text>
+	</g>
+	<g id="draw1">
+	<use href="#draw0" />
+	<rect x="20" y="10" width="40" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 180)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,20)-(60,60) [0,1],[-,4]</text>
+	</g>
+	<g id="draw2">
+	<use href="#draw1" />
+	<rect x="20" y="20" width="40" height="40" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 270)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,60)-(20,70) [0,5],[0,1]</text>
+	</g>
+	<g id="draw3">
+	<use href="#draw2" />
+	<rect x="20" y="60" width="0" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 360)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;0&#34; atpoint: (20,10) [0,0] fill: black</text>
+	</g>
+	<g id="draw4">
+	<use href="#draw3" />
+	<text x="22" y="18" fill="black" class="small">0</text>
+	</g>
+</g>
+
+<g transform="translate(0, 450)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;1&#34; atpoint: (20,20) [0,1] fill: black</text>
+	</g>
+	<g id="draw5">
+	<use href="#draw4" />
+	<text x="22" y="28" fill="black" class="small">1</text>
+	</g>
+</g>
+
+<g transform="translate(0, 540)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;2&#34; atpoint: (20,30) [0,2] fill: black</text>
+	</g>
+	<g id="draw6">
+	<use href="#draw5" />
+	<text x="22" y="38" fill="black" class="small">2</text>
+	</g>
+</g>
+
+<g transform="translate(0, 630)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;3&#34; atpoint: (20,40) [0,3] fill: black</text>
+	</g>
+	<g id="draw7">
+	<use href="#draw6" />
+	<text x="22" y="48" fill="black" class="small">3</text>
+	</g>
+</g>
+
+<g transform="translate(0, 720)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;4&#34; atpoint: (20,50) [0,4] fill: black</text>
+	</g>
+	<g id="draw8">
+	<use href="#draw7" />
+	<text x="22" y="58" fill="black" class="small">4</text>
+	</g>
+</g>
+
+<g transform="translate(0, 810)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (33,50)-(60,60) [1,4],[-,1]</text>
+	</g>
+	<g id="draw9">
+	<use href="#draw8" />
+	<rect x="33" y="50" width="27" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 900)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,60)-(20,70) [0,5],[0,1]</text>
+	</g>
+	<g id="draw10">
+	<use href="#draw9" />
+	<rect x="20" y="60" width="0" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 990)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;XX&#34; atpoint: (33,50) [1,4] fill: black</text>
+	</g>
+	<g id="draw11">
+	<use href="#draw10" />
+	<text x="35" y="58" fill="black" class="small">X</text>
+	<text x="48" y="58" fill="black" class="small">X</text>
+	</g>
+</g>
+
+</svg>
+</body>
+</html>

--- a/frame/testdata/TestInsert/insertForcesRippleOfWrapped.html
+++ b/frame/testdata/TestInsert/insertForcesRippleOfWrapped.html
@@ -1,0 +1,213 @@
+<html lang="en-US">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+</head>
+<body>
+<svg viewBox="-20 -30 190 1440" xmlns="http://www.w3.org/2000/svg">
+
+<style>
+	.small { font: 8px sans-serif; }
+</style>
+
+<g transform="translate(0, 0)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">target rect (20,10)-(60,60)</text>
+	</g>
+	<g id="draw0">
+	<rect x="20" y="10" width="40" height="50" fill="none" stroke="black"/>
+	</g>
+</g>
+
+<g transform="translate(0, 90)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,10)-(60,20) [0,0],[-,1]</text>
+	</g>
+	<g id="draw1">
+	<use href="#draw0" />
+	<rect x="20" y="10" width="40" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 180)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,20)-(60,60) [0,1],[-,4]</text>
+	</g>
+	<g id="draw2">
+	<use href="#draw1" />
+	<rect x="20" y="20" width="40" height="40" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 270)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,60)-(20,70) [0,5],[0,1]</text>
+	</g>
+	<g id="draw3">
+	<use href="#draw2" />
+	<rect x="20" y="60" width="0" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 360)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;0ab&#34; atpoint: (20,10) [0,0] fill: black</text>
+	</g>
+	<g id="draw4">
+	<use href="#draw3" />
+	<text x="22" y="18" fill="black" class="small">0</text>
+	<text x="35" y="18" fill="black" class="small">a</text>
+	<text x="48" y="18" fill="black" class="small">b</text>
+	</g>
+</g>
+
+<g transform="translate(0, 450)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;1cd&#34; atpoint: (20,20) [0,1] fill: black</text>
+	</g>
+	<g id="draw5">
+	<use href="#draw4" />
+	<text x="22" y="28" fill="black" class="small">1</text>
+	<text x="35" y="28" fill="black" class="small">c</text>
+	<text x="48" y="28" fill="black" class="small">d</text>
+	</g>
+</g>
+
+<g transform="translate(0, 540)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;2ef&#34; atpoint: (20,30) [0,2] fill: black</text>
+	</g>
+	<g id="draw6">
+	<use href="#draw5" />
+	<text x="22" y="38" fill="black" class="small">2</text>
+	<text x="35" y="38" fill="black" class="small">e</text>
+	<text x="48" y="38" fill="black" class="small">f</text>
+	</g>
+</g>
+
+<g transform="translate(0, 630)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;3gh&#34; atpoint: (20,40) [0,3] fill: black</text>
+	</g>
+	<g id="draw7">
+	<use href="#draw6" />
+	<text x="22" y="48" fill="black" class="small">3</text>
+	<text x="35" y="48" fill="black" class="small">g</text>
+	<text x="48" y="48" fill="black" class="small">h</text>
+	</g>
+</g>
+
+<g transform="translate(0, 720)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;4ij&#34; atpoint: (20,50) [0,4] fill: black</text>
+	</g>
+	<g id="draw8">
+	<use href="#draw7" />
+	<text x="22" y="58" fill="black" class="small">4</text>
+	<text x="35" y="58" fill="black" class="small">i</text>
+	<text x="48" y="58" fill="black" class="small">j</text>
+	</g>
+</g>
+
+<g transform="translate(0, 810)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (20,20)-(60,50) [0,1],[-,3], to (20,30)-(60,60) [0,2],[-,3]</text>
+	</g>
+	<use href="#draw8" />
+<rect x="20" y="20" width="40" height="30" fill="none" stroke="red"/>
+<g transform="translate(70, 0)">
+	<g id="draw9">
+		<use href="#draw8" />
+		<clipPath id="draw9_blitsource">
+			
+			<rect x="20" y="20" width="40" height="30" />
+		</clipPath>
+		<use href="#draw8" clip-path="url(#draw9_blitsource)" x="0" y="10" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 900)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (59,10)-(60,20) [3,0],[-,1], to (59,20)-(60,30) [3,1],[-,1]</text>
+	</g>
+	<use href="#draw9" />
+<rect x="59" y="10" width="1" height="10" fill="none" stroke="red"/>
+<g transform="translate(70, 0)">
+	<g id="draw10">
+		<use href="#draw9" />
+		<clipPath id="draw10_blitsource">
+			
+			<rect x="59" y="10" width="1" height="10" />
+		</clipPath>
+		<use href="#draw9" clip-path="url(#draw10_blitsource)" x="0" y="10" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 990)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (20,10)-(59,20) [0,0],[3,1], to (20,20)-(59,30) [0,1],[3,1]</text>
+	</g>
+	<use href="#draw10" />
+<rect x="20" y="10" width="39" height="10" fill="none" stroke="red"/>
+<g transform="translate(70, 0)">
+	<g id="draw11">
+		<use href="#draw10" />
+		<clipPath id="draw11_blitsource">
+			
+			<rect x="20" y="10" width="39" height="10" />
+		</clipPath>
+		<use href="#draw10" clip-path="url(#draw11_blitsource)" x="0" y="10" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 1080)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,10)-(60,20) [0,0],[-,1]</text>
+	</g>
+	<g id="draw12">
+	<use href="#draw11" />
+	<rect x="20" y="10" width="40" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 1170)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,10)-(60,20) [0,0],[-,1]</text>
+	</g>
+	<g id="draw13">
+	<use href="#draw12" />
+	<rect x="20" y="10" width="40" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 1260)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,20)-(20,30) [0,1],[0,1]</text>
+	</g>
+	<g id="draw14">
+	<use href="#draw13" />
+	<rect x="20" y="20" width="0" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 1350)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;ABC&#34; atpoint: (20,10) [0,0] fill: black</text>
+	</g>
+	<g id="draw15">
+	<use href="#draw14" />
+	<text x="22" y="18" fill="black" class="small">A</text>
+	<text x="35" y="18" fill="black" class="small">B</text>
+	<text x="48" y="18" fill="black" class="small">C</text>
+	</g>
+</g>
+
+</svg>
+</body>
+</html>

--- a/frame/testdata/TestInsert/insertForcesWrap.html
+++ b/frame/testdata/TestInsert/insertForcesWrap.html
@@ -1,0 +1,230 @@
+<html lang="en-US">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+</head>
+<body>
+<svg viewBox="-20 -30 190 1530" xmlns="http://www.w3.org/2000/svg">
+
+<style>
+	.small { font: 8px sans-serif; }
+</style>
+
+<g transform="translate(0, 0)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">target rect (20,10)-(60,60)</text>
+	</g>
+	<g id="draw0">
+	<rect x="20" y="10" width="40" height="50" fill="none" stroke="black"/>
+	</g>
+</g>
+
+<g transform="translate(0, 90)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,10)-(60,20) [0,0],[-,1]</text>
+	</g>
+	<g id="draw1">
+	<use href="#draw0" />
+	<rect x="20" y="10" width="40" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 180)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,20)-(60,50) [0,1],[-,3]</text>
+	</g>
+	<g id="draw2">
+	<use href="#draw1" />
+	<rect x="20" y="20" width="40" height="30" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 270)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,50)-(59,60) [0,4],[3,1]</text>
+	</g>
+	<g id="draw3">
+	<use href="#draw2" />
+	<rect x="20" y="50" width="39" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 360)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;0ab&#34; atpoint: (20,10) [0,0] fill: black</text>
+	</g>
+	<g id="draw4">
+	<use href="#draw3" />
+	<text x="22" y="18" fill="black" class="small">0</text>
+	<text x="35" y="18" fill="black" class="small">a</text>
+	<text x="48" y="18" fill="black" class="small">b</text>
+	</g>
+</g>
+
+<g transform="translate(0, 450)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;1cd&#34; atpoint: (20,20) [0,1] fill: black</text>
+	</g>
+	<g id="draw5">
+	<use href="#draw4" />
+	<text x="22" y="28" fill="black" class="small">1</text>
+	<text x="35" y="28" fill="black" class="small">c</text>
+	<text x="48" y="28" fill="black" class="small">d</text>
+	</g>
+</g>
+
+<g transform="translate(0, 540)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;2ef&#34; atpoint: (20,30) [0,2] fill: black</text>
+	</g>
+	<g id="draw6">
+	<use href="#draw5" />
+	<text x="22" y="38" fill="black" class="small">2</text>
+	<text x="35" y="38" fill="black" class="small">e</text>
+	<text x="48" y="38" fill="black" class="small">f</text>
+	</g>
+</g>
+
+<g transform="translate(0, 630)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;3gh&#34; atpoint: (20,40) [0,3] fill: black</text>
+	</g>
+	<g id="draw7">
+	<use href="#draw6" />
+	<text x="22" y="48" fill="black" class="small">3</text>
+	<text x="35" y="48" fill="black" class="small">g</text>
+	<text x="48" y="48" fill="black" class="small">h</text>
+	</g>
+</g>
+
+<g transform="translate(0, 720)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;4ij&#34; atpoint: (20,50) [0,4] fill: black</text>
+	</g>
+	<g id="draw8">
+	<use href="#draw7" />
+	<text x="22" y="58" fill="black" class="small">4</text>
+	<text x="35" y="58" fill="black" class="small">i</text>
+	<text x="48" y="58" fill="black" class="small">j</text>
+	</g>
+</g>
+
+<g transform="translate(0, 810)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (20,30)-(60,50) [0,2],[-,2], to (20,40)-(60,60) [0,3],[-,2]</text>
+	</g>
+	<use href="#draw8" />
+<rect x="20" y="30" width="40" height="20" fill="none" stroke="red"/>
+<g transform="translate(70, 0)">
+	<g id="draw9">
+		<use href="#draw8" />
+		<clipPath id="draw9_blitsource">
+			
+			<rect x="20" y="30" width="40" height="20" />
+		</clipPath>
+		<use href="#draw8" clip-path="url(#draw9_blitsource)" x="0" y="10" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 900)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (59,20)-(60,30) [3,1],[-,1], to (59,30)-(60,40) [3,2],[-,1]</text>
+	</g>
+	<use href="#draw9" />
+<rect x="59" y="20" width="1" height="10" fill="none" stroke="red"/>
+<g transform="translate(70, 0)">
+	<g id="draw10">
+		<use href="#draw9" />
+		<clipPath id="draw10_blitsource">
+			
+			<rect x="59" y="20" width="1" height="10" />
+		</clipPath>
+		<use href="#draw9" clip-path="url(#draw10_blitsource)" x="0" y="10" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 990)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (20,20)-(59,30) [0,1],[3,1], to (20,30)-(59,40) [0,2],[3,1]</text>
+	</g>
+	<use href="#draw10" />
+<rect x="20" y="20" width="39" height="10" fill="none" stroke="red"/>
+<g transform="translate(70, 0)">
+	<g id="draw11">
+		<use href="#draw10" />
+		<clipPath id="draw11_blitsource">
+			
+			<rect x="20" y="20" width="39" height="10" />
+		</clipPath>
+		<use href="#draw10" clip-path="url(#draw11_blitsource)" x="0" y="10" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 1080)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (33,20)-(60,30) [1,1],[-,1]</text>
+	</g>
+	<g id="draw12">
+	<use href="#draw11" />
+	<rect x="33" y="20" width="27" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 1170)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (46,10)-(59,20) [2,0],[1,1], to (20,20)-(33,30) [0,1],[1,1]</text>
+	</g>
+	<use href="#draw12" />
+<rect x="46" y="10" width="13" height="10" fill="none" stroke="red"/>
+<g transform="translate(70, 0)">
+	<g id="draw13">
+		<use href="#draw12" />
+		<clipPath id="draw13_blitsource">
+			
+			<rect x="46" y="10" width="13" height="10" />
+		</clipPath>
+		<use href="#draw12" clip-path="url(#draw13_blitsource)" x="-26" y="10" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 1260)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (46,10)-(60,20) [2,0],[-,1]</text>
+	</g>
+	<g id="draw14">
+	<use href="#draw13" />
+	<rect x="46" y="10" width="14" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 1350)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,20)-(20,30) [0,1],[0,1]</text>
+	</g>
+	<g id="draw15">
+	<use href="#draw14" />
+	<rect x="20" y="20" width="0" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 1440)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;X&#34; atpoint: (46,10) [2,0] fill: black</text>
+	</g>
+	<g id="draw16">
+	<use href="#draw15" />
+	<text x="48" y="18" fill="black" class="small">X</text>
+	</g>
+</g>
+
+</svg>
+</body>
+</html>

--- a/frame/testdata/TestInsert/insertIntoLongLine.html
+++ b/frame/testdata/TestInsert/insertIntoLongLine.html
@@ -1,0 +1,334 @@
+<html lang="en-US">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+</head>
+<body>
+<svg viewBox="-20 -30 870 2860" xmlns="http://www.w3.org/2000/svg">
+
+<style>
+	.small { font: 8px sans-serif; }
+</style>
+
+<g transform="translate(0, 0)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">target rect (20,10)-(400,100)</text>
+	</g>
+	<g id="draw0">
+	<rect x="20" y="10" width="380" height="90" fill="none" stroke="black"/>
+	</g>
+</g>
+
+<g transform="translate(0, 130)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,10)-(400,20) [0,0],[-,1]</text>
+	</g>
+	<g id="draw1">
+	<use href="#draw0" />
+	<rect x="20" y="10" width="380" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 260)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,20)-(400,30) [0,1],[-,1]</text>
+	</g>
+	<g id="draw2">
+	<use href="#draw1" />
+	<rect x="20" y="20" width="380" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 390)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,30)-(46,40) [0,2],[2,1]</text>
+	</g>
+	<g id="draw3">
+	<use href="#draw2" />
+	<rect x="20" y="30" width="26" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 520)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;ab&#34; atpoint: (20,10) [0,0] fill: black</text>
+	</g>
+	<g id="draw4">
+	<use href="#draw3" />
+	<text x="22" y="18" fill="black" class="small">a</text>
+	<text x="35" y="18" fill="black" class="small">b</text>
+	</g>
+</g>
+
+<g transform="translate(0, 650)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;cd&#34; atpoint: (20,20) [0,1] fill: black</text>
+	</g>
+	<g id="draw5">
+	<use href="#draw4" />
+	<text x="22" y="28" fill="black" class="small">c</text>
+	<text x="35" y="28" fill="black" class="small">d</text>
+	</g>
+</g>
+
+<g transform="translate(0, 780)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;ef&#34; atpoint: (20,30) [0,2] fill: black</text>
+	</g>
+	<g id="draw6">
+	<use href="#draw5" />
+	<text x="22" y="38" fill="black" class="small">e</text>
+	<text x="35" y="38" fill="black" class="small">f</text>
+	</g>
+</g>
+
+<g transform="translate(0, 910)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (20,30)-(46,40) [0,2],[2,1], to (20,40)-(46,50) [0,3],[2,1]</text>
+	</g>
+	<use href="#draw6" />
+<rect x="20" y="30" width="26" height="10" fill="none" stroke="red"/>
+<g transform="translate(410, 0)">
+	<g id="draw7">
+		<use href="#draw6" />
+		<clipPath id="draw7_blitsource">
+			
+			<rect x="20" y="30" width="26" height="10" />
+		</clipPath>
+		<use href="#draw6" clip-path="url(#draw7_blitsource)" x="0" y="10" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 1040)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (254,30)-(400,40) [18,2],[-,1]</text>
+	</g>
+	<g id="draw8">
+	<use href="#draw7" />
+	<rect x="254" y="30" width="146" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 1170)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (33,20)-(46,30) [1,1],[1,1], to (241,30)-(254,40) [17,2],[1,1]</text>
+	</g>
+	<use href="#draw8" />
+<rect x="33" y="20" width="13" height="10" fill="none" stroke="red"/>
+<g transform="translate(410, 0)">
+	<g id="draw9">
+		<use href="#draw8" />
+		<clipPath id="draw9_blitsource">
+			
+			<rect x="33" y="20" width="13" height="10" />
+		</clipPath>
+		<use href="#draw8" clip-path="url(#draw9_blitsource)" x="208" y="10" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 1300)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (33,20)-(400,30) [1,1],[-,1]</text>
+	</g>
+	<g id="draw10">
+	<use href="#draw9" />
+	<rect x="33" y="20" width="367" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 1430)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,30)-(241,40) [0,2],[17,1]</text>
+	</g>
+	<g id="draw11">
+	<use href="#draw10" />
+	<rect x="20" y="30" width="221" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 1560)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;a本ポポポポポポポポポポポポポポポポポポポポポポポポポポ&#34; atpoint: (33,20) [1,1] fill: black</text>
+	</g>
+	<g id="draw12">
+	<use href="#draw11" />
+	<text x="35" y="28" fill="black" class="small">a</text>
+	<text x="48" y="28" fill="black" class="small">本</text>
+	<text x="61" y="28" fill="black" class="small">ポ</text>
+	<text x="74" y="28" fill="black" class="small">ポ</text>
+	<text x="87" y="28" fill="black" class="small">ポ</text>
+	<text x="100" y="28" fill="black" class="small">ポ</text>
+	<text x="113" y="28" fill="black" class="small">ポ</text>
+	<text x="126" y="28" fill="black" class="small">ポ</text>
+	<text x="139" y="28" fill="black" class="small">ポ</text>
+	<text x="152" y="28" fill="black" class="small">ポ</text>
+	<text x="165" y="28" fill="black" class="small">ポ</text>
+	<text x="178" y="28" fill="black" class="small">ポ</text>
+	<text x="191" y="28" fill="black" class="small">ポ</text>
+	<text x="204" y="28" fill="black" class="small">ポ</text>
+	<text x="217" y="28" fill="black" class="small">ポ</text>
+	<text x="230" y="28" fill="black" class="small">ポ</text>
+	<text x="243" y="28" fill="black" class="small">ポ</text>
+	<text x="256" y="28" fill="black" class="small">ポ</text>
+	<text x="269" y="28" fill="black" class="small">ポ</text>
+	<text x="282" y="28" fill="black" class="small">ポ</text>
+	<text x="295" y="28" fill="black" class="small">ポ</text>
+	<text x="308" y="28" fill="black" class="small">ポ</text>
+	<text x="321" y="28" fill="black" class="small">ポ</text>
+	<text x="334" y="28" fill="black" class="small">ポ</text>
+	<text x="347" y="28" fill="black" class="small">ポ</text>
+	<text x="360" y="28" fill="black" class="small">ポ</text>
+	<text x="373" y="28" fill="black" class="small">ポ</text>
+	<text x="386" y="28" fill="black" class="small">ポ</text>
+	</g>
+</g>
+
+<g transform="translate(0, 1690)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;ポポポポポポポポポポポポhello&#34; atpoint: (20,30) [0,2] fill: black</text>
+	</g>
+	<g id="draw13">
+	<use href="#draw12" />
+	<text x="22" y="38" fill="black" class="small">ポ</text>
+	<text x="35" y="38" fill="black" class="small">ポ</text>
+	<text x="48" y="38" fill="black" class="small">ポ</text>
+	<text x="61" y="38" fill="black" class="small">ポ</text>
+	<text x="74" y="38" fill="black" class="small">ポ</text>
+	<text x="87" y="38" fill="black" class="small">ポ</text>
+	<text x="100" y="38" fill="black" class="small">ポ</text>
+	<text x="113" y="38" fill="black" class="small">ポ</text>
+	<text x="126" y="38" fill="black" class="small">ポ</text>
+	<text x="139" y="38" fill="black" class="small">ポ</text>
+	<text x="152" y="38" fill="black" class="small">ポ</text>
+	<text x="165" y="38" fill="black" class="small">ポ</text>
+	<text x="178" y="38" fill="black" class="small">h</text>
+	<text x="191" y="38" fill="black" class="small">e</text>
+	<text x="204" y="38" fill="black" class="small">l</text>
+	<text x="217" y="38" fill="black" class="small">l</text>
+	<text x="230" y="38" fill="black" class="small">o</text>
+	</g>
+</g>
+
+<g transform="translate(0, 1820)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (20,40)-(46,50) [0,3],[2,1], to (20,40)-(46,50) [0,3],[2,1]</text>
+	</g>
+	<use href="#draw13" />
+<rect x="20" y="40" width="26" height="10" fill="none" stroke="red"/>
+<g transform="translate(410, 0)">
+	<g id="draw14">
+		<use href="#draw13" />
+		<clipPath id="draw14_blitsource">
+			
+			<rect x="20" y="40" width="26" height="10" />
+		</clipPath>
+		<use href="#draw13" clip-path="url(#draw14_blitsource)" x="0" y="0" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 1950)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (267,30)-(400,40) [19,2],[-,1]</text>
+	</g>
+	<g id="draw15">
+	<use href="#draw14" />
+	<rect x="267" y="30" width="133" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 2080)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (20,30)-(254,40) [0,2],[18,1], to (33,30)-(267,40) [1,2],[18,1]</text>
+	</g>
+	<use href="#draw15" />
+<rect x="20" y="30" width="234" height="10" fill="none" stroke="red"/>
+<g transform="translate(410, 0)">
+	<g id="draw16">
+		<use href="#draw15" />
+		<clipPath id="draw16_blitsource">
+			
+			<rect x="20" y="30" width="234" height="10" />
+		</clipPath>
+		<use href="#draw15" clip-path="url(#draw16_blitsource)" x="13" y="0" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 2210)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (384,20)-(397,30) [28,1],[1,1], to (20,30)-(33,40) [0,2],[1,1]</text>
+	</g>
+	<use href="#draw16" />
+<rect x="384" y="20" width="13" height="10" fill="none" stroke="red"/>
+<g transform="translate(410, 0)">
+	<g id="draw17">
+		<use href="#draw16" />
+		<clipPath id="draw17_blitsource">
+			
+			<rect x="384" y="20" width="13" height="10" />
+		</clipPath>
+		<use href="#draw16" clip-path="url(#draw17_blitsource)" x="-364" y="10" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 2340)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (33,20)-(384,30) [1,1],[27,1], to (46,20)-(397,30) [2,1],[27,1]</text>
+	</g>
+	<use href="#draw17" />
+<rect x="33" y="20" width="351" height="10" fill="none" stroke="red"/>
+<g transform="translate(410, 0)">
+	<g id="draw18">
+		<use href="#draw17" />
+		<clipPath id="draw18_blitsource">
+			
+			<rect x="33" y="20" width="351" height="10" />
+		</clipPath>
+		<use href="#draw17" clip-path="url(#draw18_blitsource)" x="13" y="0" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 2470)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (397,20)-(400,30) [29,1],[-,1]</text>
+	</g>
+	<g id="draw19">
+	<use href="#draw18" />
+	<rect x="397" y="20" width="3" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 2600)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (33,20)-(46,30) [1,1],[1,1]</text>
+	</g>
+	<g id="draw20">
+	<use href="#draw19" />
+	<rect x="33" y="20" width="13" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 2730)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;X&#34; atpoint: (33,20) [1,1] fill: black</text>
+	</g>
+	<g id="draw21">
+	<use href="#draw20" />
+	<text x="35" y="28" fill="black" class="small">X</text>
+	</g>
+</g>
+
+</svg>
+</body>
+</html>

--- a/frame/testdata/TestInsert/insertLongLine.html
+++ b/frame/testdata/TestInsert/insertLongLine.html
@@ -1,0 +1,218 @@
+<html lang="en-US">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+</head>
+<body>
+<svg viewBox="-20 -30 870 1820" xmlns="http://www.w3.org/2000/svg">
+
+<style>
+	.small { font: 8px sans-serif; }
+</style>
+
+<g transform="translate(0, 0)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">target rect (20,10)-(400,100)</text>
+	</g>
+	<g id="draw0">
+	<rect x="20" y="10" width="380" height="90" fill="none" stroke="black"/>
+	</g>
+</g>
+
+<g transform="translate(0, 130)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,10)-(400,20) [0,0],[-,1]</text>
+	</g>
+	<g id="draw1">
+	<use href="#draw0" />
+	<rect x="20" y="10" width="380" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 260)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,20)-(400,30) [0,1],[-,1]</text>
+	</g>
+	<g id="draw2">
+	<use href="#draw1" />
+	<rect x="20" y="20" width="380" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 390)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,30)-(46,40) [0,2],[2,1]</text>
+	</g>
+	<g id="draw3">
+	<use href="#draw2" />
+	<rect x="20" y="30" width="26" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 520)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;ab&#34; atpoint: (20,10) [0,0] fill: black</text>
+	</g>
+	<g id="draw4">
+	<use href="#draw3" />
+	<text x="22" y="18" fill="black" class="small">a</text>
+	<text x="35" y="18" fill="black" class="small">b</text>
+	</g>
+</g>
+
+<g transform="translate(0, 650)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;cd&#34; atpoint: (20,20) [0,1] fill: black</text>
+	</g>
+	<g id="draw5">
+	<use href="#draw4" />
+	<text x="22" y="28" fill="black" class="small">c</text>
+	<text x="35" y="28" fill="black" class="small">d</text>
+	</g>
+</g>
+
+<g transform="translate(0, 780)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;ef&#34; atpoint: (20,30) [0,2] fill: black</text>
+	</g>
+	<g id="draw6">
+	<use href="#draw5" />
+	<text x="22" y="38" fill="black" class="small">e</text>
+	<text x="35" y="38" fill="black" class="small">f</text>
+	</g>
+</g>
+
+<g transform="translate(0, 910)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (20,30)-(46,40) [0,2],[2,1], to (20,40)-(46,50) [0,3],[2,1]</text>
+	</g>
+	<use href="#draw6" />
+<rect x="20" y="30" width="26" height="10" fill="none" stroke="red"/>
+<g transform="translate(410, 0)">
+	<g id="draw7">
+		<use href="#draw6" />
+		<clipPath id="draw7_blitsource">
+			
+			<rect x="20" y="30" width="26" height="10" />
+		</clipPath>
+		<use href="#draw6" clip-path="url(#draw7_blitsource)" x="0" y="10" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 1040)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (254,30)-(400,40) [18,2],[-,1]</text>
+	</g>
+	<g id="draw8">
+	<use href="#draw7" />
+	<rect x="254" y="30" width="146" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 1170)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (33,20)-(46,30) [1,1],[1,1], to (241,30)-(254,40) [17,2],[1,1]</text>
+	</g>
+	<use href="#draw8" />
+<rect x="33" y="20" width="13" height="10" fill="none" stroke="red"/>
+<g transform="translate(410, 0)">
+	<g id="draw9">
+		<use href="#draw8" />
+		<clipPath id="draw9_blitsource">
+			
+			<rect x="33" y="20" width="13" height="10" />
+		</clipPath>
+		<use href="#draw8" clip-path="url(#draw9_blitsource)" x="208" y="10" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 1300)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (33,20)-(400,30) [1,1],[-,1]</text>
+	</g>
+	<g id="draw10">
+	<use href="#draw9" />
+	<rect x="33" y="20" width="367" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 1430)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,30)-(241,40) [0,2],[17,1]</text>
+	</g>
+	<g id="draw11">
+	<use href="#draw10" />
+	<rect x="20" y="30" width="221" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 1560)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;a本ポポポポポポポポポポポポポポポポポポポポポポポポポポ&#34; atpoint: (33,20) [1,1] fill: black</text>
+	</g>
+	<g id="draw12">
+	<use href="#draw11" />
+	<text x="35" y="28" fill="black" class="small">a</text>
+	<text x="48" y="28" fill="black" class="small">本</text>
+	<text x="61" y="28" fill="black" class="small">ポ</text>
+	<text x="74" y="28" fill="black" class="small">ポ</text>
+	<text x="87" y="28" fill="black" class="small">ポ</text>
+	<text x="100" y="28" fill="black" class="small">ポ</text>
+	<text x="113" y="28" fill="black" class="small">ポ</text>
+	<text x="126" y="28" fill="black" class="small">ポ</text>
+	<text x="139" y="28" fill="black" class="small">ポ</text>
+	<text x="152" y="28" fill="black" class="small">ポ</text>
+	<text x="165" y="28" fill="black" class="small">ポ</text>
+	<text x="178" y="28" fill="black" class="small">ポ</text>
+	<text x="191" y="28" fill="black" class="small">ポ</text>
+	<text x="204" y="28" fill="black" class="small">ポ</text>
+	<text x="217" y="28" fill="black" class="small">ポ</text>
+	<text x="230" y="28" fill="black" class="small">ポ</text>
+	<text x="243" y="28" fill="black" class="small">ポ</text>
+	<text x="256" y="28" fill="black" class="small">ポ</text>
+	<text x="269" y="28" fill="black" class="small">ポ</text>
+	<text x="282" y="28" fill="black" class="small">ポ</text>
+	<text x="295" y="28" fill="black" class="small">ポ</text>
+	<text x="308" y="28" fill="black" class="small">ポ</text>
+	<text x="321" y="28" fill="black" class="small">ポ</text>
+	<text x="334" y="28" fill="black" class="small">ポ</text>
+	<text x="347" y="28" fill="black" class="small">ポ</text>
+	<text x="360" y="28" fill="black" class="small">ポ</text>
+	<text x="373" y="28" fill="black" class="small">ポ</text>
+	<text x="386" y="28" fill="black" class="small">ポ</text>
+	</g>
+</g>
+
+<g transform="translate(0, 1690)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;ポポポポポポポポポポポポhello&#34; atpoint: (20,30) [0,2] fill: black</text>
+	</g>
+	<g id="draw13">
+	<use href="#draw12" />
+	<text x="22" y="38" fill="black" class="small">ポ</text>
+	<text x="35" y="38" fill="black" class="small">ポ</text>
+	<text x="48" y="38" fill="black" class="small">ポ</text>
+	<text x="61" y="38" fill="black" class="small">ポ</text>
+	<text x="74" y="38" fill="black" class="small">ポ</text>
+	<text x="87" y="38" fill="black" class="small">ポ</text>
+	<text x="100" y="38" fill="black" class="small">ポ</text>
+	<text x="113" y="38" fill="black" class="small">ポ</text>
+	<text x="126" y="38" fill="black" class="small">ポ</text>
+	<text x="139" y="38" fill="black" class="small">ポ</text>
+	<text x="152" y="38" fill="black" class="small">ポ</text>
+	<text x="165" y="38" fill="black" class="small">ポ</text>
+	<text x="178" y="38" fill="black" class="small">h</text>
+	<text x="191" y="38" fill="black" class="small">e</text>
+	<text x="204" y="38" fill="black" class="small">l</text>
+	<text x="217" y="38" fill="black" class="small">l</text>
+	<text x="230" y="38" fill="black" class="small">o</text>
+	</g>
+</g>
+
+</svg>
+</body>
+</html>

--- a/frame/testdata/TestInsert/insertPastEnd.html
+++ b/frame/testdata/TestInsert/insertPastEnd.html
@@ -1,0 +1,90 @@
+<html lang="en-US">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+</head>
+<body>
+<svg viewBox="-20 -30 190 490" xmlns="http://www.w3.org/2000/svg">
+
+<style>
+	.small { font: 8px sans-serif; }
+</style>
+
+<g transform="translate(0, 0)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">target rect (20,10)-(60,40)</text>
+	</g>
+	<g id="draw0">
+	<rect x="20" y="10" width="40" height="30" fill="none" stroke="black"/>
+	</g>
+</g>
+
+<g transform="translate(0, 70)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,10)-(60,20) [0,0],[-,1]</text>
+	</g>
+	<g id="draw1">
+	<use href="#draw0" />
+	<rect x="20" y="10" width="40" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 140)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,20)-(60,40) [0,1],[-,2]</text>
+	</g>
+	<g id="draw2">
+	<use href="#draw1" />
+	<rect x="20" y="20" width="40" height="20" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 210)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,40)-(20,50) [0,3],[0,1]</text>
+	</g>
+	<g id="draw3">
+	<use href="#draw2" />
+	<rect x="20" y="40" width="0" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 280)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;a本ポ&#34; atpoint: (20,10) [0,0] fill: black</text>
+	</g>
+	<g id="draw4">
+	<use href="#draw3" />
+	<text x="22" y="18" fill="black" class="small">a</text>
+	<text x="35" y="18" fill="black" class="small">本</text>
+	<text x="48" y="18" fill="black" class="small">ポ</text>
+	</g>
+</g>
+
+<g transform="translate(0, 350)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;ポポポ&#34; atpoint: (20,20) [0,1] fill: black</text>
+	</g>
+	<g id="draw5">
+	<use href="#draw4" />
+	<text x="22" y="28" fill="black" class="small">ポ</text>
+	<text x="35" y="28" fill="black" class="small">ポ</text>
+	<text x="48" y="28" fill="black" class="small">ポ</text>
+	</g>
+</g>
+
+<g transform="translate(0, 420)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;ポポh&#34; atpoint: (20,30) [0,2] fill: black</text>
+	</g>
+	<g id="draw6">
+	<use href="#draw5" />
+	<text x="22" y="38" fill="black" class="small">ポ</text>
+	<text x="35" y="38" fill="black" class="small">ポ</text>
+	<text x="48" y="38" fill="black" class="small">h</text>
+	</g>
+</g>
+
+</svg>
+</body>
+</html>

--- a/frame/testdata/TestInsert/insertPushesBlankLineOffEnd.html
+++ b/frame/testdata/TestInsert/insertPushesBlankLineOffEnd.html
@@ -1,0 +1,237 @@
+<html lang="en-US">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+</head>
+<body>
+<svg viewBox="-20 -30 190 1530" xmlns="http://www.w3.org/2000/svg">
+
+<style>
+	.small { font: 8px sans-serif; }
+</style>
+
+<g transform="translate(0, 0)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">target rect (20,10)-(60,60)</text>
+	</g>
+	<g id="draw0">
+	<rect x="20" y="10" width="40" height="50" fill="none" stroke="black"/>
+	</g>
+</g>
+
+<g transform="translate(0, 90)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,10)-(60,20) [0,0],[-,1]</text>
+	</g>
+	<g id="draw1">
+	<use href="#draw0" />
+	<rect x="20" y="10" width="40" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 180)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,20)-(60,60) [0,1],[-,4]</text>
+	</g>
+	<g id="draw2">
+	<use href="#draw1" />
+	<rect x="20" y="20" width="40" height="40" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 270)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,60)-(20,70) [0,5],[0,1]</text>
+	</g>
+	<g id="draw3">
+	<use href="#draw2" />
+	<rect x="20" y="60" width="0" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 360)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;0ab&#34; atpoint: (20,10) [0,0] fill: black</text>
+	</g>
+	<g id="draw4">
+	<use href="#draw3" />
+	<text x="22" y="18" fill="black" class="small">0</text>
+	<text x="35" y="18" fill="black" class="small">a</text>
+	<text x="48" y="18" fill="black" class="small">b</text>
+	</g>
+</g>
+
+<g transform="translate(0, 450)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;1cd&#34; atpoint: (20,20) [0,1] fill: black</text>
+	</g>
+	<g id="draw5">
+	<use href="#draw4" />
+	<text x="22" y="28" fill="black" class="small">1</text>
+	<text x="35" y="28" fill="black" class="small">c</text>
+	<text x="48" y="28" fill="black" class="small">d</text>
+	</g>
+</g>
+
+<g transform="translate(0, 540)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;2ef&#34; atpoint: (20,30) [0,2] fill: black</text>
+	</g>
+	<g id="draw6">
+	<use href="#draw5" />
+	<text x="22" y="38" fill="black" class="small">2</text>
+	<text x="35" y="38" fill="black" class="small">e</text>
+	<text x="48" y="38" fill="black" class="small">f</text>
+	</g>
+</g>
+
+<g transform="translate(0, 630)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;3gh&#34; atpoint: (20,40) [0,3] fill: black</text>
+	</g>
+	<g id="draw7">
+	<use href="#draw6" />
+	<text x="22" y="48" fill="black" class="small">3</text>
+	<text x="35" y="48" fill="black" class="small">g</text>
+	<text x="48" y="48" fill="black" class="small">h</text>
+	</g>
+</g>
+
+<g transform="translate(0, 720)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (20,30)-(60,50) [0,2],[-,2], to (20,40)-(60,60) [0,3],[-,2]</text>
+	</g>
+	<use href="#draw7" />
+<rect x="20" y="30" width="40" height="20" fill="none" stroke="red"/>
+<g transform="translate(70, 0)">
+	<g id="draw8">
+		<use href="#draw7" />
+		<clipPath id="draw8_blitsource">
+			
+			<rect x="20" y="30" width="40" height="20" />
+		</clipPath>
+		<use href="#draw7" clip-path="url(#draw8_blitsource)" x="0" y="10" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 810)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (59,20)-(60,30) [3,1],[-,1], to (59,30)-(60,40) [3,2],[-,1]</text>
+	</g>
+	<use href="#draw8" />
+<rect x="59" y="20" width="1" height="10" fill="none" stroke="red"/>
+<g transform="translate(70, 0)">
+	<g id="draw9">
+		<use href="#draw8" />
+		<clipPath id="draw9_blitsource">
+			
+			<rect x="59" y="20" width="1" height="10" />
+		</clipPath>
+		<use href="#draw8" clip-path="url(#draw9_blitsource)" x="0" y="10" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 900)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (20,20)-(59,30) [0,1],[3,1], to (20,30)-(59,40) [0,2],[3,1]</text>
+	</g>
+	<use href="#draw9" />
+<rect x="20" y="20" width="39" height="10" fill="none" stroke="red"/>
+<g transform="translate(70, 0)">
+	<g id="draw10">
+		<use href="#draw9" />
+		<clipPath id="draw10_blitsource">
+			
+			<rect x="20" y="20" width="39" height="10" />
+		</clipPath>
+		<use href="#draw9" clip-path="url(#draw10_blitsource)" x="0" y="10" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 990)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (33,20)-(60,30) [1,1],[-,1]</text>
+	</g>
+	<g id="draw11">
+	<use href="#draw10" />
+	<rect x="33" y="20" width="27" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 1080)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (46,10)-(59,20) [2,0],[1,1], to (20,20)-(33,30) [0,1],[1,1]</text>
+	</g>
+	<use href="#draw11" />
+<rect x="46" y="10" width="13" height="10" fill="none" stroke="red"/>
+<g transform="translate(70, 0)">
+	<g id="draw12">
+		<use href="#draw11" />
+		<clipPath id="draw12_blitsource">
+			
+			<rect x="46" y="10" width="13" height="10" />
+		</clipPath>
+		<use href="#draw11" clip-path="url(#draw12_blitsource)" x="-26" y="10" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 1170)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (33,10)-(46,20) [1,0],[1,1], to (46,10)-(59,20) [2,0],[1,1]</text>
+	</g>
+	<use href="#draw12" />
+<rect x="33" y="10" width="13" height="10" fill="none" stroke="red"/>
+<g transform="translate(70, 0)">
+	<g id="draw13">
+		<use href="#draw12" />
+		<clipPath id="draw13_blitsource">
+			
+			<rect x="33" y="10" width="13" height="10" />
+		</clipPath>
+		<use href="#draw12" clip-path="url(#draw13_blitsource)" x="13" y="0" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 1260)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (59,10)-(60,20) [3,0],[-,1]</text>
+	</g>
+	<g id="draw14">
+	<use href="#draw13" />
+	<rect x="59" y="10" width="1" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 1350)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (33,10)-(46,20) [1,0],[1,1]</text>
+	</g>
+	<g id="draw15">
+	<use href="#draw14" />
+	<rect x="33" y="10" width="13" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 1440)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;X&#34; atpoint: (33,10) [1,0] fill: black</text>
+	</g>
+	<g id="draw16">
+	<use href="#draw15" />
+	<text x="35" y="18" fill="black" class="small">X</text>
+	</g>
+</g>
+
+</svg>
+</body>
+</html>

--- a/frame/testdata/TestInsert/insertTabAndChar.html
+++ b/frame/testdata/TestInsert/insertTabAndChar.html
@@ -1,0 +1,104 @@
+<html lang="en-US">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+</head>
+<body>
+<svg viewBox="-20 -30 870 1040" xmlns="http://www.w3.org/2000/svg">
+
+<style>
+	.small { font: 8px sans-serif; }
+</style>
+
+<g transform="translate(0, 0)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">target rect (20,10)-(400,100)</text>
+	</g>
+	<g id="draw0">
+	<rect x="20" y="10" width="380" height="90" fill="none" stroke="black"/>
+	</g>
+</g>
+
+<g transform="translate(0, 130)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,10)-(46,20) [0,0],[2,1]</text>
+	</g>
+	<g id="draw1">
+	<use href="#draw0" />
+	<rect x="20" y="10" width="26" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 260)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;ab&#34; atpoint: (20,10) [0,0] fill: black</text>
+	</g>
+	<g id="draw2">
+	<use href="#draw1" />
+	<text x="22" y="18" fill="black" class="small">a</text>
+	<text x="35" y="18" fill="black" class="small">b</text>
+	</g>
+</g>
+
+<g transform="translate(0, 390)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (33,10)-(46,20) [1,0],[1,1], to (124,10)-(137,20) [8,0],[1,1]</text>
+	</g>
+	<use href="#draw2" />
+<rect x="33" y="10" width="13" height="10" fill="none" stroke="red"/>
+<g transform="translate(410, 0)">
+	<g id="draw3">
+		<use href="#draw2" />
+		<clipPath id="draw3_blitsource">
+			
+			<rect x="33" y="10" width="13" height="10" />
+		</clipPath>
+		<use href="#draw2" clip-path="url(#draw3_blitsource)" x="91" y="0" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 520)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (33,10)-(124,20) [1,0],[7,1]</text>
+	</g>
+	<g id="draw4">
+	<use href="#draw3" />
+	<rect x="33" y="10" width="91" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 650)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (46,10)-(124,20) [2,0],[6,1]</text>
+	</g>
+	<g id="draw5">
+	<use href="#draw4" />
+	<rect x="46" y="10" width="78" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 780)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (33,10)-(46,20) [1,0],[1,1]</text>
+	</g>
+	<g id="draw6">
+	<use href="#draw5" />
+	<rect x="33" y="10" width="13" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 910)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;X&#34; atpoint: (33,10) [1,0] fill: black</text>
+	</g>
+	<g id="draw7">
+	<use href="#draw6" />
+	<text x="35" y="18" fill="black" class="small">X</text>
+	</g>
+</g>
+
+</svg>
+</body>
+</html>

--- a/frame/testdata/TestInsert/insertWrappedThatForcesRipple.html
+++ b/frame/testdata/TestInsert/insertWrappedThatForcesRipple.html
@@ -1,0 +1,176 @@
+<html lang="en-US">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+</head>
+<body>
+<svg viewBox="-20 -30 190 1350" xmlns="http://www.w3.org/2000/svg">
+
+<style>
+	.small { font: 8px sans-serif; }
+</style>
+
+<g transform="translate(0, 0)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">target rect (20,10)-(60,60)</text>
+	</g>
+	<g id="draw0">
+	<rect x="20" y="10" width="40" height="50" fill="none" stroke="black"/>
+	</g>
+</g>
+
+<g transform="translate(0, 90)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,10)-(60,20) [0,0],[-,1]</text>
+	</g>
+	<g id="draw1">
+	<use href="#draw0" />
+	<rect x="20" y="10" width="40" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 180)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,20)-(60,60) [0,1],[-,4]</text>
+	</g>
+	<g id="draw2">
+	<use href="#draw1" />
+	<rect x="20" y="20" width="40" height="40" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 270)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,60)-(20,70) [0,5],[0,1]</text>
+	</g>
+	<g id="draw3">
+	<use href="#draw2" />
+	<rect x="20" y="60" width="0" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 360)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;0&#34; atpoint: (20,10) [0,0] fill: black</text>
+	</g>
+	<g id="draw4">
+	<use href="#draw3" />
+	<text x="22" y="18" fill="black" class="small">0</text>
+	</g>
+</g>
+
+<g transform="translate(0, 450)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;1&#34; atpoint: (20,20) [0,1] fill: black</text>
+	</g>
+	<g id="draw5">
+	<use href="#draw4" />
+	<text x="22" y="28" fill="black" class="small">1</text>
+	</g>
+</g>
+
+<g transform="translate(0, 540)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;2&#34; atpoint: (20,30) [0,2] fill: black</text>
+	</g>
+	<g id="draw6">
+	<use href="#draw5" />
+	<text x="22" y="38" fill="black" class="small">2</text>
+	</g>
+</g>
+
+<g transform="translate(0, 630)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;3b&#34; atpoint: (20,40) [0,3] fill: black</text>
+	</g>
+	<g id="draw7">
+	<use href="#draw6" />
+	<text x="22" y="48" fill="black" class="small">3</text>
+	<text x="35" y="48" fill="black" class="small">b</text>
+	</g>
+</g>
+
+<g transform="translate(0, 720)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;4&#34; atpoint: (20,50) [0,4] fill: black</text>
+	</g>
+	<g id="draw8">
+	<use href="#draw7" />
+	<text x="22" y="58" fill="black" class="small">4</text>
+	</g>
+</g>
+
+<g transform="translate(0, 810)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (59,50)-(60,60) [3,4],[-,1]</text>
+	</g>
+	<g id="draw9">
+	<use href="#draw8" />
+	<rect x="59" y="50" width="1" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 900)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (33,40)-(46,50) [1,3],[1,1], to (46,50)-(59,60) [2,4],[1,1]</text>
+	</g>
+	<use href="#draw9" />
+<rect x="33" y="40" width="13" height="10" fill="none" stroke="red"/>
+<g transform="translate(70, 0)">
+	<g id="draw10">
+		<use href="#draw9" />
+		<clipPath id="draw10_blitsource">
+			
+			<rect x="33" y="40" width="13" height="10" />
+		</clipPath>
+		<use href="#draw9" clip-path="url(#draw10_blitsource)" x="13" y="10" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 990)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (33,40)-(60,50) [1,3],[-,1]</text>
+	</g>
+	<g id="draw11">
+	<use href="#draw10" />
+	<rect x="33" y="40" width="27" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 1080)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,50)-(46,60) [0,4],[2,1]</text>
+	</g>
+	<g id="draw12">
+	<use href="#draw11" />
+	<rect x="20" y="50" width="26" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 1170)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;ij&#34; atpoint: (33,40) [1,3] fill: black</text>
+	</g>
+	<g id="draw13">
+	<use href="#draw12" />
+	<text x="35" y="48" fill="black" class="small">i</text>
+	<text x="48" y="48" fill="black" class="small">j</text>
+	</g>
+</g>
+
+<g transform="translate(0, 1260)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;XX&#34; atpoint: (20,50) [0,4] fill: black</text>
+	</g>
+	<g id="draw14">
+	<use href="#draw13" />
+	<text x="22" y="58" fill="black" class="small">X</text>
+	<text x="35" y="58" fill="black" class="small">X</text>
+	</g>
+</g>
+
+</svg>
+</body>
+</html>

--- a/frame/testdata/TestInsert/insertsRippledNewLine.html
+++ b/frame/testdata/TestInsert/insertsRippledNewLine.html
@@ -1,0 +1,141 @@
+<html lang="en-US">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+</head>
+<body>
+<svg viewBox="-20 -30 190 990" xmlns="http://www.w3.org/2000/svg">
+
+<style>
+	.small { font: 8px sans-serif; }
+</style>
+
+<g transform="translate(0, 0)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">target rect (20,10)-(60,60)</text>
+	</g>
+	<g id="draw0">
+	<rect x="20" y="10" width="40" height="50" fill="none" stroke="black"/>
+	</g>
+</g>
+
+<g transform="translate(0, 90)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,10)-(60,20) [0,0],[-,1]</text>
+	</g>
+	<g id="draw1">
+	<use href="#draw0" />
+	<rect x="20" y="10" width="40" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 180)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,20)-(60,50) [0,1],[-,3]</text>
+	</g>
+	<g id="draw2">
+	<use href="#draw1" />
+	<rect x="20" y="20" width="40" height="30" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 270)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,50)-(20,60) [0,4],[0,1]</text>
+	</g>
+	<g id="draw3">
+	<use href="#draw2" />
+	<rect x="20" y="50" width="0" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 360)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;0ab&#34; atpoint: (20,10) [0,0] fill: black</text>
+	</g>
+	<g id="draw4">
+	<use href="#draw3" />
+	<text x="22" y="18" fill="black" class="small">0</text>
+	<text x="35" y="18" fill="black" class="small">a</text>
+	<text x="48" y="18" fill="black" class="small">b</text>
+	</g>
+</g>
+
+<g transform="translate(0, 450)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;1cd&#34; atpoint: (20,20) [0,1] fill: black</text>
+	</g>
+	<g id="draw5">
+	<use href="#draw4" />
+	<text x="22" y="28" fill="black" class="small">1</text>
+	<text x="35" y="28" fill="black" class="small">c</text>
+	<text x="48" y="28" fill="black" class="small">d</text>
+	</g>
+</g>
+
+<g transform="translate(0, 540)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;2ef&#34; atpoint: (20,30) [0,2] fill: black</text>
+	</g>
+	<g id="draw6">
+	<use href="#draw5" />
+	<text x="22" y="38" fill="black" class="small">2</text>
+	<text x="35" y="38" fill="black" class="small">e</text>
+	<text x="48" y="38" fill="black" class="small">f</text>
+	</g>
+</g>
+
+<g transform="translate(0, 630)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;3gh&#34; atpoint: (20,40) [0,3] fill: black</text>
+	</g>
+	<g id="draw7">
+	<use href="#draw6" />
+	<text x="22" y="48" fill="black" class="small">3</text>
+	<text x="35" y="48" fill="black" class="small">g</text>
+	<text x="48" y="48" fill="black" class="small">h</text>
+	</g>
+</g>
+
+<g transform="translate(0, 720)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (20,40)-(60,50) [0,3],[-,1], to (20,50)-(60,60) [0,4],[-,1]</text>
+	</g>
+	<use href="#draw7" />
+<rect x="20" y="40" width="40" height="10" fill="none" stroke="red"/>
+<g transform="translate(70, 0)">
+	<g id="draw8">
+		<use href="#draw7" />
+		<clipPath id="draw8_blitsource">
+			
+			<rect x="20" y="40" width="40" height="10" />
+		</clipPath>
+		<use href="#draw7" clip-path="url(#draw8_blitsource)" x="0" y="10" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 810)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,40)-(60,50) [0,3],[-,1]</text>
+	</g>
+	<g id="draw9">
+	<use href="#draw8" />
+	<rect x="20" y="40" width="40" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 900)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,50)-(20,60) [0,4],[0,1]</text>
+	</g>
+	<g id="draw10">
+	<use href="#draw9" />
+	<rect x="20" y="50" width="0" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+</svg>
+</body>
+</html>

--- a/frame/testdata/TestInsert/multiInsertShortString.html
+++ b/frame/testdata/TestInsert/multiInsertShortString.html
@@ -1,0 +1,66 @@
+<html lang="en-US">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+</head>
+<body>
+<svg viewBox="-20 -30 870 650" xmlns="http://www.w3.org/2000/svg">
+
+<style>
+	.small { font: 8px sans-serif; }
+</style>
+
+<g transform="translate(0, 0)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">target rect (20,10)-(400,100)</text>
+	</g>
+	<g id="draw0">
+	<rect x="20" y="10" width="380" height="90" fill="none" stroke="black"/>
+	</g>
+</g>
+
+<g transform="translate(0, 130)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,10)-(400,20) [0,0],[-,1]</text>
+	</g>
+	<g id="draw1">
+	<use href="#draw0" />
+	<rect x="20" y="10" width="380" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 260)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,20)-(46,30) [0,1],[2,1]</text>
+	</g>
+	<g id="draw2">
+	<use href="#draw1" />
+	<rect x="20" y="20" width="26" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 390)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;ab&#34; atpoint: (20,10) [0,0] fill: black</text>
+	</g>
+	<g id="draw3">
+	<use href="#draw2" />
+	<text x="22" y="18" fill="black" class="small">a</text>
+	<text x="35" y="18" fill="black" class="small">b</text>
+	</g>
+</g>
+
+<g transform="translate(0, 520)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;cd&#34; atpoint: (20,20) [0,1] fill: black</text>
+	</g>
+	<g id="draw4">
+	<use href="#draw3" />
+	<text x="22" y="28" fill="black" class="small">c</text>
+	<text x="35" y="28" fill="black" class="small">d</text>
+	</g>
+</g>
+
+</svg>
+</body>
+</html>

--- a/frame/testdata/TestInsert/setupFrame.html
+++ b/frame/testdata/TestInsert/setupFrame.html
@@ -1,0 +1,24 @@
+<html lang="en-US">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+</head>
+<body>
+<svg viewBox="-20 -30 870 530" xmlns="http://www.w3.org/2000/svg">
+
+<style>
+	.small { font: 8px sans-serif; }
+</style>
+
+<g transform="translate(0, 0)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">target rect (20,10)-(400,500)</text>
+	</g>
+	<g id="draw0">
+	<rect x="20" y="10" width="380" height="490" fill="none" stroke="black"/>
+	</g>
+</g>
+
+</svg>
+</body>
+</html>

--- a/frame/testdata/TestInsert/simpleInsertShortString.html
+++ b/frame/testdata/TestInsert/simpleInsertShortString.html
@@ -1,0 +1,45 @@
+<html lang="en-US">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+</head>
+<body>
+<svg viewBox="-20 -30 870 390" xmlns="http://www.w3.org/2000/svg">
+
+<style>
+	.small { font: 8px sans-serif; }
+</style>
+
+<g transform="translate(0, 0)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">target rect (20,10)-(400,100)</text>
+	</g>
+	<g id="draw0">
+	<rect x="20" y="10" width="380" height="90" fill="none" stroke="black"/>
+	</g>
+</g>
+
+<g transform="translate(0, 130)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,10)-(46,20) [0,0],[2,1]</text>
+	</g>
+	<g id="draw1">
+	<use href="#draw0" />
+	<rect x="20" y="10" width="26" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 260)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;ab&#34; atpoint: (20,10) [0,0] fill: black</text>
+	</g>
+	<g id="draw2">
+	<use href="#draw1" />
+	<text x="22" y="18" fill="black" class="small">a</text>
+	<text x="35" y="18" fill="black" class="small">b</text>
+	</g>
+</g>
+
+</svg>
+</body>
+</html>

--- a/frame/testdata/TestInsert/splitWrappedLine.html
+++ b/frame/testdata/TestInsert/splitWrappedLine.html
@@ -1,0 +1,132 @@
+<html lang="en-US">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+</head>
+<body>
+<svg viewBox="-20 -30 190 990" xmlns="http://www.w3.org/2000/svg">
+
+<style>
+	.small { font: 8px sans-serif; }
+</style>
+
+<g transform="translate(0, 0)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">target rect (20,10)-(60,60)</text>
+	</g>
+	<g id="draw0">
+	<rect x="20" y="10" width="40" height="50" fill="none" stroke="black"/>
+	</g>
+</g>
+
+<g transform="translate(0, 90)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,10)-(60,20) [0,0],[-,1]</text>
+	</g>
+	<g id="draw1">
+	<use href="#draw0" />
+	<rect x="20" y="10" width="40" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 180)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,20)-(60,50) [0,1],[-,3]</text>
+	</g>
+	<g id="draw2">
+	<use href="#draw1" />
+	<rect x="20" y="20" width="40" height="30" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 270)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,50)-(33,60) [0,4],[1,1]</text>
+	</g>
+	<g id="draw3">
+	<use href="#draw2" />
+	<rect x="20" y="50" width="13" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 360)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;a本ポ&#34; atpoint: (20,10) [0,0] fill: black</text>
+	</g>
+	<g id="draw4">
+	<use href="#draw3" />
+	<text x="22" y="18" fill="black" class="small">a</text>
+	<text x="35" y="18" fill="black" class="small">本</text>
+	<text x="48" y="18" fill="black" class="small">ポ</text>
+	</g>
+</g>
+
+<g transform="translate(0, 450)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;ポポポ&#34; atpoint: (20,20) [0,1] fill: black</text>
+	</g>
+	<g id="draw5">
+	<use href="#draw4" />
+	<text x="22" y="28" fill="black" class="small">ポ</text>
+	<text x="35" y="28" fill="black" class="small">ポ</text>
+	<text x="48" y="28" fill="black" class="small">ポ</text>
+	</g>
+</g>
+
+<g transform="translate(0, 540)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;ポポh&#34; atpoint: (20,30) [0,2] fill: black</text>
+	</g>
+	<g id="draw6">
+	<use href="#draw5" />
+	<text x="22" y="38" fill="black" class="small">ポ</text>
+	<text x="35" y="38" fill="black" class="small">ポ</text>
+	<text x="48" y="38" fill="black" class="small">h</text>
+	</g>
+</g>
+
+<g transform="translate(0, 630)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;ell&#34; atpoint: (20,40) [0,3] fill: black</text>
+	</g>
+	<g id="draw7">
+	<use href="#draw6" />
+	<text x="22" y="48" fill="black" class="small">e</text>
+	<text x="35" y="48" fill="black" class="small">l</text>
+	<text x="48" y="48" fill="black" class="small">l</text>
+	</g>
+</g>
+
+<g transform="translate(0, 720)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;o&#34; atpoint: (20,50) [0,4] fill: black</text>
+	</g>
+	<g id="draw8">
+	<use href="#draw7" />
+	<text x="22" y="58" fill="black" class="small">o</text>
+	</g>
+</g>
+
+<g transform="translate(0, 810)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (59,10)-(60,20) [3,0],[-,1]</text>
+	</g>
+	<g id="draw9">
+	<use href="#draw8" />
+	<rect x="59" y="10" width="1" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 900)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,20)-(20,30) [0,1],[0,1]</text>
+	</g>
+	<g id="draw10">
+	<use href="#draw9" />
+	<rect x="20" y="20" width="0" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+</svg>
+</body>
+</html>

--- a/frame/testdata/TestInsertAligned/appendAtEnd.html
+++ b/frame/testdata/TestInsertAligned/appendAtEnd.html
@@ -1,0 +1,134 @@
+<html lang="en-US">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+</head>
+<body>
+<svg viewBox="-20 -30 188 990" xmlns="http://www.w3.org/2000/svg">
+
+<style>
+	.small { font: 8px sans-serif; }
+</style>
+
+<g transform="translate(0, 0)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">target rect (20,10)-(59,60)</text>
+	</g>
+	<g id="draw0">
+	<rect x="20" y="10" width="39" height="50" fill="none" stroke="black"/>
+	</g>
+</g>
+
+<g transform="translate(0, 90)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,10)-(59,20) [0,0],[3,1]</text>
+	</g>
+	<g id="draw1">
+	<use href="#draw0" />
+	<rect x="20" y="10" width="39" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 180)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,20)-(59,50) [0,1],[3,3]</text>
+	</g>
+	<g id="draw2">
+	<use href="#draw1" />
+	<rect x="20" y="20" width="39" height="30" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 270)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,50)-(59,60) [0,4],[3,1]</text>
+	</g>
+	<g id="draw3">
+	<use href="#draw2" />
+	<rect x="20" y="50" width="39" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 360)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;0ab&#34; atpoint: (20,10) [0,0] fill: black</text>
+	</g>
+	<g id="draw4">
+	<use href="#draw3" />
+	<text x="22" y="18" fill="black" class="small">0</text>
+	<text x="35" y="18" fill="black" class="small">a</text>
+	<text x="48" y="18" fill="black" class="small">b</text>
+	</g>
+</g>
+
+<g transform="translate(0, 450)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;1cd&#34; atpoint: (20,20) [0,1] fill: black</text>
+	</g>
+	<g id="draw5">
+	<use href="#draw4" />
+	<text x="22" y="28" fill="black" class="small">1</text>
+	<text x="35" y="28" fill="black" class="small">c</text>
+	<text x="48" y="28" fill="black" class="small">d</text>
+	</g>
+</g>
+
+<g transform="translate(0, 540)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;2ef&#34; atpoint: (20,30) [0,2] fill: black</text>
+	</g>
+	<g id="draw6">
+	<use href="#draw5" />
+	<text x="22" y="38" fill="black" class="small">2</text>
+	<text x="35" y="38" fill="black" class="small">e</text>
+	<text x="48" y="38" fill="black" class="small">f</text>
+	</g>
+</g>
+
+<g transform="translate(0, 630)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;3gh&#34; atpoint: (20,40) [0,3] fill: black</text>
+	</g>
+	<g id="draw7">
+	<use href="#draw6" />
+	<text x="22" y="48" fill="black" class="small">3</text>
+	<text x="35" y="48" fill="black" class="small">g</text>
+	<text x="48" y="48" fill="black" class="small">h</text>
+	</g>
+</g>
+
+<g transform="translate(0, 720)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;4ij&#34; atpoint: (20,50) [0,4] fill: black</text>
+	</g>
+	<g id="draw8">
+	<use href="#draw7" />
+	<text x="22" y="58" fill="black" class="small">4</text>
+	<text x="35" y="58" fill="black" class="small">i</text>
+	<text x="48" y="58" fill="black" class="small">j</text>
+	</g>
+</g>
+
+<g transform="translate(0, 810)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (58,50)-(59,60) [-,4],[-,1]</text>
+	</g>
+	<g id="draw9">
+	<use href="#draw8" />
+	<rect x="58" y="50" width="1" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 900)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,60)-(20,70) [0,5],[0,1]</text>
+	</g>
+	<g id="draw10">
+	<use href="#draw9" />
+	<rect x="20" y="60" width="0" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+</svg>
+</body>
+</html>

--- a/frame/testdata/TestInsertAligned/appendHangingLongAtEnd.html
+++ b/frame/testdata/TestInsertAligned/appendHangingLongAtEnd.html
@@ -1,0 +1,135 @@
+<html lang="en-US">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+</head>
+<body>
+<svg viewBox="-20 -30 188 1080" xmlns="http://www.w3.org/2000/svg">
+
+<style>
+	.small { font: 8px sans-serif; }
+</style>
+
+<g transform="translate(0, 0)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">target rect (20,10)-(59,60)</text>
+	</g>
+	<g id="draw0">
+	<rect x="20" y="10" width="39" height="50" fill="none" stroke="black"/>
+	</g>
+</g>
+
+<g transform="translate(0, 90)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,10)-(59,20) [0,0],[3,1]</text>
+	</g>
+	<g id="draw1">
+	<use href="#draw0" />
+	<rect x="20" y="10" width="39" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 180)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,20)-(59,60) [0,1],[3,4]</text>
+	</g>
+	<g id="draw2">
+	<use href="#draw1" />
+	<rect x="20" y="20" width="39" height="40" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 270)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,60)-(20,70) [0,5],[0,1]</text>
+	</g>
+	<g id="draw3">
+	<use href="#draw2" />
+	<rect x="20" y="60" width="0" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 360)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;0&#34; atpoint: (20,10) [0,0] fill: black</text>
+	</g>
+	<g id="draw4">
+	<use href="#draw3" />
+	<text x="22" y="18" fill="black" class="small">0</text>
+	</g>
+</g>
+
+<g transform="translate(0, 450)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;1&#34; atpoint: (20,20) [0,1] fill: black</text>
+	</g>
+	<g id="draw5">
+	<use href="#draw4" />
+	<text x="22" y="28" fill="black" class="small">1</text>
+	</g>
+</g>
+
+<g transform="translate(0, 540)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;2&#34; atpoint: (20,30) [0,2] fill: black</text>
+	</g>
+	<g id="draw6">
+	<use href="#draw5" />
+	<text x="22" y="38" fill="black" class="small">2</text>
+	</g>
+</g>
+
+<g transform="translate(0, 630)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;3&#34; atpoint: (20,40) [0,3] fill: black</text>
+	</g>
+	<g id="draw7">
+	<use href="#draw6" />
+	<text x="22" y="48" fill="black" class="small">3</text>
+	</g>
+</g>
+
+<g transform="translate(0, 720)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;4&#34; atpoint: (20,50) [0,4] fill: black</text>
+	</g>
+	<g id="draw8">
+	<use href="#draw7" />
+	<text x="22" y="58" fill="black" class="small">4</text>
+	</g>
+</g>
+
+<g transform="translate(0, 810)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (33,50)-(59,60) [1,4],[2,1]</text>
+	</g>
+	<g id="draw9">
+	<use href="#draw8" />
+	<rect x="33" y="50" width="26" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 900)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,60)-(20,70) [0,5],[0,1]</text>
+	</g>
+	<g id="draw10">
+	<use href="#draw9" />
+	<rect x="20" y="60" width="0" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 990)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;XX&#34; atpoint: (33,50) [1,4] fill: black</text>
+	</g>
+	<g id="draw11">
+	<use href="#draw10" />
+	<text x="35" y="58" fill="black" class="small">X</text>
+	<text x="48" y="58" fill="black" class="small">X</text>
+	</g>
+</g>
+
+</svg>
+</body>
+</html>

--- a/frame/testdata/TestInsertAligned/insertForcesWrap.html
+++ b/frame/testdata/TestInsertAligned/insertForcesWrap.html
@@ -1,0 +1,230 @@
+<html lang="en-US">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+</head>
+<body>
+<svg viewBox="-20 -30 188 1530" xmlns="http://www.w3.org/2000/svg">
+
+<style>
+	.small { font: 8px sans-serif; }
+</style>
+
+<g transform="translate(0, 0)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">target rect (20,10)-(59,60)</text>
+	</g>
+	<g id="draw0">
+	<rect x="20" y="10" width="39" height="50" fill="none" stroke="black"/>
+	</g>
+</g>
+
+<g transform="translate(0, 90)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,10)-(59,20) [0,0],[3,1]</text>
+	</g>
+	<g id="draw1">
+	<use href="#draw0" />
+	<rect x="20" y="10" width="39" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 180)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,20)-(59,50) [0,1],[3,3]</text>
+	</g>
+	<g id="draw2">
+	<use href="#draw1" />
+	<rect x="20" y="20" width="39" height="30" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 270)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,50)-(59,60) [0,4],[3,1]</text>
+	</g>
+	<g id="draw3">
+	<use href="#draw2" />
+	<rect x="20" y="50" width="39" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 360)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;0ab&#34; atpoint: (20,10) [0,0] fill: black</text>
+	</g>
+	<g id="draw4">
+	<use href="#draw3" />
+	<text x="22" y="18" fill="black" class="small">0</text>
+	<text x="35" y="18" fill="black" class="small">a</text>
+	<text x="48" y="18" fill="black" class="small">b</text>
+	</g>
+</g>
+
+<g transform="translate(0, 450)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;1cd&#34; atpoint: (20,20) [0,1] fill: black</text>
+	</g>
+	<g id="draw5">
+	<use href="#draw4" />
+	<text x="22" y="28" fill="black" class="small">1</text>
+	<text x="35" y="28" fill="black" class="small">c</text>
+	<text x="48" y="28" fill="black" class="small">d</text>
+	</g>
+</g>
+
+<g transform="translate(0, 540)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;2ef&#34; atpoint: (20,30) [0,2] fill: black</text>
+	</g>
+	<g id="draw6">
+	<use href="#draw5" />
+	<text x="22" y="38" fill="black" class="small">2</text>
+	<text x="35" y="38" fill="black" class="small">e</text>
+	<text x="48" y="38" fill="black" class="small">f</text>
+	</g>
+</g>
+
+<g transform="translate(0, 630)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;3gh&#34; atpoint: (20,40) [0,3] fill: black</text>
+	</g>
+	<g id="draw7">
+	<use href="#draw6" />
+	<text x="22" y="48" fill="black" class="small">3</text>
+	<text x="35" y="48" fill="black" class="small">g</text>
+	<text x="48" y="48" fill="black" class="small">h</text>
+	</g>
+</g>
+
+<g transform="translate(0, 720)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;4ij&#34; atpoint: (20,50) [0,4] fill: black</text>
+	</g>
+	<g id="draw8">
+	<use href="#draw7" />
+	<text x="22" y="58" fill="black" class="small">4</text>
+	<text x="35" y="58" fill="black" class="small">i</text>
+	<text x="48" y="58" fill="black" class="small">j</text>
+	</g>
+</g>
+
+<g transform="translate(0, 810)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (20,30)-(59,50) [0,2],[3,2], to (20,40)-(59,60) [0,3],[3,2]</text>
+	</g>
+	<use href="#draw8" />
+<rect x="20" y="30" width="39" height="20" fill="none" stroke="red"/>
+<g transform="translate(69, 0)">
+	<g id="draw9">
+		<use href="#draw8" />
+		<clipPath id="draw9_blitsource">
+			
+			<rect x="20" y="30" width="39" height="20" />
+		</clipPath>
+		<use href="#draw8" clip-path="url(#draw9_blitsource)" x="0" y="10" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 900)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (59,20)-(59,30) [3,1],[0,1], to (59,30)-(59,40) [3,2],[0,1]</text>
+	</g>
+	<use href="#draw9" />
+<rect x="59" y="20" width="0" height="10" fill="none" stroke="red"/>
+<g transform="translate(69, 0)">
+	<g id="draw10">
+		<use href="#draw9" />
+		<clipPath id="draw10_blitsource">
+			
+			<rect x="59" y="20" width="0" height="10" />
+		</clipPath>
+		<use href="#draw9" clip-path="url(#draw10_blitsource)" x="0" y="10" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 990)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (20,20)-(59,30) [0,1],[3,1], to (20,30)-(59,40) [0,2],[3,1]</text>
+	</g>
+	<use href="#draw10" />
+<rect x="20" y="20" width="39" height="10" fill="none" stroke="red"/>
+<g transform="translate(69, 0)">
+	<g id="draw11">
+		<use href="#draw10" />
+		<clipPath id="draw11_blitsource">
+			
+			<rect x="20" y="20" width="39" height="10" />
+		</clipPath>
+		<use href="#draw10" clip-path="url(#draw11_blitsource)" x="0" y="10" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 1080)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (33,20)-(59,30) [1,1],[2,1]</text>
+	</g>
+	<g id="draw12">
+	<use href="#draw11" />
+	<rect x="33" y="20" width="26" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 1170)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (46,10)-(59,20) [2,0],[1,1], to (20,20)-(33,30) [0,1],[1,1]</text>
+	</g>
+	<use href="#draw12" />
+<rect x="46" y="10" width="13" height="10" fill="none" stroke="red"/>
+<g transform="translate(69, 0)">
+	<g id="draw13">
+		<use href="#draw12" />
+		<clipPath id="draw13_blitsource">
+			
+			<rect x="46" y="10" width="13" height="10" />
+		</clipPath>
+		<use href="#draw12" clip-path="url(#draw13_blitsource)" x="-26" y="10" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 1260)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (46,10)-(59,20) [2,0],[1,1]</text>
+	</g>
+	<g id="draw14">
+	<use href="#draw13" />
+	<rect x="46" y="10" width="13" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 1350)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,20)-(20,30) [0,1],[0,1]</text>
+	</g>
+	<g id="draw15">
+	<use href="#draw14" />
+	<rect x="20" y="20" width="0" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 1440)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;X&#34; atpoint: (46,10) [2,0] fill: black</text>
+	</g>
+	<g id="draw16">
+	<use href="#draw15" />
+	<text x="48" y="18" fill="black" class="small">X</text>
+	</g>
+</g>
+
+</svg>
+</body>
+</html>

--- a/frame/testdata/TestInsertAligned/insertPastEnd.html
+++ b/frame/testdata/TestInsertAligned/insertPastEnd.html
@@ -1,0 +1,90 @@
+<html lang="en-US">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+</head>
+<body>
+<svg viewBox="-20 -30 188 490" xmlns="http://www.w3.org/2000/svg">
+
+<style>
+	.small { font: 8px sans-serif; }
+</style>
+
+<g transform="translate(0, 0)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">target rect (20,10)-(59,40)</text>
+	</g>
+	<g id="draw0">
+	<rect x="20" y="10" width="39" height="30" fill="none" stroke="black"/>
+	</g>
+</g>
+
+<g transform="translate(0, 70)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,10)-(59,20) [0,0],[3,1]</text>
+	</g>
+	<g id="draw1">
+	<use href="#draw0" />
+	<rect x="20" y="10" width="39" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 140)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,20)-(59,40) [0,1],[3,2]</text>
+	</g>
+	<g id="draw2">
+	<use href="#draw1" />
+	<rect x="20" y="20" width="39" height="20" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 210)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,40)-(20,50) [0,3],[0,1]</text>
+	</g>
+	<g id="draw3">
+	<use href="#draw2" />
+	<rect x="20" y="40" width="0" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 280)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;a本ポ&#34; atpoint: (20,10) [0,0] fill: black</text>
+	</g>
+	<g id="draw4">
+	<use href="#draw3" />
+	<text x="22" y="18" fill="black" class="small">a</text>
+	<text x="35" y="18" fill="black" class="small">本</text>
+	<text x="48" y="18" fill="black" class="small">ポ</text>
+	</g>
+</g>
+
+<g transform="translate(0, 350)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;ポポポ&#34; atpoint: (20,20) [0,1] fill: black</text>
+	</g>
+	<g id="draw5">
+	<use href="#draw4" />
+	<text x="22" y="28" fill="black" class="small">ポ</text>
+	<text x="35" y="28" fill="black" class="small">ポ</text>
+	<text x="48" y="28" fill="black" class="small">ポ</text>
+	</g>
+</g>
+
+<g transform="translate(0, 420)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;ポポh&#34; atpoint: (20,30) [0,2] fill: black</text>
+	</g>
+	<g id="draw6">
+	<use href="#draw5" />
+	<text x="22" y="38" fill="black" class="small">ポ</text>
+	<text x="35" y="38" fill="black" class="small">ポ</text>
+	<text x="48" y="38" fill="black" class="small">h</text>
+	</g>
+</g>
+
+</svg>
+</body>
+</html>

--- a/frame/testdata/TestInsertAligned/insertPastEndl.html
+++ b/frame/testdata/TestInsertAligned/insertPastEndl.html
@@ -1,0 +1,90 @@
+<html lang="en-US">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+</head>
+<body>
+<svg viewBox="-20 -30 188 490" xmlns="http://www.w3.org/2000/svg">
+
+<style>
+	.small { font: 8px sans-serif; }
+</style>
+
+<g transform="translate(0, 0)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">target rect (20,10)-(59,40)</text>
+	</g>
+	<g id="draw0">
+	<rect x="20" y="10" width="39" height="30" fill="none" stroke="black"/>
+	</g>
+</g>
+
+<g transform="translate(0, 70)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,10)-(59,20) [0,0],[3,1]</text>
+	</g>
+	<g id="draw1">
+	<use href="#draw0" />
+	<rect x="20" y="10" width="39" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 140)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,20)-(59,40) [0,1],[3,2]</text>
+	</g>
+	<g id="draw2">
+	<use href="#draw1" />
+	<rect x="20" y="20" width="39" height="20" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 210)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,40)-(20,50) [0,3],[0,1]</text>
+	</g>
+	<g id="draw3">
+	<use href="#draw2" />
+	<rect x="20" y="40" width="0" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 280)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;a本ポ&#34; atpoint: (20,10) [0,0] fill: black</text>
+	</g>
+	<g id="draw4">
+	<use href="#draw3" />
+	<text x="22" y="18" fill="black" class="small">a</text>
+	<text x="35" y="18" fill="black" class="small">本</text>
+	<text x="48" y="18" fill="black" class="small">ポ</text>
+	</g>
+</g>
+
+<g transform="translate(0, 350)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;ポポポ&#34; atpoint: (20,20) [0,1] fill: black</text>
+	</g>
+	<g id="draw5">
+	<use href="#draw4" />
+	<text x="22" y="28" fill="black" class="small">ポ</text>
+	<text x="35" y="28" fill="black" class="small">ポ</text>
+	<text x="48" y="28" fill="black" class="small">ポ</text>
+	</g>
+</g>
+
+<g transform="translate(0, 420)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;ポポh&#34; atpoint: (20,30) [0,2] fill: black</text>
+	</g>
+	<g id="draw6">
+	<use href="#draw5" />
+	<text x="22" y="38" fill="black" class="small">ポ</text>
+	<text x="35" y="38" fill="black" class="small">ポ</text>
+	<text x="48" y="38" fill="black" class="small">h</text>
+	</g>
+</g>
+
+</svg>
+</body>
+</html>

--- a/frame/testdata/TestInsertAligned/insertPushesBlankLineOffEnd.html
+++ b/frame/testdata/TestInsertAligned/insertPushesBlankLineOffEnd.html
@@ -1,0 +1,237 @@
+<html lang="en-US">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+</head>
+<body>
+<svg viewBox="-20 -30 188 1530" xmlns="http://www.w3.org/2000/svg">
+
+<style>
+	.small { font: 8px sans-serif; }
+</style>
+
+<g transform="translate(0, 0)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">target rect (20,10)-(59,60)</text>
+	</g>
+	<g id="draw0">
+	<rect x="20" y="10" width="39" height="50" fill="none" stroke="black"/>
+	</g>
+</g>
+
+<g transform="translate(0, 90)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,10)-(59,20) [0,0],[3,1]</text>
+	</g>
+	<g id="draw1">
+	<use href="#draw0" />
+	<rect x="20" y="10" width="39" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 180)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,20)-(59,60) [0,1],[3,4]</text>
+	</g>
+	<g id="draw2">
+	<use href="#draw1" />
+	<rect x="20" y="20" width="39" height="40" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 270)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,60)-(20,70) [0,5],[0,1]</text>
+	</g>
+	<g id="draw3">
+	<use href="#draw2" />
+	<rect x="20" y="60" width="0" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 360)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;0ab&#34; atpoint: (20,10) [0,0] fill: black</text>
+	</g>
+	<g id="draw4">
+	<use href="#draw3" />
+	<text x="22" y="18" fill="black" class="small">0</text>
+	<text x="35" y="18" fill="black" class="small">a</text>
+	<text x="48" y="18" fill="black" class="small">b</text>
+	</g>
+</g>
+
+<g transform="translate(0, 450)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;1cd&#34; atpoint: (20,20) [0,1] fill: black</text>
+	</g>
+	<g id="draw5">
+	<use href="#draw4" />
+	<text x="22" y="28" fill="black" class="small">1</text>
+	<text x="35" y="28" fill="black" class="small">c</text>
+	<text x="48" y="28" fill="black" class="small">d</text>
+	</g>
+</g>
+
+<g transform="translate(0, 540)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;2ef&#34; atpoint: (20,30) [0,2] fill: black</text>
+	</g>
+	<g id="draw6">
+	<use href="#draw5" />
+	<text x="22" y="38" fill="black" class="small">2</text>
+	<text x="35" y="38" fill="black" class="small">e</text>
+	<text x="48" y="38" fill="black" class="small">f</text>
+	</g>
+</g>
+
+<g transform="translate(0, 630)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;3gh&#34; atpoint: (20,40) [0,3] fill: black</text>
+	</g>
+	<g id="draw7">
+	<use href="#draw6" />
+	<text x="22" y="48" fill="black" class="small">3</text>
+	<text x="35" y="48" fill="black" class="small">g</text>
+	<text x="48" y="48" fill="black" class="small">h</text>
+	</g>
+</g>
+
+<g transform="translate(0, 720)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (20,30)-(59,50) [0,2],[3,2], to (20,40)-(59,60) [0,3],[3,2]</text>
+	</g>
+	<use href="#draw7" />
+<rect x="20" y="30" width="39" height="20" fill="none" stroke="red"/>
+<g transform="translate(69, 0)">
+	<g id="draw8">
+		<use href="#draw7" />
+		<clipPath id="draw8_blitsource">
+			
+			<rect x="20" y="30" width="39" height="20" />
+		</clipPath>
+		<use href="#draw7" clip-path="url(#draw8_blitsource)" x="0" y="10" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 810)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (59,20)-(59,30) [3,1],[0,1], to (59,30)-(59,40) [3,2],[0,1]</text>
+	</g>
+	<use href="#draw8" />
+<rect x="59" y="20" width="0" height="10" fill="none" stroke="red"/>
+<g transform="translate(69, 0)">
+	<g id="draw9">
+		<use href="#draw8" />
+		<clipPath id="draw9_blitsource">
+			
+			<rect x="59" y="20" width="0" height="10" />
+		</clipPath>
+		<use href="#draw8" clip-path="url(#draw9_blitsource)" x="0" y="10" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 900)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (20,20)-(59,30) [0,1],[3,1], to (20,30)-(59,40) [0,2],[3,1]</text>
+	</g>
+	<use href="#draw9" />
+<rect x="20" y="20" width="39" height="10" fill="none" stroke="red"/>
+<g transform="translate(69, 0)">
+	<g id="draw10">
+		<use href="#draw9" />
+		<clipPath id="draw10_blitsource">
+			
+			<rect x="20" y="20" width="39" height="10" />
+		</clipPath>
+		<use href="#draw9" clip-path="url(#draw10_blitsource)" x="0" y="10" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 990)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (33,20)-(59,30) [1,1],[2,1]</text>
+	</g>
+	<g id="draw11">
+	<use href="#draw10" />
+	<rect x="33" y="20" width="26" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 1080)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (46,10)-(59,20) [2,0],[1,1], to (20,20)-(33,30) [0,1],[1,1]</text>
+	</g>
+	<use href="#draw11" />
+<rect x="46" y="10" width="13" height="10" fill="none" stroke="red"/>
+<g transform="translate(69, 0)">
+	<g id="draw12">
+		<use href="#draw11" />
+		<clipPath id="draw12_blitsource">
+			
+			<rect x="46" y="10" width="13" height="10" />
+		</clipPath>
+		<use href="#draw11" clip-path="url(#draw12_blitsource)" x="-26" y="10" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 1170)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (33,10)-(46,20) [1,0],[1,1], to (46,10)-(59,20) [2,0],[1,1]</text>
+	</g>
+	<use href="#draw12" />
+<rect x="33" y="10" width="13" height="10" fill="none" stroke="red"/>
+<g transform="translate(69, 0)">
+	<g id="draw13">
+		<use href="#draw12" />
+		<clipPath id="draw13_blitsource">
+			
+			<rect x="33" y="10" width="13" height="10" />
+		</clipPath>
+		<use href="#draw12" clip-path="url(#draw13_blitsource)" x="13" y="0" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 1260)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (59,10)-(59,20) [3,0],[0,1]</text>
+	</g>
+	<g id="draw14">
+	<use href="#draw13" />
+	<rect x="59" y="10" width="0" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 1350)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (33,10)-(46,20) [1,0],[1,1]</text>
+	</g>
+	<g id="draw15">
+	<use href="#draw14" />
+	<rect x="33" y="10" width="13" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 1440)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;X&#34; atpoint: (33,10) [1,0] fill: black</text>
+	</g>
+	<g id="draw16">
+	<use href="#draw15" />
+	<text x="35" y="18" fill="black" class="small">X</text>
+	</g>
+</g>
+
+</svg>
+</body>
+</html>

--- a/frame/testdata/TestInsertAligned/insertWrappedThatForcesRipple.html
+++ b/frame/testdata/TestInsertAligned/insertWrappedThatForcesRipple.html
@@ -1,0 +1,176 @@
+<html lang="en-US">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+</head>
+<body>
+<svg viewBox="-20 -30 188 1350" xmlns="http://www.w3.org/2000/svg">
+
+<style>
+	.small { font: 8px sans-serif; }
+</style>
+
+<g transform="translate(0, 0)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">target rect (20,10)-(59,60)</text>
+	</g>
+	<g id="draw0">
+	<rect x="20" y="10" width="39" height="50" fill="none" stroke="black"/>
+	</g>
+</g>
+
+<g transform="translate(0, 90)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,10)-(59,20) [0,0],[3,1]</text>
+	</g>
+	<g id="draw1">
+	<use href="#draw0" />
+	<rect x="20" y="10" width="39" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 180)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,20)-(59,60) [0,1],[3,4]</text>
+	</g>
+	<g id="draw2">
+	<use href="#draw1" />
+	<rect x="20" y="20" width="39" height="40" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 270)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,60)-(20,70) [0,5],[0,1]</text>
+	</g>
+	<g id="draw3">
+	<use href="#draw2" />
+	<rect x="20" y="60" width="0" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 360)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;0&#34; atpoint: (20,10) [0,0] fill: black</text>
+	</g>
+	<g id="draw4">
+	<use href="#draw3" />
+	<text x="22" y="18" fill="black" class="small">0</text>
+	</g>
+</g>
+
+<g transform="translate(0, 450)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;1&#34; atpoint: (20,20) [0,1] fill: black</text>
+	</g>
+	<g id="draw5">
+	<use href="#draw4" />
+	<text x="22" y="28" fill="black" class="small">1</text>
+	</g>
+</g>
+
+<g transform="translate(0, 540)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;2&#34; atpoint: (20,30) [0,2] fill: black</text>
+	</g>
+	<g id="draw6">
+	<use href="#draw5" />
+	<text x="22" y="38" fill="black" class="small">2</text>
+	</g>
+</g>
+
+<g transform="translate(0, 630)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;3b&#34; atpoint: (20,40) [0,3] fill: black</text>
+	</g>
+	<g id="draw7">
+	<use href="#draw6" />
+	<text x="22" y="48" fill="black" class="small">3</text>
+	<text x="35" y="48" fill="black" class="small">b</text>
+	</g>
+</g>
+
+<g transform="translate(0, 720)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;4&#34; atpoint: (20,50) [0,4] fill: black</text>
+	</g>
+	<g id="draw8">
+	<use href="#draw7" />
+	<text x="22" y="58" fill="black" class="small">4</text>
+	</g>
+</g>
+
+<g transform="translate(0, 810)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (59,50)-(59,60) [3,4],[0,1]</text>
+	</g>
+	<g id="draw9">
+	<use href="#draw8" />
+	<rect x="59" y="50" width="0" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 900)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">blit (33,40)-(46,50) [1,3],[1,1], to (46,50)-(59,60) [2,4],[1,1]</text>
+	</g>
+	<use href="#draw9" />
+<rect x="33" y="40" width="13" height="10" fill="none" stroke="red"/>
+<g transform="translate(69, 0)">
+	<g id="draw10">
+		<use href="#draw9" />
+		<clipPath id="draw10_blitsource">
+			
+			<rect x="33" y="40" width="13" height="10" />
+		</clipPath>
+		<use href="#draw9" clip-path="url(#draw10_blitsource)" x="13" y="10" />
+	</g>
+</g>
+
+</g>
+
+<g transform="translate(0, 990)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (33,40)-(59,50) [1,3],[2,1]</text>
+	</g>
+	<g id="draw11">
+	<use href="#draw10" />
+	<rect x="33" y="40" width="26" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 1080)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,50)-(46,60) [0,4],[2,1]</text>
+	</g>
+	<g id="draw12">
+	<use href="#draw11" />
+	<rect x="20" y="50" width="26" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 1170)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;ij&#34; atpoint: (33,40) [1,3] fill: black</text>
+	</g>
+	<g id="draw13">
+	<use href="#draw12" />
+	<text x="35" y="48" fill="black" class="small">i</text>
+	<text x="48" y="48" fill="black" class="small">j</text>
+	</g>
+</g>
+
+<g transform="translate(0, 1260)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;XX&#34; atpoint: (20,50) [0,4] fill: black</text>
+	</g>
+	<g id="draw14">
+	<use href="#draw13" />
+	<text x="22" y="58" fill="black" class="small">X</text>
+	<text x="35" y="58" fill="black" class="small">X</text>
+	</g>
+</g>
+
+</svg>
+</body>
+</html>

--- a/frame/testdata/TestInsertAligned/splitWrappedLine.html
+++ b/frame/testdata/TestInsertAligned/splitWrappedLine.html
@@ -1,0 +1,132 @@
+<html lang="en-US">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width">
+</head>
+<body>
+<svg viewBox="-20 -30 188 990" xmlns="http://www.w3.org/2000/svg">
+
+<style>
+	.small { font: 8px sans-serif; }
+</style>
+
+<g transform="translate(0, 0)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">target rect (20,10)-(59,60)</text>
+	</g>
+	<g id="draw0">
+	<rect x="20" y="10" width="39" height="50" fill="none" stroke="black"/>
+	</g>
+</g>
+
+<g transform="translate(0, 90)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,10)-(59,20) [0,0],[3,1]</text>
+	</g>
+	<g id="draw1">
+	<use href="#draw0" />
+	<rect x="20" y="10" width="39" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 180)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,20)-(59,50) [0,1],[3,3]</text>
+	</g>
+	<g id="draw2">
+	<use href="#draw1" />
+	<rect x="20" y="20" width="39" height="30" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 270)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,50)-(33,60) [0,4],[1,1]</text>
+	</g>
+	<g id="draw3">
+	<use href="#draw2" />
+	<rect x="20" y="50" width="13" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 360)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;a本ポ&#34; atpoint: (20,10) [0,0] fill: black</text>
+	</g>
+	<g id="draw4">
+	<use href="#draw3" />
+	<text x="22" y="18" fill="black" class="small">a</text>
+	<text x="35" y="18" fill="black" class="small">本</text>
+	<text x="48" y="18" fill="black" class="small">ポ</text>
+	</g>
+</g>
+
+<g transform="translate(0, 450)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;ポポポ&#34; atpoint: (20,20) [0,1] fill: black</text>
+	</g>
+	<g id="draw5">
+	<use href="#draw4" />
+	<text x="22" y="28" fill="black" class="small">ポ</text>
+	<text x="35" y="28" fill="black" class="small">ポ</text>
+	<text x="48" y="28" fill="black" class="small">ポ</text>
+	</g>
+</g>
+
+<g transform="translate(0, 540)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;ポポh&#34; atpoint: (20,30) [0,2] fill: black</text>
+	</g>
+	<g id="draw6">
+	<use href="#draw5" />
+	<text x="22" y="38" fill="black" class="small">ポ</text>
+	<text x="35" y="38" fill="black" class="small">ポ</text>
+	<text x="48" y="38" fill="black" class="small">h</text>
+	</g>
+</g>
+
+<g transform="translate(0, 630)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;ell&#34; atpoint: (20,40) [0,3] fill: black</text>
+	</g>
+	<g id="draw7">
+	<use href="#draw6" />
+	<text x="22" y="48" fill="black" class="small">e</text>
+	<text x="35" y="48" fill="black" class="small">l</text>
+	<text x="48" y="48" fill="black" class="small">l</text>
+	</g>
+</g>
+
+<g transform="translate(0, 720)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">string &#34;o&#34; atpoint: (20,50) [0,4] fill: black</text>
+	</g>
+	<g id="draw8">
+	<use href="#draw7" />
+	<text x="22" y="58" fill="black" class="small">o</text>
+	</g>
+</g>
+
+<g transform="translate(0, 810)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (58,10)-(59,20) [-,0],[-,1]</text>
+	</g>
+	<g id="draw9">
+	<use href="#draw8" />
+	<rect x="58" y="10" width="1" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+<g transform="translate(0, 900)">
+	<g transform="translate(0, -2)">
+		<text x="0" y="0" fill="black" class="small">fill (20,20)-(20,30) [0,1],[0,1]</text>
+	</g>
+	<g id="draw10">
+	<use href="#draw9" />
+	<rect x="20" y="20" width="0" height="10" fill="#ffffdd"/>
+	</g>
+</g>
+
+</svg>
+</body>
+</html>

--- a/frame/testing_helpers_test.go
+++ b/frame/testing_helpers_test.go
@@ -1,0 +1,88 @@
+package frame
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/rjkroege/edwood/edwoodtest"
+)
+
+// Code needed to help write tests.
+
+// testName creates the correct name for the visualized test output.
+func testName(t *testing.T, suffix string) string {
+	return filepath.Join("testdata", t.Name()) + suffix + ".html"
+}
+
+func makeVisualizedOutputTestPath(t *testing.T) string {
+	t.Helper()
+
+	tp := testName(t, "_trial")
+	dir := filepath.Dir(tp)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("can't make makeVisualizedOutputTestPath %s: %v", dir, err)
+	}
+
+	return tp
+}
+
+// compareVisualizedOutputTestToBaseline compares the generated SVG to
+// the baseline. f
+func compareVisualizedOutputTestToBaseline(t *testing.T) {
+	t.Helper()
+
+	// load the base
+	baselinename := testName(t, "")
+	want := ""
+	if b, err := os.ReadFile(baselinename); err != nil {
+		t.Errorf("baseline unreadable for %s", baselinename)
+		return
+	} else {
+		want = string(b)
+	}
+
+	testoutname := testName(t, "_trial")
+	got := ""
+	if b, err := os.ReadFile(testoutname); err != nil {
+		t.Errorf("test result unreadable for %s", testoutname)
+		return
+	} else {
+		got = string(b)
+	}
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("visualized output mismatch (-want +got):\n%s", diff)
+	} else {
+
+		if err := os.RemoveAll(testoutname); err != nil {
+			t.Errorf("can't remove valid output %s: %v", testoutname, err)
+		}
+	}
+}
+
+func gdo(t *testing.T, fr Frame) edwoodtest.GettableDrawOps {
+	t.Helper()
+	frimpl := fr.(*frameimpl)
+	gdo := frimpl.display.(edwoodtest.GettableDrawOps)
+	return gdo
+}
+
+// visualizedoutputtest generates SVG-based graphical output
+func visualizedoutputtest(t *testing.T, fr Frame) {
+
+	oname := makeVisualizedOutputTestPath(t)
+	sf, err := os.Create(oname)
+	if err != nil {
+		t.Fatalf("can't make a file for the test output %s: %v", oname, err)
+	}
+	if err := gdo(t, fr).SVGDrawOps(sf); err != nil {
+		t.Fatalf("can't write a file for the test output %s: %v", oname, err)
+	}
+	sf.Close()
+
+	// Compare the generated SVG to the baseline.
+	compareVisualizedOutputTestToBaseline(t)
+
+}

--- a/fsys_test.go
+++ b/fsys_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"image"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -25,7 +26,7 @@ func TestMain(m *testing.M) {
 	switch os.Getenv("TEST_MAIN") {
 	case "edwood":
 		dump := predrawInit()
-		display := edwoodtest.NewDisplay()
+		display := edwoodtest.NewDisplay(image.Rectangle{})
 		mainWithDisplay(global, dump, display)
 	default:
 		// Prevent mounting any acme file server being run by the user running tests.

--- a/logf.go
+++ b/logf.go
@@ -99,9 +99,9 @@ func xfidlogflush(x *Xfid) {
 // expected calls:
 //
 // op == "new" for each new window
-// - caller of coladd or makenewwindow responsible for calling
-// 	xfidlog after setting window name
-// - exception: zerox
+//   - caller of coladd or makenewwindow responsible for calling
+//     xfidlog after setting window name
+//   - exception: zerox
 //
 // op == "zerox" for new window created via zerox
 // - called from zeroxx

--- a/row_test.go
+++ b/row_test.go
@@ -435,7 +435,7 @@ func jsonEscapePath(s string) string {
 
 func setGlobalsForLoadTesting() {
 	global.WinID = 0 // reset
-	display := edwoodtest.NewDisplay()
+	display := edwoodtest.NewDisplay(image.Rectangle{})
 
 	global.colbutton = edwoodtest.NewImage(display, "colbutton", image.Rectangle{})
 	global.button = edwoodtest.NewImage(display, "button", image.Rectangle{})

--- a/rowmock_test.go
+++ b/rowmock_test.go
@@ -50,7 +50,7 @@ func updateText(t *Text, sertext *dumpfile.Text, display draw.Display) *Text {
 // reflect the state of the model under non-test operating conditions.
 // Callers of this function should adjust the dirty state externally.
 func MakeWindowScaffold(content *dumpfile.Content) {
-	display := edwoodtest.NewDisplay()
+	display := edwoodtest.NewDisplay(image.Rectangle{})
 	global.seq = 0
 
 	global.row = Row{

--- a/wind_test.go
+++ b/wind_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"image"
 	"reflect"
 	"testing"
 
@@ -19,7 +20,7 @@ func TestSetTag1(t *testing.T) {
 		"/home/ゴーファー/src/エドウード.txt",
 		"/home/ゴーファー/src/",
 	} {
-		display := edwoodtest.NewDisplay()
+		display := edwoodtest.NewDisplay(image.Rectangle{})
 		global.configureGlobals(display)
 
 		w := NewWindow().initHeadless(nil)

--- a/xfid_test.go
+++ b/xfid_test.go
@@ -61,7 +61,7 @@ func TestXfidctl(t *testing.T) {
 
 	x := &Xfid{c: make(chan func(*Xfid))}
 	defer close(x.c)
-	go xfidctl(x, edwoodtest.NewDisplay())
+	go xfidctl(x, edwoodtest.NewDisplay(image.Rectangle{}))
 
 	called := false
 	x.c <- func(x *Xfid) { called = true }
@@ -255,7 +255,7 @@ func TestXfidwriteQWaddr(t *testing.T) {
 }
 
 func TestXfidopen(t *testing.T) {
-	display := edwoodtest.NewDisplay()
+	display := edwoodtest.NewDisplay(image.Rectangle{})
 	global.configureGlobals(display)
 
 	for _, tc := range []struct {
@@ -348,7 +348,7 @@ func TestXfidopenQeditout(t *testing.T) {
 }
 
 func TestXfidopenQWeditout(t *testing.T) {
-	global.configureGlobals(edwoodtest.NewDisplay())
+	global.configureGlobals(edwoodtest.NewDisplay(image.Rectangle{}))
 	mr := new(mockResponder)
 
 	x := &Xfid{
@@ -476,7 +476,7 @@ func TestXfidclose(t *testing.T) {
 				w = NewWindow().initHeadless(nil)
 				w.tag.fr = &MockFrame{}
 				w.body.fr = &MockFrame{}
-				w.body.display = edwoodtest.NewDisplay()
+				w.body.display = edwoodtest.NewDisplay(image.Rectangle{})
 				w.col = new(Column)
 				w.rdselfd = tmpfile
 				w.nomark = true
@@ -540,7 +540,7 @@ func TestXfidclose(t *testing.T) {
 }
 
 func TestXfidwriteQWdata(t *testing.T) {
-	display := edwoodtest.NewDisplay()
+	display := edwoodtest.NewDisplay(image.Rectangle{})
 	global.configureGlobals(display)
 
 	mr := new(mockResponder)
@@ -672,7 +672,7 @@ func TestXfidwriteQWtag(t *testing.T) {
 }
 
 func TestXfidwriteQWwrsel(t *testing.T) {
-	mockDisplay := edwoodtest.NewDisplay()
+	mockDisplay := edwoodtest.NewDisplay(image.Rectangle{})
 	global.configureGlobals(mockDisplay)
 
 	w := NewWindow().initHeadless(nil)
@@ -745,13 +745,13 @@ func TestXfidwriteQlabel(t *testing.T) {
 }
 
 func TestXfidwriteQcons(t *testing.T) {
-	global.configureGlobals(edwoodtest.NewDisplay())
+	global.configureGlobals(edwoodtest.NewDisplay(image.Rectangle{}))
 	mr := new(mockResponder)
 
 	global.row.Init(image.Rectangle{
 		image.Point{0, 0},
 		image.Point{800, 600},
-	}, edwoodtest.NewDisplay())
+	}, edwoodtest.NewDisplay(image.Rectangle{}))
 
 	data := []byte("cons error: Hello, 世界!\n")
 	x := &Xfid{
@@ -782,7 +782,7 @@ func TestXfidwriteQWerrors(t *testing.T) {
 	// be using a quality backing mock.
 	data := []byte("window error: Hello, 世界!\n")
 
-	mockdisplay := edwoodtest.NewDisplay()
+	mockdisplay := edwoodtest.NewDisplay(image.Rectangle{})
 	global.configureGlobals(mockdisplay)
 	mr := new(mockResponder)
 
@@ -892,7 +892,7 @@ func TestXfidwriteQWeditout(t *testing.T) {
 }
 
 func TestXfidwriteQWctl(t *testing.T) {
-	global.configureGlobals(edwoodtest.NewDisplay())
+	global.configureGlobals(edwoodtest.NewDisplay(image.Rectangle{}))
 	warnings = nil
 	global.cwarn = nil
 
@@ -943,7 +943,7 @@ func TestXfidwriteQWctl(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("Data=%q", tc.data), func(t *testing.T) {
 			mr := new(mockResponder)
-			display := edwoodtest.NewDisplay()
+			display := edwoodtest.NewDisplay(image.Rectangle{})
 			w := NewWindow().initHeadless(nil)
 			w.display = display
 			w.col = &Column{
@@ -1033,7 +1033,7 @@ func TestXfidwriteQWevent(t *testing.T) {
 // Issue https://github.com/rjkroege/edwood/issues/285
 func TestXfidwriteQWeventExecuteSend(t *testing.T) {
 	// Setup a new window with "Send" in the tag.
-	d := edwoodtest.NewDisplay()
+	d := edwoodtest.NewDisplay(image.Rectangle{})
 	global.row = Row{
 		display: d,
 	}
@@ -1120,7 +1120,7 @@ func TestXfidreadEmptyFiles(t *testing.T) {
 func TestXfidreadQWbodyQWtag(t *testing.T) {
 	// TODO(rjk): These tests are fragile in how they setup their skeleton.
 	// Use the common skeleton.
-	display := edwoodtest.NewDisplay()
+	display := edwoodtest.NewDisplay(image.Rectangle{})
 	global.configureGlobals(display)
 	const data = "This is an εxαmplε sentence.\n"
 
@@ -1316,7 +1316,7 @@ func TestXfidreadQWctl(t *testing.T) {
 	global.WinID = 0
 	w := NewWindow().initHeadless(nil)
 	w.col = new(Column)
-	w.display = edwoodtest.NewDisplay()
+	w.display = edwoodtest.NewDisplay(image.Rectangle{})
 	w.body.fr = &MockFrame{}
 	w.tag.file = file.MakeObservableEditableBuffer("", []rune(("/etc/hosts Del Snarf | Look Get ")))
 	w.body.file = file.MakeObservableEditableBuffer("", []rune("Hello, world!\n"))


### PR DESCRIPTION
Extend the edwoodtest mock devdraw to support emitting HTML/SVG files
that visualize the requested draw operations. Record these
visualizations from the frame tests. Use validated visualizations as
test baselines.
