### PR TITLE
Clean up util package: move test, inline wrappers, use builtins

### DIFF
--- a/col.go
+++ b/col.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"image"
+	"log"
 	"sort"
 
 	"github.com/rjkroege/edwood/draw"
 	"github.com/rjkroege/edwood/file"
 	"github.com/rjkroege/edwood/frame"
-	"github.com/rjkroege/edwood/util"
 )
 
 var (
@@ -147,10 +147,10 @@ func (c *Column) Add(w, clone *Window, y int) *Window {
 		}
 
 		// new window must start after v's tag ends
-		y = util.Max(y, v.tagtop.Max.Y+c.display.ScaleSize(Border))
+		y = max(y, v.tagtop.Max.Y+c.display.ScaleSize(Border))
 
 		// new window must start early enough to end before ymax
-		y = util.Min(y, ymax-minht)
+		y = min(y, ymax-minht)
 
 		// if y is too small, too many windows in column
 		if y < v.tagtop.Max.Y+c.display.ScaleSize(Border) {
@@ -164,9 +164,9 @@ func (c *Column) Add(w, clone *Window, y int) *Window {
 			c.display.ScreenImage().Draw(r, global.textcolors[frame.ColBack], nil, image.Point{})
 		}
 		r1 := r
-		y = util.Min(y, ymax-(v.tag.fr.DefaultFontHeight()*v.taglines+v.body.fr.DefaultFontHeight()+c.display.ScaleSize(Border)+1))
+		y = min(y, ymax-(v.tag.fr.DefaultFontHeight()*v.taglines+v.body.fr.DefaultFontHeight()+c.display.ScaleSize(Border)+1))
 		ffs := v.body.fr.GetFrameFillStatus()
-		r1.Max.Y = util.Min(y, v.body.fr.Rect().Min.Y+ffs.Nlines*v.body.fr.DefaultFontHeight())
+		r1.Max.Y = min(y, v.body.fr.Rect().Min.Y+ffs.Nlines*v.body.fr.DefaultFontHeight())
 		r1.Min.Y = v.Resize(r1, false, false)
 		r1.Max.Y = r1.Min.Y + c.display.ScaleSize(Border)
 		if c.display != nil {
@@ -224,7 +224,7 @@ func (c *Column) Close(w *Window, dofree bool) {
 			goto Found
 		}
 	}
-	util.AcmeError("can't find window", nil)
+	log.Panicf("acme: %s: %v\n", "can't find window", nil)
 Found:
 	r = w.r
 	// Crash noted in #385 happens when closing windows with the
@@ -311,7 +311,7 @@ func (c *Column) Resize(r image.Rectangle) {
 				r1.Max.Y += (w.r.Dy() + c.display.ScaleSize(Border)) * r.Dy() / c.r.Dy()
 			}
 		}
-		r1.Max.Y = util.Max(r1.Max.Y, r1.Min.Y+c.display.ScaleSize(Border)+fontget(global.tagfont, c.display).Height())
+		r1.Max.Y = max(r1.Max.Y, r1.Min.Y+c.display.ScaleSize(Border)+fontget(global.tagfont, c.display).Height())
 		r2 := r1
 		r2.Max.Y = r2.Min.Y + c.display.ScaleSize(Border)
 		c.display.ScreenImage().Draw(r2, c.display.Black(), nil, image.Point{})
@@ -356,7 +356,7 @@ func (c *Column) Grow(w *Window, but int) {
 		}
 	}
 	if windex == len(c.w) {
-		util.AcmeError("can't find window", nil)
+		log.Panicf("acme: %s: %v\n", "can't find window", nil)
 	}
 
 	cr := c.r
@@ -409,7 +409,7 @@ func (c *Column) Grow(w *Window, but int) {
 		goto Pack
 	}
 	{ // Scope for nnl & dln
-		nnl := util.Min(onl+util.Max(util.Min(5, w.taglines-1+w.maxlines), onl/2), tot) // TODO(flux) more bad taglines use
+		nnl := min(onl+max(min(5, w.taglines-1+w.maxlines), onl/2), tot) // TODO(flux) more bad taglines use
 		if nnl < w.taglines-1+w.maxlines {
 			nnl = (w.taglines - 1 + w.maxlines + nnl) / 2
 		}
@@ -422,7 +422,7 @@ func (c *Column) Grow(w *Window, but int) {
 			// prune from later window
 			j := windex + k
 			if j < c.nw() && nl[j] != 0 {
-				l := util.Min(dnl, util.Max(1, nl[j]/2))
+				l := min(dnl, max(1, nl[j]/2))
 				nl[j] -= l
 				nl[windex] += l
 				dnl -= l
@@ -430,7 +430,7 @@ func (c *Column) Grow(w *Window, but int) {
 			// prune from earlier window
 			j = windex - k
 			if j >= 0 && nl[j] != 0 {
-				l := util.Min(dnl, util.Max(1, nl[j]/2))
+				l := min(dnl, max(1, nl[j]/2))
 				nl[j] -= l
 				nl[windex] += l
 				dnl -= l
@@ -539,20 +539,20 @@ func (c *Column) DragWin(w *Window, but int) {
 			goto Found
 		}
 	}
-	util.AcmeError("can't find window", nil)
+	log.Panicf("acme: %s: %v\n", "can't find window", nil)
 
 Found:
 	if w.tagexpand { // force recomputation of window tag size
 		w.taglines = 1
 	}
 	p = global.mouse.Point
-	if util.Abs(p.X-op.X) < 5 && util.Abs(p.Y-op.Y) < 5 {
+	if max(p.X-op.X, -(p.X-op.X)) < 5 && max(p.Y-op.Y, -(p.Y-op.Y)) < 5 {
 		c.Grow(w, but)
 		w.MouseBut()
 		return
 	}
 	// is it a flick to the right? Or a jump to the le-e-e-eft?
-	if util.Abs(p.Y-op.Y) < 10 && p.X > op.X+30 && c.row.WhichCol(p) == c {
+	if max(p.Y-op.Y, -(p.Y-op.Y)) < 10 && p.X > op.X+30 && c.row.WhichCol(p) == c {
 		p.X = op.X + w.r.Dx() // yes: toss to next column
 	}
 	nc = c.row.WhichCol(p)

--- a/ecmd.go
+++ b/ecmd.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1049,7 +1050,7 @@ func cmdaddress(ap *Addr, a Address, sign int) Address {
 				a = lineaddr(1, a, sign)
 			}
 		default:
-			util.AcmeError("cmdaddress", nil)
+			log.Panicf("acme: %s: %v\n", "cmdaddress", nil)
 			return a
 		}
 		ap = ap.next

--- a/fsys.go
+++ b/fsys.go
@@ -13,7 +13,6 @@ import (
 
 	"9fans.net/go/plan9"
 	"github.com/rjkroege/edwood/ninep"
-	"github.com/rjkroege/edwood/util"
 )
 
 type fileServer struct {
@@ -105,10 +104,10 @@ var mnt Mnt
 func fsysinit() *fileServer {
 	p0, p1, err := newPipe()
 	if err != nil {
-		util.AcmeError("failed to create pipe", err)
+		log.Panicf("acme: %s: %v\n", "failed to create pipe", err)
 	}
 	if err := post9pservice(p0, "acme", *mtpt); err != nil {
-		util.AcmeError("can't post service", err)
+		log.Panicf("acme: %s: %v\n", "can't post service", err)
 	}
 
 	fs := &fileServer{
@@ -133,7 +132,7 @@ func (fs *fileServer) fsysproc() {
 			if fs.closing {
 				break
 			}
-			util.AcmeError("fsysproc", err)
+			log.Panicf("acme: %s: %v\n", "fsysproc", err)
 		}
 		if DEBUG {
 			fmt.Fprintf(os.Stderr, "<-- %v\n", fc)
@@ -242,7 +241,7 @@ func (fs *fileServer) respond(x *Xfid, t *plan9.Fcall, err error) *Xfid {
 	t.Fid = x.fcall.Fid
 	t.Tag = x.fcall.Tag
 	if err := plan9.WriteFcall(fs.conn, t); err != nil {
-		util.AcmeError("write error in respond", err)
+		log.Panicf("acme: %s: %v\n", "write error in respond", err)
 	}
 	if DEBUG {
 		fmt.Fprintf(os.Stderr, "--> %v\n", t)
@@ -448,7 +447,7 @@ func (f *Fid) Walk1(wname string) (found bool, err error) {
 	err = nil
 	if wname == "new" {
 		if f.w != nil {
-			util.AcmeError("w set in walk to new", nil)
+			log.Panicf("acme: %s: %v\n", "w set in walk to new", nil)
 		}
 		global.cnewwindow <- nil  // signal newwindowthread
 		f.w = <-global.cnewwindow // receive new window

--- a/fsys_plan9.go
+++ b/fsys_plan9.go
@@ -2,13 +2,13 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"net"
 	"os"
 	"path"
 	"syscall"
 
 	"9fans.net/go/plan9/client"
-	"github.com/rjkroege/edwood/util"
 )
 
 // These constants are from /sys/include/libc.h
@@ -50,15 +50,15 @@ func post9pservice(conn net.Conn, name string, mtpt string) error {
 		// hasn't been started yet.
 		err := syscall.Mount(cfd, -1, mtpt, MREPL, "")
 		if err != nil {
-			util.AcmeError("mount failed", err)
+			log.Panicf("acme: %s: %v\n", "mount failed", err)
 		}
 		err = syscall.Bind(mtpt, "/mnt/wsys", MREPL)
 		if err != nil {
-			util.AcmeError("bind /mnt/wsys filed", err)
+			log.Panicf("acme: %s: %v\n", "bind /mnt/wsys filed", err)
 		}
 		err = syscall.Bind(mtpt, "/dev", MBEFORE)
 		if err != nil {
-			util.AcmeError("bind /dev filed", err)
+			log.Panicf("acme: %s: %v\n", "bind /dev filed", err)
 		}
 	}()
 	return nil

--- a/fsys_unix.go
+++ b/fsys_unix.go
@@ -6,13 +6,13 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"net"
 	"os"
 	"path/filepath"
 
 	"9fans.net/go/plan9/client"
 	"github.com/fhs/mux9p"
-	"github.com/rjkroege/edwood/util"
 )
 
 func newPipe() (net.Conn, net.Conn, error) {
@@ -33,7 +33,7 @@ func post9pservice(conn net.Conn, name string, mtpt string) error {
 	go func() {
 		err := mux9p.Listen("unix", addr, conn, nil)
 		if err != nil {
-			util.AcmeError("9P multiplexer failed", err)
+			log.Panicf("acme: %s: %v\n", "9P multiplexer failed", err)
 		}
 	}()
 	return nil

--- a/fsys_windows.go
+++ b/fsys_windows.go
@@ -3,11 +3,11 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log"
 	"net"
 
 	"9fans.net/go/plan9/client"
 	"github.com/fhs/mux9p"
-	"github.com/rjkroege/edwood/util"
 )
 
 var (
@@ -28,7 +28,7 @@ func post9pservice(conn net.Conn, name string, mtpt string) error {
 	go func() {
 		defer l.Close()
 		if err := mux9p.Do(l, conn, nil); err != nil {
-			util.AcmeError("9P multiplexer failed", err)
+			log.Panicf("acme: %s: %v\n", "9P multiplexer failed", err)
 		}
 	}()
 	fsysAddr = l.Addr()

--- a/row.go
+++ b/row.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"image"
+	"log"
 	"math"
 	"os"
 	"path/filepath"
@@ -13,7 +14,6 @@ import (
 	"github.com/rjkroege/edwood/draw"
 	"github.com/rjkroege/edwood/dumpfile"
 	"github.com/rjkroege/edwood/file"
-	"github.com/rjkroege/edwood/util"
 )
 
 const RowTag = "Newcol Kill Putall Dump Exit"
@@ -80,7 +80,7 @@ func (row *Row) Add(c *Column, x int) *Column {
 		}
 		row.display.ScreenImage().Draw(r, row.display.White(), nil, image.Point{})
 		r1 := r
-		r1.Max.X = util.Min(x-row.display.ScaleSize(Border), r.Max.X-row.display.ScaleSize(50))
+		r1.Max.X = min(x-row.display.ScaleSize(Border), r.Max.X-row.display.ScaleSize(50))
 		if r1.Dx() < row.display.ScaleSize(50) {
 			r1.Max.X = r1.Min.X + row.display.ScaleSize(50)
 		}
@@ -163,11 +163,11 @@ func (row *Row) DragCol(c *Column, _ int) {
 			goto Found
 		}
 	}
-	util.AcmeError("can't find column", nil)
+	log.Panicf("acme: %s: %v\n", "can't find column", nil)
 
 Found:
 	p = global.mouse.Point
-	if util.Abs(p.X-op.X) < 5 && util.Abs(p.Y-op.Y) < 5 {
+	if max(p.X-op.X, -(p.X-op.X)) < 5 && max(p.Y-op.Y, -(p.Y-op.Y)) < 5 {
 		return
 	}
 	if (i > 0 && p.X < row.col[i-1].r.Min.X) || (i < len(row.col)-1 && p.X > c.r.Max.X) {
@@ -220,7 +220,7 @@ func (row *Row) Close(c *Column, dofree bool) {
 			goto Found
 		}
 	}
-	util.AcmeError("can't find column", nil)
+	log.Panicf("acme: %s: %v\n", "can't find column", nil)
 Found:
 	r = c.r
 	if dofree {
@@ -530,7 +530,7 @@ func (row *Row) loadhelper(win *dumpfile.Window) error {
 	// Update the selection on the Text.
 	w.body.Show(q0, q1, true)
 	ffs := w.body.fr.GetFrameFillStatus()
-	w.maxlines = util.Min(ffs.Nlines, util.Max(w.maxlines, ffs.Nlines))
+	w.maxlines = min(ffs.Nlines, max(w.maxlines, ffs.Nlines))
 
 	// TODO(rjk): Conceivably this should be a zerox xfidlog when reconstituting a zerox?
 	xfidlog(w, "new")

--- a/sam/texter.go
+++ b/sam/texter.go
@@ -1,9 +1,5 @@
 package sam
 
-import (
-	"github.com/rjkroege/edwood/util"
-)
-
 // Texter abstracts the buffering side of Text, allowing testing of Elog Apply
 // TODO(flux): This is probably lame and will get re-done when I understand
 // how Text stores its text.
@@ -35,8 +31,8 @@ func NewTextBuffer(q0 int, q1 int, buf []rune) *TextBuffer {
 }
 
 func (t TextBuffer) Constrain(q0, q1 int) (p0, p1 int) {
-	p0 = util.Min(q0, len(t.buf))
-	p1 = util.Min(q1, len(t.buf))
+	p0 = min(q0, len(t.buf))
+	p1 = min(q1, len(t.buf))
 	return p0, p1
 }
 

--- a/tagindex.go
+++ b/tagindex.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/rjkroege/edwood/file"
 	"github.com/rjkroege/edwood/runes"
-	"github.com/rjkroege/edwood/util"
 	//	"log"
 )
 
@@ -271,7 +270,7 @@ func (w *Window) setTag1() {
 			w.tag.q0 = w.tagfilenameend
 		default:
 			// log.Println("q0 default")
-			w.tag.q0 = util.Min(q0, w.tag.Nc())
+			w.tag.q0 = min(q0, w.tag.Nc())
 		}
 
 		switch { // q1
@@ -293,13 +292,13 @@ func (w *Window) setTag1() {
 			w.tag.q1 = w.tag.Nc()
 		default:
 			// log.Println("q1", "default")
-			w.tag.q1 = util.Min(q1, w.tag.Nc())
+			w.tag.q1 = min(q1, w.tag.Nc())
 		}
 	}
 
 	w.tag.file.Clean()
-	w.tag.q0 = util.Min(w.tag.q0, w.tag.Nc())
-	w.tag.q1 = util.Min(w.tag.q1, w.tag.Nc())
+	w.tag.q0 = min(w.tag.q0, w.tag.Nc())
+	w.tag.q1 = min(w.tag.q1, w.tag.Nc())
 
 	// TODO(rjk): This can redraw the selection unnecessarily.
 	w.tag.SetSelect(w.tag.q0, w.tag.q1)

--- a/text.go
+++ b/text.go
@@ -19,7 +19,6 @@ import (
 	"github.com/rjkroege/edwood/file"
 	"github.com/rjkroege/edwood/frame"
 	"github.com/rjkroege/edwood/runes"
-	"github.com/rjkroege/edwood/util"
 )
 
 const (
@@ -139,7 +138,7 @@ func (t *Text) Redraw(r image.Rectangle, odx int, noredraw bool) {
 	maxt := int(global.maxtab)
 	if t.what == Body {
 		if t.file.IsDir() {
-			maxt = util.Min(TABDIR, int(global.maxtab))
+			maxt = min(TABDIR, int(global.maxtab))
 		} else {
 			maxt = t.tabstop
 		}
@@ -195,7 +194,7 @@ func (t *Text) Resize(r image.Rectangle, keepextra, noredraw bool) int {
 func (t *Text) Close() {
 	t.fr.Clear(true)
 	if err := t.file.DelObserver(t); err != nil {
-		util.AcmeError(err.Error(), nil)
+		log.Panicf("acme: %s: %v\n", err.Error(), nil)
 	}
 	t.file = nil
 	if global.argtext == t {
@@ -228,7 +227,7 @@ func (t *Text) Columnate(names []string, widths []int) {
 
 	mint = t.getfont().StringWidth("0")
 	// go for narrower tabs if set more than 3 wide
-	t.fr.Maxtab(util.Min(int(global.maxtab), TABDIR) * mint)
+	t.fr.Maxtab(min(int(global.maxtab), TABDIR) * mint)
 	maxt = t.fr.GetMaxtab()
 	for _, w := range widths {
 		if maxt-w%maxt < mint || w%maxt == 0 {
@@ -244,7 +243,7 @@ func (t *Text) Columnate(names []string, widths []int) {
 	if colw == 0 {
 		ncol = 1
 	} else {
-		ncol = util.Max(1, t.fr.Rect().Dx()/colw)
+		ncol = max(1, t.fr.Rect().Dx()/colw)
 	}
 	nrow = (len(names) + ncol - 1) / ncol
 
@@ -637,13 +636,13 @@ func (t *Text) Deleted(oq0, oq1 file.OffsetTuple) {
 		t.w.utflastqid = -1
 	}
 	if q0 < t.iq1 {
-		t.iq1 -= util.Min(n, t.iq1-q0)
+		t.iq1 -= min(n, t.iq1-q0)
 	}
 	if q0 < t.q0 {
-		t.q0 -= util.Min(n, t.q0-q0)
+		t.q0 -= min(n, t.q0-q0)
 	}
 	if q0 < t.q1 {
-		t.q1 -= util.Min(n, t.q1-q0)
+		t.q1 -= min(n, t.q1-q0)
 	}
 	if q1 <= t.org {
 		t.org -= n
@@ -689,8 +688,8 @@ func (t *Text) Q1() int                                  { return t.q1 }
 func (t *Text) SetQ0(q0 int)                             { t.q0 = q0 }
 func (t *Text) SetQ1(q1 int)                             { t.q1 = q1 }
 func (t *Text) Constrain(q0, q1 int) (p0, p1 int) {
-	p0 = util.Min(q0, t.file.Nr())
-	p1 = util.Min(q1, t.file.Nr())
+	p0 = min(q0, t.file.Nr())
+	p1 = min(q1, t.file.Nr())
 	return p0, p1
 }
 
@@ -1191,7 +1190,7 @@ func (t *Text) Select() {
 		// TODO(rjk): Ack. This is horrible? Layering violation?
 		for {
 			global.mousectl.Read()
-			if !(global.mouse.Buttons == b && util.Abs(global.mouse.Point.X-x) < 3 && util.Abs(global.mouse.Point.Y-y) < 3) {
+			if !(global.mouse.Buttons == b && max(global.mouse.Point.X-x, -(global.mouse.Point.X-x)) < 3 && max(global.mouse.Point.Y-y, -(global.mouse.Point.Y-y)) < 3) {
 				break
 			}
 		}

--- a/util.go
+++ b/util.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"image"
+	"log"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -70,7 +71,7 @@ func errorwin1(dir string, incl []string) *Window {
 		// TODO(rjk): This should be inside the row lock.
 		if len(global.row.col) == 0 {
 			if global.row.Add(nil, -1) == nil {
-				util.AcmeError("can't create column to make error window", nil)
+				log.Panicf("acme: %s: %v\n", "can't create column to make error window", nil)
 			}
 		}
 		w = global.row.col[len(global.row.col)-1].Add(nil, nil, -1)
@@ -155,7 +156,7 @@ func makenewwindow(t *Text) *Window {
 		c = t.col
 	default:
 		if len(global.row.col) == 0 && global.row.Add(nil, -1) == nil {
-			util.AcmeError("can't make column", nil)
+			log.Panicf("acme: %s: %v\n", "can't make column", nil)
 		}
 		c = global.row.col[len(global.row.col)-1]
 	}

--- a/util/util.go
+++ b/util/util.go
@@ -1,39 +1,8 @@
 package util
 
 import (
-	"log"
 	"unicode/utf8"
 )
-
-func Min(a, b int) int {
-	if a < b {
-		return a
-	}
-	return b
-}
-func Minu(a, b uint) uint {
-	if a < b {
-		return a
-	}
-	return b
-}
-func Max(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
-
-func Abs(x int) int {
-	if x < 0 {
-		return -x
-	}
-	return x
-}
-
-func AcmeError(s string, err error) {
-	log.Panicf("acme: %s: %v\n", s, err)
-}
 
 // Cvttorunes decodes runes r from p. It's guaranteed that first n
 // bytes of p will be interpreted without worrying about partial runes.

--- a/util/util_test.go
+++ b/util/util_test.go
@@ -1,0 +1,34 @@
+package util
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCvttorunes(t *testing.T) {
+	testCases := []struct {
+		p     []byte
+		n     int
+		r     []rune
+		nb    int
+		nulls bool
+	}{
+		{[]byte("Hello world"), 11, []rune("Hello world"), 11, false},
+		{[]byte("Hello \x00\x00world"), 13, []rune("Hello world"), 13, true},
+		{[]byte("Hello 世界"), 6 + 3 + 3, []rune("Hello 世界"), 6 + 3 + 3, false},
+		{[]byte("Hello 世界"), 6 + 3 + 1, []rune("Hello 世界"), 6 + 3 + 3, false},
+		{[]byte("Hello 世界"), 6 + 3 + 2, []rune("Hello 世界"), 6 + 3 + 3, false},
+		{[]byte("Hello 世\xe7\x95"), 6 + 3 + 1, []rune("Hello 世�"), 6 + 3 + 1, false},
+		{[]byte("Hello 世\xe7\x95"), 6 + 3 + 2, []rune("Hello 世��"), 6 + 3 + 2, false},
+		{[]byte("\xe4\xb8\x96\xe7\x95\x8c hello"), 3 + 3 + 6, []rune("世界 hello"), 3 + 3 + 6, false},
+		{[]byte("\xb8\x96\xe7\x95\x8c hello"), 2 + 3 + 6, []rune("��界 hello"), 2 + 3 + 6, false},
+		{[]byte("\x96\xe7\x95\x8c hello"), 1 + 3 + 6, []rune("�界 hello"), 1 + 3 + 6, false},
+	}
+	for _, tc := range testCases {
+		r, nb, nulls := Cvttorunes(tc.p, tc.n)
+		if !reflect.DeepEqual(r, tc.r) || nb != tc.nb || nulls != tc.nulls {
+			t.Errorf("Cvttorunes of (%q, %v) returned %q, %v, %v; expected %q, %v, %v\n",
+				tc.p, tc.n, r, nb, nulls, tc.r, tc.nb, tc.nulls)
+		}
+	}
+}

--- a/util_test.go
+++ b/util_test.go
@@ -8,36 +8,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/rjkroege/edwood/dumpfile"
-	"github.com/rjkroege/edwood/util"
 )
-
-func TestCvttorunes(t *testing.T) {
-	testCases := []struct {
-		p     []byte
-		n     int
-		r     []rune
-		nb    int
-		nulls bool
-	}{
-		{[]byte("Hello world"), 11, []rune("Hello world"), 11, false},
-		{[]byte("Hello \x00\x00world"), 13, []rune("Hello world"), 13, true},
-		{[]byte("Hello 世界"), 6 + 3 + 3, []rune("Hello 世界"), 6 + 3 + 3, false},
-		{[]byte("Hello 世界"), 6 + 3 + 1, []rune("Hello 世界"), 6 + 3 + 3, false},
-		{[]byte("Hello 世界"), 6 + 3 + 2, []rune("Hello 世界"), 6 + 3 + 3, false},
-		{[]byte("Hello 世\xe7\x95"), 6 + 3 + 1, []rune("Hello 世\uFFFD"), 6 + 3 + 1, false},
-		{[]byte("Hello 世\xe7\x95"), 6 + 3 + 2, []rune("Hello 世\uFFFD\uFFFD"), 6 + 3 + 2, false},
-		{[]byte("\xe4\xb8\x96界 hello"), 3 + 3 + 6, []rune("世界 hello"), 3 + 3 + 6, false},
-		{[]byte("\xb8\x96界 hello"), 2 + 3 + 6, []rune("\uFFFD\uFFFD界 hello"), 2 + 3 + 6, false},
-		{[]byte("\x96界 hello"), 1 + 3 + 6, []rune("\uFFFD界 hello"), 1 + 3 + 6, false},
-	}
-	for _, tc := range testCases {
-		r, nb, nulls := util.Cvttorunes(tc.p, tc.n)
-		if !reflect.DeepEqual(r, tc.r) || nb != tc.nb || nulls != tc.nulls {
-			t.Errorf("util.Cvttorunes of (%q, %v) returned %q, %v, %v; expected %q, %v, %v\n",
-				tc.p, tc.n, r, nb, nulls, tc.r, tc.nb, tc.nulls)
-		}
-	}
-}
 
 // Given the complexity of errorwin1Name, one might wonder why we test
 // this so comprehensively. :-)

--- a/wind.go
+++ b/wind.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"image"
+	"log"
 	"os"
 	"path/filepath"
 	"sync"
@@ -11,7 +12,6 @@ import (
 	"github.com/rjkroege/edwood/draw"
 	"github.com/rjkroege/edwood/file"
 	"github.com/rjkroege/edwood/frame"
-	"github.com/rjkroege/edwood/util"
 )
 
 type Window struct {
@@ -268,12 +268,12 @@ func (w *Window) Resize(r image.Rectangle, safe, keepextra bool) int {
 	w.tagtop.Max.Y = r.Min.Y + fontget(global.tagfont, w.display).Height()
 
 	r1 := r
-	r1.Max.Y = util.Min(r.Max.Y, r1.Min.Y+w.taglines*fontget(global.tagfont, w.display).Height())
+	r1.Max.Y = min(r.Max.Y, r1.Min.Y+w.taglines*fontget(global.tagfont, w.display).Height())
 
 	// If needed, recompute number of lines in tag.
 	if !safe || !w.tagsafe || !w.tag.all.Eq(r1) {
 		w.taglines = w.TagLines(r)
-		r1.Max.Y = util.Min(r.Max.Y, r1.Min.Y+w.taglines*fontget(global.tagfont, w.display).Height())
+		r1.Max.Y = min(r.Max.Y, r1.Min.Y+w.taglines*fontget(global.tagfont, w.display).Height())
 	}
 
 	// Resize/redraw tag TODO(flux)
@@ -313,7 +313,7 @@ func (w *Window) Resize(r image.Rectangle, safe, keepextra bool) int {
 				w.display.ScreenImage().Draw(r1, global.tagcolors[frame.ColBord], nil, image.Point{})
 			}
 			y++
-			r1.Min.Y = util.Min(y, r.Max.Y)
+			r1.Min.Y = min(y, r.Max.Y)
 			r1.Max.Y = r.Max.Y
 		} else {
 			r1.Min.Y = y
@@ -325,7 +325,7 @@ func (w *Window) Resize(r image.Rectangle, safe, keepextra bool) int {
 		w.body.ScrDraw(w.body.fr.GetFrameFillStatus().Nchars)
 		w.body.all.Min.Y = oy
 	}
-	w.maxlines = util.Min(w.body.fr.GetFrameFillStatus().Nlines, util.Max(w.maxlines, w.body.fr.GetFrameFillStatus().Maxlines))
+	w.maxlines = min(w.body.fr.GetFrameFillStatus().Nlines, max(w.maxlines, w.body.fr.GetFrameFillStatus().Maxlines))
 	// TODO(rjk): this value doesn't make sense when we've collapsed
 	// the tag if the rectangle update block is not executed.
 	return w.r.Max.Y
@@ -534,7 +534,7 @@ func (w *Window) Eventf(format string, args ...interface{}) {
 		return
 	}
 	if w.owner == 0 {
-		util.AcmeError("no window owner", nil)
+		log.Panicf("acme: %s: %v\n", "no window owner", nil)
 	}
 	buffy := new(bytes.Buffer)
 	fmt.Fprintf(buffy, format, args...)

--- a/xfid.go
+++ b/xfid.go
@@ -229,7 +229,7 @@ func xfidclose(x *Xfid) {
 		case QWwrsel:
 			w.nomark = false
 			t := &w.body
-			t.Show(util.Min(w.wrselrange.q0, t.Nc()), util.Min(w.wrselrange.q1, t.Nc()), true)
+			t.Show(min(w.wrselrange.q0, t.Nc()), min(w.wrselrange.q1, t.Nc()), true)
 			t.ScrDraw(t.fr.GetFrameFillStatus().Nchars)
 		case QWeditout:
 			<-w.editoutlk
@@ -873,7 +873,7 @@ func xfidutfread(x *Xfid, t *Text, q1 int, qid int) {
 		} else {
 			if boff+uint64(nb) > off {
 				if n != 0 {
-					util.AcmeError("bad count in utfrune", nil)
+					log.Panicf("acme: %s: %v\n", "bad count in utfrune", nil)
 				}
 				m := nb - int(off-boff)
 				if m > int(x.fcall.Count) {
@@ -903,7 +903,7 @@ func xfidruneread(x *Xfid, t *Text, q0 int, q1 int) int {
 	t.w.Commit(t)
 
 	// Get Count runes, but that might be larger than Count bytes
-	nr := util.Min(q1-q0, int(x.fcall.Count))
+	nr := min(q1-q0, int(x.fcall.Count))
 	tmp := make([]rune, nr)
 	t.file.Read(q0, tmp)
 	buf := []byte(string(tmp))
@@ -989,7 +989,7 @@ func xfidindexread(x *Xfid) {
 				continue
 			}
 			sb.WriteString(w.CtlPrint(false))
-			m := util.Min(BUFSIZE/utf8.UTFMax, w.tag.Nc())
+			m := min(BUFSIZE/utf8.UTFMax, w.tag.Nc())
 			tag := make([]rune, m)
 			w.tag.file.Read(0, tag)
 


### PR DESCRIPTION
## Summary

- Moves `TestCvttorunes` into the `util` package so it tests the function directly
- Inlines `util.AcmeError` as `log.Panicf("acme: %s: %v\n", s, err)` at all call sites and removes the wrapper
- Replaces `util.Min`, `util.Max`, `util.Minu` with the Go 1.21 built-in `min`/`max`; bumps `go.mod` from `go 1.11` to `go 1.21`
- Replaces `util.Abs` with `max(x, -x)` using the Go 1.21 built-in `max`

`util/util.go` now contains only `Cvttorunes`, which has genuine logic with no standard-library replacement.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./...` passes
- [ ] Existing `TestCvttorunes` tests cover UTF-8 decoding edge cases including partial runes, invalid encodings, and null elision

🤖 Generated with [Claude Code](https://claude.com/claude-code)