### PR TITLE
Windows filename handling

### DIFF
--- a/expandfile.go
+++ b/expandfile.go
@@ -1,0 +1,203 @@
+//go:build !windows
+package main
+
+// PAL: If our q1==q0 selection is within ' chars, we check if it's a filename, otherwise fall
+// back to our original selection code.  Returns the quoted string.
+func findquotedcontext(t *Text, q0 int) (qq0, qq1 int) {
+	qq0 = q0
+	qq1 = q0
+	foundquote := false
+	foundcolon := false
+	for qq0 >= 0 {
+		c := t.ReadC(qq0)
+		if c == ':' {
+			// We are looking for the case where the click
+			// happened in an address, in which case we aren't (yet)
+			// in a quoted context.
+			foundcolon = true
+			qq0--
+			continue
+		}
+		if foundcolon && !foundquote && c != '\'' {
+			qq0++
+			break
+		}
+		if c == '\'' {
+			if foundcolon {
+				foundquote = true
+				foundcolon = false // we no longer care about the colon
+				qq1 = qq0          // Make the search rightward start from within the quotes.
+				qq0--
+				continue // Keep marching leftwards;
+			}
+			foundquote = true
+			break
+		}
+		if !isfilec(c) && !isfilespace(c) {
+			return q0, q0 // No quote found leftward.
+		}
+		qq0--
+	}
+	if !foundquote {
+		return q0, q0
+	}
+	for qq1 < t.file.Nr() {
+		c := t.ReadC(qq1 - 1)
+		if c == '\'' {
+			break
+		}
+		if !isfilec(c) && !isfilespace(c) {
+			return q0, q0 // No quote found rightwards.
+		}
+		qq1++
+	}
+	return qq0, qq1
+}
+
+func expandfile(t *Text, q0 int, q1 int, e *Expand) (success bool) {
+	amax := q1
+	if q1 == q0 {
+		// Check for being in a quoted string, find out if its a file.
+		qq0, qq1 := findquotedcontext(t, q0)
+		if qq0 != qq1 {
+			// Invariant: qq0 and qq1-1 are '
+			if expandfile(t, qq0+1, qq1-1, e) {
+				// We have a file.  If we have a colon following our qq1+1 quote
+				// we have to get it and add it to Expand.
+				cq1 := qq1
+				c := t.ReadC(cq1)
+				if c != ':' { // We don't have any address information here.  Just return e.
+					e.q0 = qq0
+					e.q1 = qq1
+					return true
+				}
+				cq1++
+				// collect the address
+				e.a0 = cq1
+				for cq1 < t.file.Nr() {
+					c := t.ReadC(cq1)
+					if !isaddrc(c) && !isregexc(c) && c != '\'' {
+						break
+					}
+					cq1++
+				}
+				e.a1 = cq1
+				q0 = qq0
+				q1 = cq1
+				e.q0 = q0
+				e.q1 = q1
+				return true
+			}
+		} else {
+			colon := int(-1)
+			// TODO(rjk): utf8 conversion work.
+			for q1 < t.file.Nr() {
+				c := t.ReadC(q1)
+				if !isfilec(c) {
+					break
+				}
+				if c == ':' {
+					colon = q1
+					break
+				}
+				q1++
+			}
+			for q0 > 0 {
+				c := t.ReadC(q0 - 1)
+				if !isfilec(c) && !isaddrc(c) && !isregexc(c) {
+					break
+				}
+				if colon < 0 && c == ':' {
+					colon = q0 - 1
+				}
+				q0--
+			}
+			// if it looks like it might begin file: , consume address chars after :
+			// otherwise terminate expansion at :
+			if colon >= 0 {
+				q1 = colon
+				if colon < t.file.Nr()-1 {
+					c := t.ReadC(colon + 1)
+					if isaddrc(c) {
+						q1 = colon + 1
+						for q1 < t.file.Nr() {
+							c := t.ReadC(q1)
+							if !isaddrc(c) {
+								break
+							}
+							q1++
+						}
+					}
+				}
+			}
+			if q1 > q0 {
+				if colon >= 0 { // stop at white space
+					for amax = colon + 1; amax < t.file.Nr(); amax++ {
+						c := t.ReadC(amax)
+						if c == ' ' || c == '\t' || c == '\n' {
+							break
+						}
+					}
+				} else {
+					amax = t.file.Nr()
+				}
+			}
+		}
+	}
+	amin := amax
+	e.q0 = q0
+	e.q1 = q1
+	n := q1 - q0
+	if n == 0 {
+		return false
+	}
+	// see if it's a file name
+	rb := make([]rune, n)
+	t.file.Read(q0, rb[:n])
+	// first, does it have bad chars?
+	nname := -1
+	for i, c := range rb {
+		if c == ':' && nname < 0 {
+			if q0+i+1 >= t.file.Nr() {
+				return false
+			}
+			if i != n-1 {
+				if cc := t.ReadC(q0 + i + 1); !isaddrc(cc) {
+					return false
+				}
+			}
+			amin = q0 + i
+			nname = i
+		}
+	}
+	if nname == -1 {
+		nname = n
+	}
+	for i := 0; i < nname; i++ {
+		if !isfilec(rb[i]) && rb[i] != ' ' {
+			return false
+		}
+	}
+	isFile := func(name string) bool {
+		e.name = name
+		e.at = t
+		e.a0 = amin + 1
+		_, _, e.a1 = address(true, nil, Range{-1, -1}, Range{0, 0}, e.a0, amax,
+			func(q int) rune { return t.ReadC(q) }, false)
+		return true
+	}
+	s := string(rb[:nname])
+	if amin == q0 {
+		return isFile(s)
+	}
+	dname := t.DirName(s)
+	// if it's already a window name, it's a file
+	if lookfile(dname) != nil {
+		return isFile(dname)
+	}
+	// if it's the name of a file, it's a file
+	if ismtpt(dname) || !access(dname) {
+		return false
+	}
+	return isFile(dname)
+}

--- a/expandfile.go
+++ b/expandfile.go
@@ -1,4 +1,5 @@
 //go:build !windows
+
 package main
 
 // PAL: If our q1==q0 selection is within ' chars, we check if it's a filename, otherwise fall

--- a/expandfile_win.go
+++ b/expandfile_win.go
@@ -10,6 +10,11 @@ import (
 // back to our original selection code.  Returns the quoted string.
 
 // Interesting parts: Group 2 is the filename/name, group 9 is the address
+const (
+	filenameGroup = 2
+	addressGroup  = 9
+)
+
 var filenameRE = regexp.MustCompileAcme(`((([a-zA-Z]:|((\\\\|//)[a-zA-Z0-9.]*))?((\\|/)?[^<>:*|?"'\n]*)*))(:([0-9]+|(/[^ ']+)))?`)
 
 // Interesting parts: Group 2 is the path/name; group 9 is the address
@@ -109,15 +114,15 @@ func expandfile(t *Text, q0 int, q1 int, e *Expand) (success bool) {
 	amax := q1
 	amin := amax
 	filename := ""
-	if found != nil && found[0][4] != -1 {
-		nname = found[0][5] - found[0][4]
-		filename = string(rb[found[0][4]:found[0][5]])
-		e.q0 = q0 + found[0][4]
-		e.q1 = q1 + found[0][5]
+	if found != nil && found[0][2*filenameGroup] != -1 {
+		nname = found[0][2*filenameGroup+1] - found[0][2*filenameGroup]
+		filename = string(rb[found[0][2*filenameGroup]:found[0][2*filenameGroup+1]])
+		e.q0 = q0 + found[0][2*filenameGroup]
+		e.q1 = q1 + found[0][2*filenameGroup+1]
 	}
-	if found != nil && found[0][18] != -1 {
-		amin = found[0][18] + q0
-		amax = found[0][19] + q0
+	if found != nil && found[0][2*addressGroup] != -1 {
+		amin = found[0][2*addressGroup] + q0
+		amax = found[0][2*addressGroup+1] + q0
 		e.a0 = amin
 		e.a1 = amax
 	}

--- a/expandfile_win.go
+++ b/expandfile_win.go
@@ -15,8 +15,7 @@ var filenameRE = regexp.MustCompileAcme(`((([a-zA-Z]:|((\\\\|//)[a-zA-Z0-9.]*))?
 
 var quotedfilenameRE = regexp.MustCompileAcme(`('([a-zA-Z]:|((\\\\|//)[a-zA-Z0-9.]*))?((\\|/)?[^<>:*|?"\n]*)*')(:([0-9]+|(/[^ ']+)))?`)
 
-func findquotedcontext(t *Text, q0 int) (qq0, qq1 int) {
-	// Let's try a radical departure.  Start by getting a line.
+func getline(t *Text, q0 int) (qq0, qq1 int) {
 	qq0 = q0
 	qq1 = q0
 	for qq0 > 0 {
@@ -33,12 +32,18 @@ func findquotedcontext(t *Text, q0 int) (qq0, qq1 int) {
 		}
 		qq1++
 	}
+	return qq0, qq1
+}
+
+func findquotedcontext(t *Text, q0 int) (qq0, qq1 int) {
+	// Let's try a radical departure.  Start by getting a line.
+	qq0, qq1 = getline(t, q0)
 	if qq1 == qq0 { return q0, q0 }
 
 	n := qq1 - qq0
 	rb := make([]rune, n)
 	t.file.Read(qq0, rb[:n])
-	
+
 	found := quotedfilenameRE.FindForward(rb, 0, n, -1)
 	for _, pair := range found {
 		// qq0 is zero of the range returned.
@@ -51,116 +56,61 @@ func findquotedcontext(t *Text, q0 int) (qq0, qq1 int) {
 }
 
 func expandfile(t *Text, q0 int, q1 int, e *Expand) (success bool) {
-	amax := q1
-	if q1 == q0 {
-		// Check for being in a quoted string, find out if its a file.
-		qq0, qq1 := findquotedcontext(t, q0)
-		if qq0 != qq1 {
-			// Invariant: qq0 and qq1-1 are '
-			if expandfile(t, qq0+1, qq1-1, e) {
-				// We have a file.  If we have a colon following our qq1+1 quote
-				// we have to get it and add it to Expand.
-				cq1 := qq1
-				c := t.ReadC(cq1)
-				if c != ':' { // We don't have any address information here.  Just return e.
-					e.q0 = qq0
-					e.q1 = qq1
-					return true
-				}
-				cq1++
-				// collect the address
-				e.a0 = cq1
-				for cq1 < t.file.Nr() {
-					c := t.ReadC(cq1)
-					if !isaddrc(c) && !isregexc(c) && c != '\'' {
-						break
-					}
-					cq1++
-				}
-				e.a1 = cq1
-				q0 = qq0
-				q1 = cq1
-				e.q0 = q0
-				e.q1 = q1
-				return true
-			}
-		} else {
-			colon := int(-1)
-			// TODO(rjk): utf8 conversion work.
-			for q1 < t.file.Nr() {
-				c := t.ReadC(q1)
-				if !isfilec(c) {
-					break
-				}
-				if c == ':' {
-					colon = q1
-					break
-				}
-				q1++
-			}
-			for q0 > 0 {
-				c := t.ReadC(q0 - 1)
-				if !isfilec(c) && !isaddrc(c) && !isregexc(c) {
-					break
-				}
-				if colon < 0 && c == ':' {
-					colon = q0 - 1
-				}
-				q0--
-			}
-			// if it looks like it might begin file: , consume address chars after :
-			// otherwise terminate expansion at :
-			if colon >= 0 {
-				q1 = colon
-				if colon < t.file.Nr()-1 {
-					c := t.ReadC(colon + 1)
-					if isaddrc(c) {
-						q1 = colon + 1
-						for q1 < t.file.Nr() {
-							c := t.ReadC(q1)
-							if !isaddrc(c) {
-								break
-							}
-							q1++
-						}
-					}
-				}
-			}
-			if q1 > q0 {
-				if colon >= 0 { // stop at white space
-					for amax = colon + 1; amax < t.file.Nr(); amax++ {
-						c := t.ReadC(amax)
-						if c == ' ' || c == '\t' || c == '\n' {
-							break
-						}
-					}
-				} else {
-					amax = t.file.Nr()
-				}
+	n := 0
+	var found [][]int
+	var rb []rune
+	if q0 == q1 {
+		qq0, qq1 := getline(t, q0)
+		n = qq1 - qq0
+		if n == 0 {
+			return false
+		}
+		rb = make([]rune, n)
+		t.file.Read(qq0, rb[:n])
+		found = quotedfilenameRE.FindForward(rb, 0, n, 1)
+		if found == nil {
+			found = filenameRE.FindForward(rb, 0, n, 1)
+		}
+		for i, pair := range found {
+			// qq0 is zero of the range returned.
+			// The match is thus at qq0+pair[0:1], and (q0-qq0) must fall in that range
+			if q0-qq0 >= pair[0] && q0 - qq0 <= pair[1] {
+				q0, q1 = pair[0] + qq0, pair[1] + qq0
+				found = found[i:i+1]
+				break
 			}
 		}
-	}
-	amin := amax
-	e.q0 = q0
-	e.q1 = q1
-	n := q1 - q0
-	if n == 0 {
-		return false
-	}
-	// see if it's a file name
-	rb := make([]rune, n)
-	t.file.Read(q0, rb[:n])
+	} else {
+		n = q1 - q0
+		if n == 0 {
+			return false
+		}
+		rb = make([]rune, n)
+		t.file.Read(q0, rb[:n])
 
-	found := filenameRE.FindForward(rb, 0, n, 1)
-	if found == nil {
 		found = quotedfilenameRE.FindForward(rb, 0, n, 1)
+		if found == nil {
+			found = filenameRE.FindForward(rb, 0, n, 1)
+		}
+		if found != nil && found[0][0] != 0 {
+			return false
+		}
+	}
+	if found == nil {
+		return false
 	}
 	// Found now has a filename in group 2, address in group 9
 	nname := -1
+	e.q0 = q0
+	e.q1 = q1
+	amax := q1
+	amin := amax
 	filename := ""
 	if found != nil && found[0][4] != -1 {
 		nname = found[0][5]-found[0][4] 
 		filename = string(rb[found[0][4]:found[0][5]])
+		e.q0 = q0 + found[0][4]
+		e.q1 = q1 + found[0][5]
 	}
 	if found != nil && found[0][18] != -1 {
 		amin = found[0][18] + q0

--- a/expandfile_win.go
+++ b/expandfile_win.go
@@ -1,0 +1,196 @@
+//go:build windows
+package main
+
+import (
+	"github.com/rjkroege/edwood/regexp"
+)
+
+// PAL: If our q1==q0 selection is within ' chars, we check if it's a filename, otherwise fall
+// back to our original selection code.  Returns the quoted string.
+
+// Interesting parts: Group 2 is the filename/name, group 9 is the address
+var filenameRE = regexp.MustCompileAcme(`((([a-zA-Z]:|((\\\\|//)[a-zA-Z0-9.]*))?((\\|/)?[^<>:*|?"'\n]*)*))(:([0-9]+|(/[^ ']+)))?`)
+
+// Interesting parts: Group 2 is the path/name; group 9 is the address
+
+var quotedfilenameRE = regexp.MustCompileAcme(`('([a-zA-Z]:|((\\\\|//)[a-zA-Z0-9.]*))?((\\|/)?[^<>:*|?"\n]*)*')(:([0-9]+|(/[^ ']+)))?`)
+
+func findquotedcontext(t *Text, q0 int) (qq0, qq1 int) {
+	// Let's try a radical departure.  Start by getting a line.
+	qq0 = q0
+	qq1 = q0
+	for qq0 > 0 {
+		c := t.ReadC(qq0 - 1)
+		if c == '\n' {
+			break
+		}
+		qq0--
+	}
+	for qq1 < t.file.Nr() {
+		c := t.ReadC(qq1)
+		if c == '\n' {
+			break
+		}
+		qq1++
+	}
+	if qq1 == qq0 { return q0, q0 }
+
+	n := qq1 - qq0
+	rb := make([]rune, n)
+	t.file.Read(qq0, rb[:n])
+	
+	found := quotedfilenameRE.FindForward(rb, 0, n, -1)
+	for _, pair := range found {
+		// qq0 is zero of the range returned.
+		// The match is thus at qq0+pair[0:1], and (q0-qq0) must fall in that range
+		if q0-qq0 >= pair[0] && q0 - qq0 <= pair[1] {
+			return pair[0] + qq0, pair[1] + qq0
+		}
+	}
+	return q0, q0
+}
+
+func expandfile(t *Text, q0 int, q1 int, e *Expand) (success bool) {
+	amax := q1
+	if q1 == q0 {
+		// Check for being in a quoted string, find out if its a file.
+		qq0, qq1 := findquotedcontext(t, q0)
+		if qq0 != qq1 {
+			// Invariant: qq0 and qq1-1 are '
+			if expandfile(t, qq0+1, qq1-1, e) {
+				// We have a file.  If we have a colon following our qq1+1 quote
+				// we have to get it and add it to Expand.
+				cq1 := qq1
+				c := t.ReadC(cq1)
+				if c != ':' { // We don't have any address information here.  Just return e.
+					e.q0 = qq0
+					e.q1 = qq1
+					return true
+				}
+				cq1++
+				// collect the address
+				e.a0 = cq1
+				for cq1 < t.file.Nr() {
+					c := t.ReadC(cq1)
+					if !isaddrc(c) && !isregexc(c) && c != '\'' {
+						break
+					}
+					cq1++
+				}
+				e.a1 = cq1
+				q0 = qq0
+				q1 = cq1
+				e.q0 = q0
+				e.q1 = q1
+				return true
+			}
+		} else {
+			colon := int(-1)
+			// TODO(rjk): utf8 conversion work.
+			for q1 < t.file.Nr() {
+				c := t.ReadC(q1)
+				if !isfilec(c) {
+					break
+				}
+				if c == ':' {
+					colon = q1
+					break
+				}
+				q1++
+			}
+			for q0 > 0 {
+				c := t.ReadC(q0 - 1)
+				if !isfilec(c) && !isaddrc(c) && !isregexc(c) {
+					break
+				}
+				if colon < 0 && c == ':' {
+					colon = q0 - 1
+				}
+				q0--
+			}
+			// if it looks like it might begin file: , consume address chars after :
+			// otherwise terminate expansion at :
+			if colon >= 0 {
+				q1 = colon
+				if colon < t.file.Nr()-1 {
+					c := t.ReadC(colon + 1)
+					if isaddrc(c) {
+						q1 = colon + 1
+						for q1 < t.file.Nr() {
+							c := t.ReadC(q1)
+							if !isaddrc(c) {
+								break
+							}
+							q1++
+						}
+					}
+				}
+			}
+			if q1 > q0 {
+				if colon >= 0 { // stop at white space
+					for amax = colon + 1; amax < t.file.Nr(); amax++ {
+						c := t.ReadC(amax)
+						if c == ' ' || c == '\t' || c == '\n' {
+							break
+						}
+					}
+				} else {
+					amax = t.file.Nr()
+				}
+			}
+		}
+	}
+	amin := amax
+	e.q0 = q0
+	e.q1 = q1
+	n := q1 - q0
+	if n == 0 {
+		return false
+	}
+	// see if it's a file name
+	rb := make([]rune, n)
+	t.file.Read(q0, rb[:n])
+
+	found := filenameRE.FindForward(rb, 0, n, 1)
+	if found == nil {
+		found = quotedfilenameRE.FindForward(rb, 0, n, 1)
+	}
+	// Found now has a filename in group 2, address in group 9
+	nname := -1
+	filename := ""
+	if found != nil && found[0][4] != -1 {
+		nname = found[0][5]-found[0][4] 
+		filename = string(rb[found[0][4]:found[0][5]])
+	}
+	if found != nil && found[0][18] != -1 {
+		amin = found[0][18] + q0
+		amax = found[0][19] + q0
+		e.a0 = amin
+		e.a1 = amax
+	}
+	if nname == -1 {
+		nname = n
+	}
+	isFile := func(name string) bool {
+		e.name = name
+		e.at = t
+		e.a0 = amin
+		_, _, e.a1 = address(true, nil, Range{-1, -1}, Range{0, 0}, e.a0, amax,
+			func(q int) rune { return t.ReadC(q) }, false)
+		return true
+	}
+	s := filename
+	if amin == q0 {
+		return isFile(filename)
+	}
+	dname := t.DirName(s)
+	// if it's already a window name, it's a file
+	if lookfile(dname) != nil {
+		return isFile(dname)
+	}
+	// if it's the name of a file, it's a file
+	if ismtpt(dname) || !access(dname) {
+		return false
+	}
+	return isFile(dname)
+}

--- a/expandfile_win.go
+++ b/expandfile_win.go
@@ -19,7 +19,7 @@ var filenameRE = regexp.MustCompileAcme(`((([a-zA-Z]:|((\\\\|//)[a-zA-Z0-9.]*))?
 
 // Interesting parts: Group 2 is the path/name; group 9 is the address
 
-var quotedfilenameRE = regexp.MustCompileAcme(`('([a-zA-Z]:|((\\\\|//)[a-zA-Z0-9.]*))?((\\|/)?[^<>:*|?"\n]*)*')(:([0-9]+|(/[^ ']+)))?`)
+var quotedfilenameRE = regexp.MustCompileAcme(`('(([a-zA-Z]:|((\\\\|//)[a-zA-Z0-9.]*))?((\\|/)?[^<>:*|?"'\n]*)*)')(:([0-9]+|(/[^ ']+)))?`)
 
 func getline(t *Text, q0 int) (qq0, qq1 int) {
 	qq0 = q0
@@ -107,15 +107,12 @@ func expandfile(t *Text, q0 int, q1 int, e *Expand) (success bool) {
 	if found == nil {
 		return false
 	}
-	// Found now has a filename in group 2, address in group 9
-	nname := -1
 	e.q0 = q0
 	e.q1 = q1
 	amax := q1
 	amin := amax
 	filename := ""
 	if found != nil && found[0][2*filenameGroup] != -1 {
-		nname = found[0][2*filenameGroup+1] - found[0][2*filenameGroup]
 		filename = string(rb[found[0][2*filenameGroup]:found[0][2*filenameGroup+1]])
 		e.q0 = q0 + found[0][2*filenameGroup]
 		e.q1 = q1 + found[0][2*filenameGroup+1]
@@ -125,9 +122,6 @@ func expandfile(t *Text, q0 int, q1 int, e *Expand) (success bool) {
 		amax = found[0][2*addressGroup+1] + q0
 		e.a0 = amin
 		e.a1 = amax
-	}
-	if nname == -1 {
-		nname = n
 	}
 	isFile := func(name string) bool {
 		e.name = name

--- a/expandfile_win.go
+++ b/expandfile_win.go
@@ -1,4 +1,5 @@
 //go:build windows
+
 package main
 
 import (
@@ -38,7 +39,9 @@ func getline(t *Text, q0 int) (qq0, qq1 int) {
 func findquotedcontext(t *Text, q0 int) (qq0, qq1 int) {
 	// Let's try a radical departure.  Start by getting a line.
 	qq0, qq1 = getline(t, q0)
-	if qq1 == qq0 { return q0, q0 }
+	if qq1 == qq0 {
+		return q0, q0
+	}
 
 	n := qq1 - qq0
 	rb := make([]rune, n)
@@ -48,7 +51,7 @@ func findquotedcontext(t *Text, q0 int) (qq0, qq1 int) {
 	for _, pair := range found {
 		// qq0 is zero of the range returned.
 		// The match is thus at qq0+pair[0:1], and (q0-qq0) must fall in that range
-		if q0-qq0 >= pair[0] && q0 - qq0 <= pair[1] {
+		if q0-qq0 >= pair[0] && q0-qq0 <= pair[1] {
 			return pair[0] + qq0, pair[1] + qq0
 		}
 	}
@@ -74,9 +77,9 @@ func expandfile(t *Text, q0 int, q1 int, e *Expand) (success bool) {
 		for i, pair := range found {
 			// qq0 is zero of the range returned.
 			// The match is thus at qq0+pair[0:1], and (q0-qq0) must fall in that range
-			if q0-qq0 >= pair[0] && q0 - qq0 <= pair[1] {
-				q0, q1 = pair[0] + qq0, pair[1] + qq0
-				found = found[i:i+1]
+			if q0-qq0 >= pair[0] && q0-qq0 <= pair[1] {
+				q0, q1 = pair[0]+qq0, pair[1]+qq0
+				found = found[i : i+1]
 				break
 			}
 		}
@@ -107,7 +110,7 @@ func expandfile(t *Text, q0 int, q1 int, e *Expand) (success bool) {
 	amin := amax
 	filename := ""
 	if found != nil && found[0][4] != -1 {
-		nname = found[0][5]-found[0][4] 
+		nname = found[0][5] - found[0][4]
 		filename = string(rb[found[0][4]:found[0][5]])
 		e.q0 = q0 + found[0][4]
 		e.q1 = q1 + found[0][5]

--- a/look.go
+++ b/look.go
@@ -308,7 +308,7 @@ func isfilespace(r rune) bool {
 }
 
 func isfilec(r rune) bool {
-	Lx := ".-+/:@"
+	Lx := ".-+/:@\\"
 	if isalnum(r) {
 		return true
 	}
@@ -323,207 +323,6 @@ func cleanrname(rs []rune) []rune {
 	s := filepath.Clean(string(rs))
 	r, _, _ := util.Cvttorunes([]byte(s), len(s))
 	return r
-}
-
-// PAL: If our q1==q0 selection is within ' chars, we check if it's a filename, otherwise fall
-// back to our original selection code.  Returns the quoted string.
-func findquotedcontext(t *Text, q0 int) (qq0, qq1 int) {
-	qq0 = q0
-	qq1 = q0
-	foundquote := false
-	foundcolon := false
-	for qq0 >= 0 {
-		c := t.ReadC(qq0)
-		if c == ':' {
-			// We are looking for the case where the click
-			// happened in an address, in which case we aren't (yet)
-			// in a quoted context.
-			foundcolon = true
-			qq0--
-			continue
-		}
-		if foundcolon && !foundquote && c != '\'' {
-			qq0++
-			break
-		}
-		if c == '\'' {
-			if foundcolon {
-				foundquote = true
-				foundcolon = false // we no longer care about the colon
-				qq1 = qq0          // Make the search rightward start from within the quotes.
-				qq0--
-				continue // Keep marching leftwards;
-			}
-			foundquote = true
-			break
-		}
-		if !isfilec(c) && !isfilespace(c) {
-			return q0, q0 // No quote found leftward.
-		}
-		qq0--
-	}
-	if !foundquote {
-		return q0, q0
-	}
-	for qq1 < t.file.Nr() {
-		c := t.ReadC(qq1 - 1)
-		if c == '\'' {
-			break
-		}
-		if !isfilec(c) && !isfilespace(c) {
-			return q0, q0 // No quote found rightwards.
-		}
-		qq1++
-	}
-	return qq0, qq1
-}
-
-func expandfile(t *Text, q0 int, q1 int, e *Expand) (success bool) {
-	amax := q1
-	if q1 == q0 {
-		// Check for being in a quoted string, find out if its a file.
-		qq0, qq1 := findquotedcontext(t, q0)
-		if qq0 != qq1 {
-			// Invariant: qq0 and qq1-1 are '
-			if expandfile(t, qq0+1, qq1-1, e) {
-				// We have a file.  If we have a colon following our qq1+1 quote
-				// we have to get it and add it to Expand.
-				cq1 := qq1
-				c := t.ReadC(cq1)
-				if c != ':' { // We don't have any address information here.  Just return e.
-					e.q0 = qq0
-					e.q1 = qq1
-					return true
-				}
-				cq1++
-				// collect the address
-				e.a0 = cq1
-				for cq1 < t.file.Nr() {
-					c := t.ReadC(cq1)
-					if !isaddrc(c) && !isregexc(c) && c != '\'' {
-						break
-					}
-					cq1++
-				}
-				e.a1 = cq1
-				q0 = qq0
-				q1 = cq1
-				e.q0 = q0
-				e.q1 = q1
-				return true
-			}
-		} else {
-			colon := int(-1)
-			// TODO(rjk): utf8 conversion work.
-			for q1 < t.file.Nr() {
-				c := t.ReadC(q1)
-				if !isfilec(c) {
-					break
-				}
-				if c == ':' {
-					colon = q1
-					break
-				}
-				q1++
-			}
-			for q0 > 0 {
-				c := t.ReadC(q0 - 1)
-				if !isfilec(c) && !isaddrc(c) && !isregexc(c) {
-					break
-				}
-				if colon < 0 && c == ':' {
-					colon = q0 - 1
-				}
-				q0--
-			}
-			// if it looks like it might begin file: , consume address chars after :
-			// otherwise terminate expansion at :
-			if colon >= 0 {
-				q1 = colon
-				if colon < t.file.Nr()-1 {
-					c := t.ReadC(colon + 1)
-					if isaddrc(c) {
-						q1 = colon + 1
-						for q1 < t.file.Nr() {
-							c := t.ReadC(q1)
-							if !isaddrc(c) {
-								break
-							}
-							q1++
-						}
-					}
-				}
-			}
-			if q1 > q0 {
-				if colon >= 0 { // stop at white space
-					for amax = colon + 1; amax < t.file.Nr(); amax++ {
-						c := t.ReadC(amax)
-						if c == ' ' || c == '\t' || c == '\n' {
-							break
-						}
-					}
-				} else {
-					amax = t.file.Nr()
-				}
-			}
-		}
-	}
-	amin := amax
-	e.q0 = q0
-	e.q1 = q1
-	n := q1 - q0
-	if n == 0 {
-		return false
-	}
-	// see if it's a file name
-	rb := make([]rune, n)
-	t.file.Read(q0, rb[:n])
-	// first, does it have bad chars?
-	nname := -1
-	for i, c := range rb {
-		if c == ':' && nname < 0 {
-			if q0+i+1 >= t.file.Nr() {
-				return false
-			}
-			if i != n-1 {
-				if cc := t.ReadC(q0 + i + 1); !isaddrc(cc) {
-					return false
-				}
-			}
-			amin = q0 + i
-			nname = i
-		}
-	}
-	if nname == -1 {
-		nname = n
-	}
-	for i := 0; i < nname; i++ {
-		if !isfilec(rb[i]) && rb[i] != ' ' {
-			return false
-		}
-	}
-	isFile := func(name string) bool {
-		e.name = name
-		e.at = t
-		e.a0 = amin + 1
-		_, _, e.a1 = address(true, nil, Range{-1, -1}, Range{0, 0}, e.a0, amax,
-			func(q int) rune { return t.ReadC(q) }, false)
-		return true
-	}
-	s := string(rb[:nname])
-	if amin == q0 {
-		return isFile(s)
-	}
-	dname := t.DirName(s)
-	// if it's already a window name, it's a file
-	if lookfile(dname) != nil {
-		return isFile(dname)
-	}
-	// if it's the name of a file, it's a file
-	if ismtpt(dname) || !access(dname) {
-		return false
-	}
-	return isFile(dname)
 }
 
 func access(name string) bool {
@@ -570,11 +369,11 @@ func expand(t *Text, q0 int, q1 int) (*Expand, bool) {
 func lookfile(s string) *Window {
 	// avoid terminal slash on directories
 	s = UnquoteFilename(s)
-	s = strings.TrimRight(s, "/")
+	s = strings.TrimRight(s, "\\/")
 	for _, c := range global.row.col {
 		for _, w := range c.w {
 			name := UnquoteFilename(w.body.file.Name())
-			k := strings.TrimRight(name, "/")
+			k := strings.TrimRight(name, "\\/")
 			if k == s {
 				cur, ok := w.body.file.GetCurObserver().(*Text)
 				if !ok {

--- a/regexp/runes.go
+++ b/regexp/runes.go
@@ -16,6 +16,14 @@ func CompileAcme(expr string) (*Regexp, error) {
 	return compile(expr, syntax.Perl&^syntax.OneLine, false)
 }
 
+func MustCompileAcme(expr string) (*Regexp) {
+	if re, err := CompileAcme(expr); err != nil {
+		panic(err)
+	} else {
+		return re
+	}
+}
+
 // FindForward is similar to FindAllSubmatchIndex but searches
 // r[start:end], taking care to match ^ and $ correctly.
 func (re *Regexp) FindForward(r []rune, start int, end int, n int) [][]int {

--- a/regexp/runes.go
+++ b/regexp/runes.go
@@ -16,7 +16,7 @@ func CompileAcme(expr string) (*Regexp, error) {
 	return compile(expr, syntax.Perl&^syntax.OneLine, false)
 }
 
-func MustCompileAcme(expr string) (*Regexp) {
+func MustCompileAcme(expr string) *Regexp {
 	if re, err := CompileAcme(expr); err != nil {
 		panic(err)
 	} else {

--- a/regexp/runes_test.go
+++ b/regexp/runes_test.go
@@ -70,10 +70,7 @@ func TestRegexpBackward(t *testing.T) {
 func runRunesTests(t *testing.T, tt []runesTest, matcher func(*Regexp, *runesTest) [][]int) {
 	for i, tc := range tt {
 		t.Run(fmt.Sprintf("test-%02d", i), func(t *testing.T) {
-			re, err := CompileAcme(tc.re)
-			if err != nil {
-				t.Fatalf("failed to compile regular expression %q", tc.re)
-			}
+			re := MustCompileAcme(tc.re)
 			rs := matcher(re, &tc)
 			if !reflect.DeepEqual(rs, tc.expected) {
 				t.Errorf("regexp %q incorrectly matches %q[%v:%v]:\nexpected: %#v\ngot: %#v",

--- a/regexp/runes_test.go
+++ b/regexp/runes_test.go
@@ -55,7 +55,7 @@ func TestRegexpForward(t *testing.T) {
 
 func TestMustCompileAcmePanics(t *testing.T) {
 	defer func() {
-		if r := recover(); r == nil  {
+		if r := recover(); r == nil {
 			t.Errorf("Should have paniced")
 		}
 	}()

--- a/regexp/runes_test.go
+++ b/regexp/runes_test.go
@@ -53,6 +53,15 @@ func TestRegexpForward(t *testing.T) {
 	})
 }
 
+func TestMustCompileAcmePanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil  {
+			t.Errorf("Should have paniced")
+		}
+	}()
+	MustCompile(")")
+}
+
 func TestRegexpBackward(t *testing.T) {
 	tt := []runesTest{
 		{"aaaaa", 0, -1, "a", [][]int{{4, 5}, {3, 4}}, 2},


### PR DESCRIPTION
Add windows-specific handling of filename Looks.
Uses regexp to find both filenames and quoted filenames followed by addresses.
Simplifies the code dramatically, at the cost of likely (minimal) overhead, and trades
comprehension of all the per-character parsing with regexp understanding.
