### PR TITLE
Spaces in names

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -583,6 +583,7 @@ func put(et *Text, _0 *Text, argt *Text, _1 bool, _2 bool, arg string) {
 		warning(nil, "no file name\n")
 		return
 	}
+	name = file.UnquoteFilename(name)
 	putfile(w.body.file, 0, f.Nr(), name)
 	xfidlog(w, "put")
 }

--- a/exec.go
+++ b/exec.go
@@ -583,7 +583,7 @@ func put(et *Text, _0 *Text, argt *Text, _1 bool, _2 bool, arg string) {
 		warning(nil, "no file name\n")
 		return
 	}
-	name = file.UnquoteFilename(name)
+	name = UnquoteFilename(name)
 	putfile(w.body.file, 0, f.Nr(), name)
 	xfidlog(w, "put")
 }

--- a/file/observable_editable_buffer.go
+++ b/file/observable_editable_buffer.go
@@ -307,7 +307,7 @@ func (e *ObservableEditableBuffer) Insert(p0 OffsetTuple, s []byte, nr int) {
 }
 
 func QuoteFilename(name string) string {
-	if strings.ContainsAny(name, " \t\\") {
+	if strings.ContainsAny(name, " \t") {
 		return "'" + name + "'"
 	}
 	return name

--- a/file/observable_editable_buffer.go
+++ b/file/observable_editable_buffer.go
@@ -306,22 +306,6 @@ func (e *ObservableEditableBuffer) Insert(p0 OffsetTuple, s []byte, nr int) {
 	e.inserted(p0, s, nr)
 }
 
-func QuoteFilename(name string) string {
-	if strings.ContainsAny(name, " \t") {
-		return "'" + name + "'"
-	}
-	return name
-}
-
-func UnquoteFilename(s string) string {
-	if len(s) > 0 && s[0] == '\'' {
-		if s[len(s)-1] == '\'' {
-			return s[1 : len(s)-1]
-		}
-	}
-	return s
-}
-
 // SetName sets the name of the backing for this file. Some backing names
 // are "virtual": the name is displayed in the ObservableEditableBuffer's
 // corresponding tag but there is no backing. Setting e's name to its

--- a/file/observable_editable_buffer.go
+++ b/file/observable_editable_buffer.go
@@ -306,6 +306,22 @@ func (e *ObservableEditableBuffer) Insert(p0 OffsetTuple, s []byte, nr int) {
 	e.inserted(p0, s, nr)
 }
 
+func QuoteFilename(name string) string {
+	if strings.ContainsAny(name, " \t\\") {
+		return "'" + name + "'"
+	}
+	return name
+}
+
+func UnquoteFilename(s string) string {
+	if len(s) > 0 && s[0] == '\'' {
+		if s[len(s)-1] == '\'' {
+			return s[1:len(s)-1]
+		}
+	}
+	return s
+}
+
 // SetName sets the name of the backing for this file. Some backing names
 // are "virtual": the name is displayed in the ObservableEditableBuffer's
 // corresponding tag but there is no backing. Setting e's name to its

--- a/file/observable_editable_buffer.go
+++ b/file/observable_editable_buffer.go
@@ -316,7 +316,7 @@ func QuoteFilename(name string) string {
 func UnquoteFilename(s string) string {
 	if len(s) > 0 && s[0] == '\'' {
 		if s[len(s)-1] == '\'' {
-			return s[1:len(s)-1]
+			return s[1 : len(s)-1]
 		}
 	}
 	return s

--- a/guide
+++ b/guide
@@ -1,3 +1,6 @@
+Get needs to quote filenames
+Look needs to respect quotes around filenames
+
 // Basics
 Edit X:edwood/\+Errors: 1,$d
 X:edwood/.*\.go: w

--- a/look.go
+++ b/look.go
@@ -415,7 +415,7 @@ func expandfile(t *Text, q0 int, q1 int, e *Expand) (success bool) {
 			// TODO(rjk): utf8 conversion work.
 			for q1 < t.file.Nr() {
 				c := t.ReadC(q1)
-				if !isfilec(c) && !isfilespace(c) {
+				if !isfilec(c) {
 					break
 				}
 				if c == ':' {

--- a/look.go
+++ b/look.go
@@ -391,6 +391,8 @@ func expandfile(t *Text, q0 int, q1 int, e *Expand) (success bool) {
 				cq1 := qq1
 				c := t.ReadC(cq1)
 				if c != ':' { // We don't have any address information here.  Just return e.
+					e.q0 = qq0
+					e.q1 = qq1
 					return true
 				}
 				cq1++

--- a/look.go
+++ b/look.go
@@ -325,6 +325,7 @@ func cleanrname(rs []rune) []rune {
 func findquotedcontext(t *Text, q0 int) (qq0, qq1 int) {
 	qq0 = q0
 	qq1 = q0
+	foundquote := false
 	for qq0 > 0 {
 		c := t.ReadC(qq0)
 		if c == '\'' {
@@ -336,6 +337,7 @@ func findquotedcontext(t *Text, q0 int) (qq0, qq1 int) {
 		}
 		qq0--
 	}
+	if !foundquote { return q0, q0 }
 	for qq1 < t.file.Nr() {
 		c := t.ReadC(qq1 - 1)
 		if c == '\'' {

--- a/look.go
+++ b/look.go
@@ -337,11 +337,13 @@ func findquotedcontext(t *Text, q0 int) (qq0, qq1 int) {
 		}
 		qq0--
 	}
-	if !foundquote { return q0, q0 }
+	if !foundquote {
+		return q0, q0
+	}
 	for qq1 < t.file.Nr() {
 		c := t.ReadC(qq1 - 1)
 		if c == '\'' {
-			qq1-- 	// remove final quote
+			qq1-- // remove final quote
 			break
 		}
 		if !isfilec(c) && c != ' ' && c != '\t' {
@@ -362,12 +364,12 @@ func expandfile(t *Text, q0 int, q1 int, e *Expand) (success bool) {
 				// We have a file.  If we have a colon following our qq1+1 quote
 				// we have to get it and add it to Expand.
 				// Invariant: qq0-1 and qq1 + 1 are '
-				cq1 := qq1+1
+				cq1 := qq1 + 1
 				c := t.ReadC(cq1)
-				if c != ':' {  // We don't have any address information here.  Just return e.
+				if c != ':' { // We don't have any address information here.  Just return e.
 					return true
 				}
-				cq1++ 
+				cq1++
 				// collect the address
 				e.a0 = cq1
 				for cq1 < t.file.Nr() {
@@ -379,7 +381,7 @@ func expandfile(t *Text, q0 int, q1 int, e *Expand) (success bool) {
 				}
 				e.a1 = cq1
 			}
-		} 
+		}
 		colon := int(-1)
 		// TODO(rjk): utf8 conversion work.
 		for q1 < t.file.Nr() {

--- a/look.go
+++ b/look.go
@@ -331,9 +331,29 @@ func findquotedcontext(t *Text, q0 int) (qq0, qq1 int) {
 	qq0 = q0
 	qq1 = q0
 	foundquote := false
+	foundcolon := false
 	for qq0 >= 0 {
 		c := t.ReadC(qq0)
+		if c == ':' {
+			// We are looking for the case where the click
+			// happened in an address, in which case we aren't (yet)
+			// in a quoted context.
+			foundcolon = true
+			qq0--
+			continue
+		}
+		if foundcolon && !foundquote && c != '\'' {
+			qq0++
+			break
+		}
 		if c == '\'' {
+			if foundcolon {
+				foundquote = true
+				foundcolon = false // we no longer care about the colon
+				qq1 = qq0          // Make the search rightward start from within the quotes.
+				qq0--
+				continue // Keep marching leftwards;
+			}
 			foundquote = true
 			break
 		}

--- a/look.go
+++ b/look.go
@@ -537,11 +537,11 @@ func expand(t *Text, q0 int, q1 int) (*Expand, bool) {
 
 func lookfile(s string) *Window {
 	// avoid terminal slash on directories
-	s = file.UnquoteFilename(s)
+	s = UnquoteFilename(s)
 	s = strings.TrimRight(s, "/")
 	for _, c := range global.row.col {
 		for _, w := range c.w {
-			name := file.UnquoteFilename(w.body.file.Name())
+			name := UnquoteFilename(w.body.file.Name())
 			k := strings.TrimRight(name, "/")
 			if k == s {
 				cur, ok := w.body.file.GetCurObserver().(*Text)

--- a/look.go
+++ b/look.go
@@ -304,10 +304,7 @@ func search(ct *Text, r []rune) bool {
 
 func isfilespace(r rune) bool {
 	Lx := " \t"
-	if strings.ContainsRune(Lx, r) {
-		return true
-	}
-	return false
+	return strings.ContainsRune(Lx, r)
 }
 
 func isfilec(r rune) bool {

--- a/look_test.go
+++ b/look_test.go
@@ -41,7 +41,11 @@ func TestExpand(t *testing.T) {
 		{true, 0, "'testdata/has a space in name.txt':42", 36, "'testdata/has a space in name.txt':42", "testdata/has a space in name.txt", "42"},
 
 		{true, 0, "'testdata/has a space in name.txt':42", 2, "'testdata/has a space in name.txt':42", "testdata/has a space in name.txt", "42"},
+		{true, 0, "'testdata/has a space in name.txt'junk", 2, "'testdata/has a space in name.txt'", "testdata/has a space in name.txt", ""},
+		{true, 0, "'testdata/has a space in name.txt':42\\asdf", 2, "'testdata/has a space in name.txt':42", "testdata/has a space in name.txt", "42"},
 		{true, 0, "look_test.go ", 2, "look_test.go", "look_test.go", ""},
+		{true, 0, "here's some \\junk", 8, "some", "", ""},
+		{true, 0, "some junk'", 2, "some", "", ""},
 		{false, 0, "     ", 2, "", "", ""},
 		{false, 0, "@@@@", 2, "", "", ""},
 		{true, 0, "hello", 2, "hello", "", ""},

--- a/look_test.go
+++ b/look_test.go
@@ -38,6 +38,8 @@ func TestExpand(t *testing.T) {
 		name string
 		addr string
 	}{
+		{true, 0, "'testdata/has a space in name.txt':42", 36, "'testdata/has a space in name.txt':42", "testdata/has a space in name.txt", "42"},
+
 		{true, 0, "'testdata/has a space in name.txt':42", 2, "'testdata/has a space in name.txt':42", "testdata/has a space in name.txt", "42"},
 		{false, 0, "     ", 2, "", "", ""},
 		{false, 0, "@@@@", 2, "", "", ""},

--- a/look_test.go
+++ b/look_test.go
@@ -38,6 +38,7 @@ func TestExpand(t *testing.T) {
 		name string
 		addr string
 	}{
+		{true, 0, "'testdata/has a space in name.txt':42", 2, "'testdata/has a space in name.txt':42", "testdata/has a space in name.txt", "42"},
 		{false, 0, "     ", 2, "", "", ""},
 		{false, 0, "@@@@", 2, "", "", ""},
 		{true, 0, "hello", 2, "hello", "", ""},

--- a/look_test.go
+++ b/look_test.go
@@ -41,6 +41,7 @@ func TestExpand(t *testing.T) {
 		{true, 0, "'testdata/has a space in name.txt':42", 36, "'testdata/has a space in name.txt':42", "testdata/has a space in name.txt", "42"},
 
 		{true, 0, "'testdata/has a space in name.txt':42", 2, "'testdata/has a space in name.txt':42", "testdata/has a space in name.txt", "42"},
+		{true, 0, "look_test.go ", 2, "look_test.go", "look_test.go", ""},
 		{false, 0, "     ", 2, "", "", ""},
 		{false, 0, "@@@@", 2, "", "", ""},
 		{true, 0, "hello", 2, "hello", "", ""},

--- a/tagindex.go
+++ b/tagindex.go
@@ -45,7 +45,7 @@ func (w *Window) ParseTag() string {
 	w.tag.file.Read(0, fnr)
 	sfnr := string(fnr)
 	if len(sfnr) > 0 && sfnr[0] == '\'' {
-		return file.UnquoteFilename(sfnr)
+		return UnquoteFilename(sfnr)
 	}
 	return sfnr
 }
@@ -202,11 +202,11 @@ func (w *Window) setTag1() {
 	// number of calls to setTag1.
 
 	var sb strings.Builder
-	sb.WriteString(file.QuoteFilename(w.body.file.Name()))
+	sb.WriteString(QuoteFilename(w.body.file.Name()))
 	sb.WriteString(Ldelsnarf)
 
 	oldfnend := w.tagfilenameend
-	w.tagfilenameend = utf8.RuneCountInString(file.QuoteFilename(w.body.file.Name()))
+	w.tagfilenameend = utf8.RuneCountInString(QuoteFilename(w.body.file.Name()))
 
 	if w.filemenu {
 		if w.body.file.HasUndoableChanges() {

--- a/tagindex.go
+++ b/tagindex.go
@@ -44,12 +44,38 @@ func (w *Window) ParseTag() string {
 	fnr := make([]rune, w.tagfilenameend)
 	w.tag.file.Read(0, fnr)
 	sfnr := string(fnr)
+	if len(sfnr) > 0 && sfnr[0] == '\'' {
+		return file.UnquoteFilename(sfnr)
+	}
 	return sfnr
 }
 
 // TODO(rjk): Consider using a regexp for this function?
+// returns the filename text scraped from the tag, including any quoting.
 func parsetaghelper(tag string) string {
 	// " |" or "\t|" ends left half of tag
+	// PAL: Filenames start at the start of the tag.  A filename in the tag may be
+	// surrounded by single quotes, at which time the filename ends at the matching quote.
+	// Otherwise the filename ends at the first space.
+	if len(tag) == 0 {
+		return ""
+	}
+	if tag[0] == '\'' {
+		endquoteidx := strings.Index(tag[1:], "'")
+		if  endquoteidx >= 0 {
+			return tag[0:endquoteidx+2]
+		}
+	}
+
+	// The filename ends at a space
+	endidx := strings.IndexAny(tag, " \t")
+	if endidx == -1 {
+		// our tag is all one word.  Unusual, but ok.
+		return tag
+	}
+	return tag[0:endidx]
+/*
+
 	// If we find " Del Snarf" in the left half of the tag
 	// (before the pipe), that ends the file name.
 	pipe := strings.Index(tag, " |")
@@ -66,6 +92,7 @@ func parsetaghelper(tag string) string {
 		return tag[:i]
 	}
 	return tag
+*/
 }
 
 // NB the sequencing: carefully. actions happen on the body. The result
@@ -171,11 +198,11 @@ func (w *Window) setTag1() {
 	// number of calls to setTag1.
 
 	var sb strings.Builder
-	sb.WriteString(w.body.file.Name())
+	sb.WriteString(file.QuoteFilename(w.body.file.Name()))
 	sb.WriteString(Ldelsnarf)
 
 	oldfnend := w.tagfilenameend
-	w.tagfilenameend = utf8.RuneCountInString(w.body.file.Name())
+	w.tagfilenameend = utf8.RuneCountInString(file.QuoteFilename(w.body.file.Name()))
 
 	if w.filemenu {
 		if w.body.file.HasUndoableChanges() {

--- a/tagindex.go
+++ b/tagindex.go
@@ -62,8 +62,8 @@ func parsetaghelper(tag string) string {
 	}
 	if tag[0] == '\'' {
 		endquoteidx := strings.Index(tag[1:], "'")
-		if  endquoteidx >= 0 {
-			return tag[0:endquoteidx+2]
+		if endquoteidx >= 0 {
+			return tag[0 : endquoteidx+2]
 		}
 	}
 
@@ -74,25 +74,29 @@ func parsetaghelper(tag string) string {
 		return tag
 	}
 	return tag[0:endidx]
-/*
+	/*
+	   // If we find " Del Snarf" in the left half of the tag
+	   // (before the pipe), that ends the file name.
+	   pipe := strings.Index(tag, " |")
 
-	// If we find " Del Snarf" in the left half of the tag
-	// (before the pipe), that ends the file name.
-	pipe := strings.Index(tag, " |")
-	if i := strings.Index(tag, "\t|"); i >= 0 && (pipe < 0 || i < pipe) {
-		pipe = i
-	}
-	// It's arguable that we should not permit the creation of filenames with
-	// a trailing space in their names because the likelihood of doing this
-	// by accident is higher than the number of times that this is desirable.
-	if i := strings.Index(tag, " Del Snarf"); i >= 0 && (pipe < 0 || i < pipe) {
-		return tag[:i]
-	}
-	if i := strings.IndexAny(tag, " \t"); i >= 0 {
-		return tag[:i]
-	}
-	return tag
-*/
+	   	if i := strings.Index(tag, "\t|"); i >= 0 && (pipe < 0 || i < pipe) {
+	   		pipe = i
+	   	}
+
+	   // It's arguable that we should not permit the creation of filenames with
+	   // a trailing space in their names because the likelihood of doing this
+	   // by accident is higher than the number of times that this is desirable.
+
+	   	if i := strings.Index(tag, " Del Snarf"); i >= 0 && (pipe < 0 || i < pipe) {
+	   		return tag[:i]
+	   	}
+
+	   	if i := strings.IndexAny(tag, " \t"); i >= 0 {
+	   		return tag[:i]
+	   	}
+
+	   return tag
+	*/
 }
 
 // NB the sequencing: carefully. actions happen on the body. The result

--- a/tagindex_test.go
+++ b/tagindex_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestParseTagHelper(t *testing.T) {
+	tests := []struct {
+		offered, expected string
+	}{
+		{"''", "''"},
+		{"This is a busted tag Del Snarf | Look","This"},
+		{"'This is a newfangled tag' Del Snarf | Look","'This is a newfangled tag'"},
+	}
+
+	for _, v := range tests {
+		returned := parsetaghelper(v.offered)
+		if returned != v.expected {
+			t.Errorf("Tag [%s]: expected [%s], got [%s]", v.offered, v.expected, returned)
+		}
+	}
+}

--- a/tagindex_test.go
+++ b/tagindex_test.go
@@ -20,3 +20,32 @@ func TestParseTagHelper(t *testing.T) {
 		}
 	}
 }
+
+func TestQuoteFilename(t *testing.T) {
+	for _, tc := range []struct {
+		in, out string
+	}{
+		{"quote me", "'quote me'"},
+		{"dontquoteme\\", "dontquoteme\\"},
+		{" quote me", "' quote me'"},
+		{"quote me ", "'quote me '"},
+		{"'dontrequoteme'", "'dontrequoteme'"},
+	} {
+		if qt := QuoteFilename(tc.in); qt != tc.out {
+			t.Errorf("QuoteFilename failed: Expected [%v] got [%v]", tc.out, qt)
+		}
+	}
+}
+
+func TestUnquoteFilename(t *testing.T) {
+	for _, tc := range []struct {
+		out, in string
+	}{
+		{"unquote me", "'unquote me'"},
+		{"dontunquoteme\\", "dontunquoteme\\"},
+	} {
+		if qt := UnquoteFilename(tc.in); qt != tc.out {
+			t.Errorf("UnquoteFilename failed: Expected [%v] got [%v]", tc.out, qt)
+		}
+	}
+}

--- a/tagindex_test.go
+++ b/tagindex_test.go
@@ -9,8 +9,8 @@ func TestParseTagHelper(t *testing.T) {
 		offered, expected string
 	}{
 		{"''", "''"},
-		{"This is a busted tag Del Snarf | Look","This"},
-		{"'This is a newfangled tag' Del Snarf | Look","'This is a newfangled tag'"},
+		{"This is a busted tag Del Snarf | Look", "This"},
+		{"'This is a newfangled tag' Del Snarf | Look", "'This is a newfangled tag'"},
 	}
 
 	for _, v := range tests {

--- a/testdata/example.index
+++ b/testdata/example.index
@@ -1,5 +1,5 @@
           1          32         162           0           1 glass Del Snarf Put | Look Edit 
           3          68         183           0           0 /home/gopher/go/src/edwood/testdata/こんにちは.txt Del Snarf | Look Edit 
-          4          63         128           1           0 /home/gopher/go/src/edwood/testdata/ Del Snarf Get | Look Edit 
+          4          63         154           1           0 /home/gopher/go/src/edwood/testdata/ Del Snarf Get | Look Edit 
           5          67          70           0           0 /home/gopher/go/src/edwood/testdata/hello.go Del Snarf | Look Edit 
           6          23          25           0           1  Del Snarf | Look Edit 

--- a/testdata/multi-line-tag.index
+++ b/testdata/multi-line-tag.index
@@ -1,3 +1,3 @@
           2         112          70           0           0 /home/gopher/go/src/edwood/testdata/hello.go Del Snarf | Look Edit The first line
-          3         108         132           1           0 /home/gopher/go/src/edwood/testdata/ Del Snarf Get | Look Edit The first line
+          3         108         166           1           0 /home/gopher/go/src/edwood/testdata/ Del Snarf Get | Look Edit The first line
           4          75           6           0           1 foo Del Snarf Put | Look Edit The first line

--- a/text.go
+++ b/text.go
@@ -370,7 +370,7 @@ func getDirNames(f *os.File) ([]string, error) {
 	}
 	sort.Strings(names)
 	for i := range names {
-		names[i] = file.QuoteFilename(names[i])
+		names[i] = QuoteFilename(names[i])
 	}
 	return names, nil
 }
@@ -1666,4 +1666,22 @@ func (t *Text) AbsDirName(name string) string {
 // debugging.
 func (t *Text) DebugString() string {
 	return fmt.Sprintf("t.what (kind): %s contents: %q", t.what, t.file.String())
+}
+
+// TODO(PAL): This probably wants to check for ' in the filename
+// and escape it - that would mean understanding \ escapes in Look.
+func QuoteFilename(name string) string {
+	if strings.ContainsAny(name, " \t") {
+		return "'" + name + "'"
+	}
+	return name
+}
+
+func UnquoteFilename(s string) string {
+	if len(s) > 0 && s[0] == '\'' {
+		if s[len(s)-1] == '\'' {
+			return s[1 : len(s)-1]
+		}
+	}
+	return s
 }

--- a/text.go
+++ b/text.go
@@ -369,6 +369,9 @@ func getDirNames(f *os.File) ([]string, error) {
 		}
 	}
 	sort.Strings(names)
+	for i := range names {
+		names[i] = file.QuoteFilename(names[i])
+	}
 	return names, nil
 }
 
@@ -1636,6 +1639,7 @@ func (t *Text) dirName(name string) string {
 		return name
 	}
 	spl := t.w.ParseTag()
+
 	if !strings.HasSuffix(spl, string(filepath.Separator)) {
 		spl = filepath.Dir(spl)
 	}

--- a/text_test.go
+++ b/text_test.go
@@ -292,8 +292,8 @@ func TestTextDirName(t *testing.T) {
 		{"RelativeFile,file=''", windowWithTag("a/b/c/d.go Del Snarf | Look "), "", "a/b/c"},
 		{"RelativeFile", windowWithTag("a/b/c/d.go Del Snarf | Look "), "e.go", "a/b/c/e.go"},
 		{"IgnoreTag", windowWithTag("/a/b/c/d.go Del Snarf | Look "), "/x/e.go", "/x/e.go"},
-		{"FileWithSpace", windowWithTag("/a/b c/d.go Del Snarf | Look "), "/a/b c/d.go", "/a/b c/d.go"},
-		{"DirWithSpace", windowWithTag("/a/b c/ Del Snarf | Look "), "", "/a/b c"},
+		{"FileWithSpace", windowWithTag("'/a/b c/d.go' Del Snarf | Look "), "/a/b c/d.go", "/a/b c/d.go"},
+		{"DirWithSpace", windowWithTag("'/a/b c/' Del Snarf | Look "), "", "/a/b c"},
 	}
 
 	for _, tc := range tt {

--- a/wind_test.go
+++ b/wind_test.go
@@ -85,13 +85,13 @@ func TestWindowParseTag(t *testing.T) {
 		filename string
 	}{
 		{"/foo/bar.txt Del Snarf | Look", "/foo/bar.txt"},
-		{"/foo/bar quux.txt Del Snarf | Look", "/foo/bar quux.txt"},
+		{"'/foo/bar quux.txt' Del Snarf | Look", "'/foo/bar quux.txt'"},
 		{"/foo/bar.txt", "/foo/bar.txt"},
 		{"/foo/bar.txt | Look", "/foo/bar.txt"},
 		{"/foo/bar.txt Del Snarf\t| Look", "/foo/bar.txt"},
 		{"/foo/bar.txt Del Snarf Del Snarf", "/foo/bar.txt"},
-		{"/foo/bar.txt  Del Snarf", "/foo/bar.txt "},
-		{"/foo/b|ar.txt  Del Snarf", "/foo/b|ar.txt "},
+		{"'/foo/bar.txt ' Del Snarf", "'/foo/bar.txt '"},
+		{"'/foo/b|ar.txt ' Del Snarf", "'/foo/b|ar.txt '"},
 	} {
 		if got, want := parsetaghelper(tc.tag), tc.filename; got != want {
 			t.Errorf("tag %q has filename %q; want %q", tc.tag, got, want)


### PR DESCRIPTION
Get on a directory now wraps filenames with spaces with single quotes.
Tag of a file with a space in the name now has the filename surrounded by single quotes.
Look now tries to find a file between single quotes, and correctly extends to an address suffix: 'a b':/foo