### PR TITLE
Fix expandfile windows

### DIFF
--- a/expandfile_win.go
+++ b/expandfile_win.go
@@ -174,8 +174,8 @@ func expandfile(t *Text, q0 int, q1 int, e *Expand) (success bool) {
 		if isFile(dname) {
 			return true
 		}
-
-		for q1 := e.q1; q1 >= e.q0; q1-- {
+		var q1 int
+		for q1 = e.q1; q1 >= e.q0; q1-- {
 			if rb[q1-1] == '\\' || rb[q1-1] == '/' {
 				// don't back up past a path separator
 				return false
@@ -185,6 +185,9 @@ func expandfile(t *Text, q0 int, q1 int, e *Expand) (success bool) {
 				e.q1 = q1
 				break
 			}
+		}
+		if q1 < e.q0 {
+			return false
 		}
 	}
 }


### PR DESCRIPTION
Was broken in the Tag where the various trailing words would confuse it into expanding too long a filename.
Fixed by peeling off trailing words and testing for being a valid file.
Also correct a bug where some filename substrings did not include the clicked position.
