### PR TITLE
Update CI to Go 1.25.x and 1.26.x

### DIFF
--- a/.github/workflows/edwood.yml
+++ b/.github/workflows/edwood.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.24.x]
+        go-version: [1.25.x, 1.26.x]
         os: [ubuntu-latest, macos-latest, windows-latest]
       fail-fast: false
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary

- Replace Go 1.24.x with 1.25.x and 1.26.x in the CI matrix
- Keeps coverage across the two most recent Go releases per the Go compatibility policy

## Test plan
- [ ] CI runs successfully on all three OS targets with both Go versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)