### PR TITLE
Fix error in xfid undo handling

### DIFF
--- a/xfid.go
+++ b/xfid.go
@@ -600,8 +600,10 @@ forloop:
 					break forloop
 				}
 			}
-			global.seq++
-			w.body.file.Mark(global.seq)
+			if !w.nomark {
+				global.seq++
+				w.body.file.Mark(global.seq)
+			}
 			w.SetName(string(r))
 		case "dump": // set dump string
 			if len(words) < 2 {


### PR DESCRIPTION
This change fixes #499: nomark works correctly when setting the name
of a buffer.
