### PR TITLE
Fix 470: missing chords

### DIFF
--- a/exec.go
+++ b/exec.go
@@ -53,7 +53,7 @@ type Exectab struct {
 // TODO(rjk): This could be more idiomatic: each command implements an
 // interface. Flags would then be unnecessary.
 
-var exectab = []Exectab{
+var globalexectab = []Exectab{
 	//	{ "Abort",		doabort,	false,	true /*unused*/,		true /*unused*/,		},
 	{"Cut", cut, true, true, true},
 	{"Del", del, false, false, true /*unused*/},
@@ -88,7 +88,8 @@ var exectab = []Exectab{
 
 var wsre = regexp.MustCompile("[ \t\n]+")
 
-func lookup(r string) *Exectab {
+// TODO(rjk): Exectab is sorted. Consider using a binary search
+func lookup(r string, exectab []Exectab) *Exectab {
 	r = wsre.ReplaceAllString(r, " ")
 	r = strings.TrimLeft(r, " ")
 	words := strings.SplitN(r, " ", 2)
@@ -190,7 +191,7 @@ func execute(t *Text, aq0 int, aq1 int, external bool, argt *Text) {
 
 	r := make([]rune, q1-q0)
 	t.file.Read(q0, r)
-	e := lookup(string(r))
+	e := lookup(string(r), globalexectab)
 
 	// Send commands to external client if the target window's event file is
 	// in use.

--- a/exec.go
+++ b/exec.go
@@ -146,12 +146,12 @@ func getarg(argt *Text, doaddr bool, dofile bool) (string, string) {
 	return string(r), a
 }
 
-// execute must run with an existing lock on t's Window
-func execute(t *Text, aq0 int, aq1 int, external bool, argt *Text) {
-	var n, f int
-
-	q0 := aq0
-	q1 := aq1
+// expandRuneOffsetsToWord expands the rune offsets on a middle click to
+// the word boundaries. TODO(rjk): Conceivably, what we think of as a
+// "word boundary" should be configurable in some way and not embedded in
+// this function.
+// TODO(rjk): Consider if this method should really be part of Text.
+func expandRuneOffsetsToWord(t *Text, q0 int, q1 int) (int, int) {
 	if q1 == q0 { // expand to find word (actually file name)
 		// if in selection, choose selection
 		if t.inSelection(q0) {
@@ -175,10 +175,19 @@ func execute(t *Text, aq0 int, aq1 int, external bool, argt *Text) {
 				}
 			}
 			if q1 == q0 {
-				return
+				return q0, q1
 			}
 		}
 	}
+	return q0, q1
+}
+
+// execute must run with an existing lock on t's Window
+func execute(t *Text, aq0 int, aq1 int, external bool, argt *Text) {
+	var n, f int
+
+	q0, q1 := expandRuneOffsetsToWord(t, aq0, aq1)
+
 	r := make([]rune, q1-q0)
 	t.file.Read(q0, r)
 	e := lookup(string(r))

--- a/guide
+++ b/guide
@@ -7,6 +7,7 @@ X:edwood/.*\.go: w
 
 {go build -tags debug}
 ./testedwood.sh
+./testacme.sh
 
 {go test -covermode=count -coverprofile=count.out}
 go tool cover -html=count.out


### PR DESCRIPTION
Prepare for later bug fixes by starting to separate the code in
exec.go:/execute into more easily testable components.
