### PR TITLE
E doesn't correctly wait for files with different name patterns

### DIFF
--- a/cmd/E/main.go
+++ b/cmd/E/main.go
@@ -48,7 +48,9 @@ func main() {
 		}
 		log.Println(ev)
 
-		if ev.Name == ap && ev.Op == "del" {
+		// Use ID because the name as loaded might not be the same as the
+		// argument string.
+		if ev.ID == win.ID() && ev.Op == "del" {
 			edwoodlog.Close()
 			return
 		}


### PR DESCRIPTION
Because `plumb` takes paths with a positional suffix specifying the
location in the file, the name of the file in the event log is not
necessarily the same as the argument to plumb. Watch for ID values
from the log file instead of the argument to `plumb`.
