### PR TITLE
Cleanup Edwood Directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Folders
 _obj
 _test
+testfiles
 
 # Architecture specific extensions/prefixes
 *.[568vq]
@@ -22,7 +23,10 @@ _testmain.go
 *.exe
 *.test
 *.prof
-edwood
+/edwood
+/E
+/sendit
+/win
 
 # Mac stuffs
 .DS_Store

--- a/file/guide
+++ b/file/guide
@@ -1,0 +1,8 @@
+// Basics
+Edit X:edwood/file/\+Errors: 1,$d
+X:edwood/.*\.go: w
+
+go test -covermode=count -coverprofile=count.out
+go tool cover -html=count.out
+
+go test --run 'TestLargeEditTargets' -covermode=count -coverprofile=count.out

--- a/guide
+++ b/guide
@@ -1,9 +1,7 @@
-Get needs to quote filenames
-Look needs to respect quotes around filenames
-
-// Basics
 Edit X:edwood/\+Errors: 1,$d
 X:edwood/.*\.go: w
+
+go build -o sendit ./cmd/sendit
 
 {go build -tags debug}
 ./testedwood.sh
@@ -16,99 +14,9 @@ go vet
 
 go test --run 'TestXfidreadQWctl' -covermode=count -coverprofile=count.out
 
-// Edit commands for converting C to Go
-cs 'flushwarnings\('
+# References
+Assorted useful internal notes.
 
-",
-{ x/->/c/./
-x/TRUE/c/true/
-x/FALSE/c/false/
-x/display.black/c/display.Black/
-x/ ZP/c/ image.ZP/
-x/[^a-zA-Z0-9_]for/+-s/for\((.*)\)/for \1 /g
-x/[^a-zA-Z0-9_]if/+-s/if\((.*)\)/if \1 /g
-x/[^a-zA-Z_0-9](max|min)\.[xy]/{ x/m/c/M/
-		x/\.y/c/.Y
-		x/\.x/c/.X
-		}
-x/[^a-zA-Z_0-9]Border([^a-zA-Z_0-9]|\n)/y/[^a-zA-Z_0-9]/g/./{
-	i/display.ScaleSize(/
-	a/)/
-	}
-}
-"
-textsetselect
-s/textshow\(([^),]+),([^)]+)\)/\1.Show(\2)/g
-,s/textsetselect\(([^),]+),([^)]+)\)/\1.SetSelect(\2)/g
-,s/textinsert\(([^),]+),([^)]+)\)/\1.Insert(\2)/g
-,s/typecommit\(([^)]+)\)/\1.TypeCommit()/g
-s/filemark\(([^)]+)\)/\1.Mark()/g
-,s/winclose\(([^)]+)\)/\1.Close()/g
-,s/winlock\(([^)]+)\)/\1.Lock()/g
-,s/winunlock\(([^)]+)\)/\1.Unlock()/g
-
-// rewrite struct decl from C to Go
-x/struct [a-zA-Z0-9_]+(.*)\n{([^}]*\n)+};/{
-	s/^	*([a-zA-Z0-9_]+)[ 	]+(\*)?([a-zA-Z0-9_]+);(.*)/	\3	\2\1	\4/g
-	s/struct ([a-zA-Z0-9_]+)((.*\n)+){/type \1 struct {\2/
-	x/};/c/}\n/
-}
-
-,x/[^a-zA-Z_0-9]uchar[^a-zA-Z_0-9]/x/[a-zA-Z0-9_]+/c/byte
-,x/[^a-zA-Z_0-9]short[^a-zA-Z_0-9]/x/[a-zA-Z0-9_]+/c/int
-,x/[^a-zA-Z_0-9]char[^a-zA-Z_0-9]/x/[a-zA-Z0-9_]+/c/byte
-
-// function decls.
-,s/^([a-zA-Z0-9_]+)[ ]*(\*?)\n([a-zA-Z0-9_]+)(\(.*)\n{/func \3 \4 (\2 \1) {/g
-,x/^func.*\([^)]*\)/x/\([^)]*\)/{
-	x/\(void\)/c/()
-	y/,/s/([a-zA-Z0-9_]+)[ 	]+(\*)?([a-zA-Z0-9_]+)/\3 \2 \1/
-}
-
-// var decls
-s/^[ 	]*([a-zA-Z0-9_]+)[ 	]+(\*?)(.*);/	\3 \2\1/g
-
-,x/\/\*.*\*\//{
-	x/\/\*/c/\/\/
-	x/\*\//d
-}
-
-,s/setcursor\(([^),]+)([^)]*)\)/\1.Commit(\2)/g
-,s/wincommit\(([^),]+)([^)]*)\)/\1.Commit(\2)/g
-,s/textcommit\(&([^),]+)([^)]*)\)/\1.Commit(\2)/g
-,s/qlock\(&([^)]+)\)/\1.Lock()/g
-,s/qunlock\(&([^)]+)\)/\1.Unlock()/g
-,s/filereset\(([^)]+)\)/\1.Reset()/g
-var decls
-s/([a-zA-Z0-9_]+)[ 	]+(\*)?([a-zA-Z0-9_]+)/\3 \2 \1/g
-// Member function call
-s/([a-zA-Z0-9_]+)\(&?([a-zA-Z0-9_.]+),?/\2.\1(/
-// enum to go const
-,x/enum [a-zA-Z0-9_]+(.*)\n{([^}]*\n)+};/{
-
-x/$/i/},
-
-
-x/^	*([a-zA-Z0-9_]+)[ 	]/p
-
-
-Watch go build '-gcflags=all=-N -l' .
-,x/[^a-zA-Z]+tick[^a-zA-Z]+/x/tick/c/TickImage
-}
-Edit X/frame\/.*\.go/{
-,x/maxlines/c/MaxLines/
-,x/maxtab/c/MaxTab/
-,x/nchars/c/NChars/
-,x/nlines/c/NLines/
-,x/lastlinefull/c/LastLineFull/
-,x/modified/c/Modified/
-,x/tickback/c/TickBack/
-,x/noredraw/c/NoRedraw/
-,x/ticked/c/Ticked/
-,x/tickscale/c/TickScale/
-}
-
-X/.*atch.*/
-x/ {.*}/d
-Watch go build '-gcflags=all=-N -l' .
-/Users/plalonde/plan9port/src/libframe
+- historical work log [[EdwoodDoingLog]]
+- [[EdwoodFilePkgTesting]] discussion of testing the file package.
+- [[MultiUndoTesting]] ideas for how to test undo spanning multiple windows. (This code is buggy)


### PR DESCRIPTION
I had a lot of cruft in my Edwood directory, test etc. Check it in,
delete it or hide it with .gitignore. Also update the guide file to
remove the C conversion tooling and add convenience links to my notes
tracking listing tests that I need to write.
