### PR TITLE
Fix a subtle bug with the mark API

### DIFF
--- a/file/observable_editable_buffer.go
+++ b/file/observable_editable_buffer.go
@@ -191,7 +191,7 @@ func (e *ObservableEditableBuffer) notifyTagObservers(before TagStatus) {
 
 // Mark is a forwarding function for file.Mark.
 // This sets an undo point. NB: call Mark before mutating the file.
-// seq must be 1 to enable Undo/Redo on the file.
+// Argument seq should be > 0 to create a valid Undo/Redo point.
 func (e *ObservableEditableBuffer) Mark(seq int) {
 	e.f.Mark()
 	e.seq = seq
@@ -528,4 +528,9 @@ func (e *ObservableEditableBuffer) End() OffsetTuple {
 // MakeBufferCursor is a forwarding function.
 func (e *ObservableEditableBuffer) MakeBufferCursor(p0, p1 OffsetTuple) *BufferCursor {
 	return MakeBufferCursor(e.f, p0, p1)
+}
+
+// DebugSeqState returns the seq state for debugging purposes.
+func (e *ObservableEditableBuffer) DebugSeqState() string {
+	return fmt.Sprintf("oeb seq %d putseq %d treatasclean %v", e.seq, e.putseq,  e.treatasclean)
 }

--- a/file/observable_editable_buffer.go
+++ b/file/observable_editable_buffer.go
@@ -532,5 +532,5 @@ func (e *ObservableEditableBuffer) MakeBufferCursor(p0, p1 OffsetTuple) *BufferC
 
 // DebugSeqState returns the seq state for debugging purposes.
 func (e *ObservableEditableBuffer) DebugSeqState() string {
-	return fmt.Sprintf("oeb seq %d putseq %d treatasclean %v", e.seq, e.putseq,  e.treatasclean)
+	return fmt.Sprintf("oeb seq %d putseq %d treatasclean %v", e.seq, e.putseq, e.treatasclean)
 }

--- a/xfid.go
+++ b/xfid.go
@@ -658,8 +658,9 @@ forloop:
 		case "nomark": // turn off automatic marking
 			w.nomark = true
 		case "mark": // mark file
-			global.seq++
-			w.body.file.Mark(global.seq)
+			w.nomark = false
+			// global.seq++
+			// w.body.file.Mark(global.seq)
 		case "nomenu": // turn off automatic menu
 			w.filemenu = false
 		case "menu": // enable automatic menu


### PR DESCRIPTION
When I refactored the undo code, I changed (perhaps wrongly) the
semantics of Undo marking. Adjust the filesystem interface to work
correctly despite this.

This is a better fix for #499.
